### PR TITLE
Fix broken link to live demonstration repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Integrating CSV validation into CI processes promotes higher data integrity, rel
 
 ## Live Demo
 
-* As a live demonstration of how the tool works you can take a look at the super minimal repository - [JBZoo/Csv-Blueprint-Demo](https://github.com/JBZoo/Csv-Blueprint). Feel free to fork it and play with the tool.
+* As a live demonstration of how the tool works you can take a look at the super minimal repository - [JBZoo/Csv-Blueprint-Demo](https://github.com/JBZoo/Csv-Blueprint-Demo). Feel free to fork it and play with the tool.
 * You can see more complex examples and different ways of reporting by looking at the [last Demo pipeline](https://github.com/JBZoo/Csv-Blueprint/actions/workflows/demo.yml?query=branch%3Amaster) (please open the logs). There you'll find the basic ways to get started. And also the `All Report Types` (left sidebar) link with the different report types.
 
 **See also**


### PR DESCRIPTION
Updated the broken link to the live demonstration repository to [JBZoo/Csv-Blueprint-Demo](https://github.com/JBZoo/Csv-Blueprint-Demo).