### PR TITLE
Add quick check option and optimize validation process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ COPY . /app
 RUN cd /app                                                           \
     && composer install --no-dev --optimize-autoloader --no-progress  \
     && composer clear-cache
-RUN chmod +x app/csv-blueprint
+RUN chmod +x /app/csv-blueprint
 
 # Color output by default
 ENV TERM_PROGRAM=Hyper
 
-ENTRYPOINT ["/app/csv-blueprint"]
+ENTRYPOINT ["sh", "-c", "/app/csv-blueprint"]

--- a/README.md
+++ b/README.md
@@ -77,14 +77,28 @@ Also see demo in the [GitHub Actions](https://github.com/JBZoo/Csv-Blueprint/act
 ### As GitHub Action
 
 ```yml
-      - name: Validate CSV file
-        uses: jbzoo/csv-blueprint@master
-        with:
-          csv: tests/**/*.csv
-          schema: tests/schema.yml
-          # Optional. Default is "github". Available options: text, table, github, etc
-          report: table
+- uses: jbzoo/csv-blueprint # See the specific version on releases page
+  with:
+    # Path(s) to validate. You can specify path in which CSV files will be searched. Feel free to use glob pattrens. Usage examples: /full/path/file.csv, p/file.csv, p/*.csv, p/**/*.csv, p/**/name-*.csv, **/*.csv, etc.
+    # Required: true
+    csv: ./tests/**/*.csv
+
+    # Schema filepath. It can be a YAML, JSON or PHP. See examples on GitHub.
+    # Required: true
+    schema: ./tests/schema.yml
+
+    # Report format. Available options: text, table, github, gitlab, teamcity, junit
+    # Default value: github
+    # You can skip it
+    report: github
+
+    # Quick mode. It will not validate all rows. It will stop after the first error.
+    # Default value: no
+    # You can skip it
+    quick: no
+
 ```
+
 **Note**. Report format for GitHub Actions is `github` by default. See [GitHub Actions friendly](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-warning-message) and [PR as a live demo](https://github.com/JBZoo/Csv-Blueprint-Demo/pull/1/files). 
 
 This allows you to see bugs in the GitHub interface at the PR level.
@@ -171,6 +185,10 @@ Options:
                                  It can be a YAML, JSON or PHP. See examples on GitHub.
   -r, --report=REPORT            Report output format. Available options:
                                  text, table, github, gitlab, teamcity, junit [default: "table"]
+  -Q, --quick[=QUICK]            Immediately terminate the check at the first error found.
+                                 Of course it will speed up the check, but you will get only 1 message out of many.
+                                 If any error is detected, the utility will return a non-zero exit code.
+                                 Empty value or "yes" will be treated as "true". [default: "no"]
       --no-progress              Disable progress bar animation for logs. It will be used only for text output format.
       --mute-errors              Mute any sort of errors. So exit code will be always "0" (if it's possible).
                                  It has major priority then --non-zero-on-error. It's on your own risk!
@@ -211,8 +229,9 @@ Default report format is `table`:
 
 
 Schema: ./tests/schemas/demo_invalid.yml
+Found CSV files: 3
 
-Invalid file: ./tests/fixtures/batch/demo-1.csv
+(1/3) Invalid file: ./tests/fixtures/batch/demo-1.csv
 +------+------------------+--------------+ demo-1.csv ------------------------------------------+
 | Line | id:Column        | Rule         | Message                                              |
 +------+------------------+--------------+------------------------------------------------------+
@@ -221,7 +240,7 @@ Invalid file: ./tests/fixtures/batch/demo-1.csv
 |      |                  |              | "green", "Blue"]                                     |
 +------+------------------+--------------+ demo-1.csv ------------------------------------------+
 
-Invalid file: ./tests/fixtures/batch/demo-2.csv
+(2/3) Invalid file: ./tests/fixtures/batch/demo-2.csv
 +------+------------+------------+----- demo-2.csv ---------------------------------------+
 | Line | id:Column  | Rule       | Message                                                |
 +------+------------+------------+--------------------------------------------------------+
@@ -235,7 +254,8 @@ Invalid file: ./tests/fixtures/batch/demo-2.csv
 | 7    | 0:Name     | min_length | Value "Lois" (length: 4) is too short. Min length is 5 |
 +------+------------+------------+----- demo-2.csv ---------------------------------------+
 
-OK: ./tests/fixtures/batch/sub/demo-3.csv
+(3/3) OK: ./tests/fixtures/batch/sub/demo-3.csv
+
 Found 7 issues in 2 out of 3 CSV files.
 
 ```
@@ -469,14 +489,17 @@ Batch processing
 * [x] ~~CSV/Schema file discovery in the folder with regex filename pattern (like `glob(./**/dir/*.csv)`).~~
 * [x] ~~If option `--csv` is a folder, then validate all files in the folder.~~
 * [x] ~~Checking multiple CSV files in one schema.~~
-* [ ] Quick stop flag. If the first error is found, then stop the validation process to save time.
-* [ ] Using multiple schemas for one csv file.
+* [x] ~~Quick stop flag. If the first error is found, then stop the validation process to save time.~~
 * [ ] If option `--csv` is not specified, then the STDIN is used. To build a pipeline in Unix-like systems.
+* [ ] Discovering CSV files by `filename_pattern` in the schema file. In case you have a lot of schemas and a lot of CSV files and want to automate the process as one command.
 
 Validation
-* [ ] Filename pattern validation with regex (like "all files in the folder should be in the format `/^[\d]{4}-[\d]{2}-[\d]{2}\.csv$/`").
+* [ ] `filename_pattern` validation with regex (like "all files in the folder should be in the format `/^[\d]{4}-[\d]{2}-[\d]{2}\.csv$/`").
 * [ ] Agregate rules (like "at least one of the fields should be not empty" or "all values must be unique").
+* [ ] Handle empty files and files with only a header row, or only with one line of data. One column wthout header is also possible.
+* [ ] Using multiple schemas for one csv file.
 * [ ] Inheritance of schemas, rules and columns. Define parent schema and override some rules in the child schemas. Make it DRY and easy to maintain.
+* [ ] Validate syntax and options in the schema file. It's important to know if the schema file is valid and can be used for validation.
 * [ ] If option `--schema` is not specified, then validate only super base level things (like "is it a CSV file?").
 * [ ] Complex rules (like "if field `A` is not empty, then field `B` should be not empty too").
 * [ ] Extending with custom rules and custom report formats. Plugins?

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@
 # @see        https://github.com/JBZoo/Csv-Blueprint
 #
 
-name: 'CSV Validator by schemas'
+name: 'CSV Blueprint - Validator by schemas'
 description: 'Strict and flexible schema-based CSV file validation with the ability to report as GitHub Annotations in your PRs.'
 author: 'Denis Smetannikov <admin@jbzoo.com>'
 
@@ -21,8 +21,7 @@ branding:
 inputs:
   csv:
     description: >
-      Path(s) to validate. You can specify path in which CSV files will be searched
-      (max depth is 10).
+      Path(s) to validate. You can specify path in which CSV files will be searched.
       Feel free to use glob pattrens. Usage examples:
       /full/path/file.csv, p/file.csv, p/*.csv, p/**/*.csv, p/**/name-*.csv, **/*.csv, etc.
     required: true
@@ -30,8 +29,12 @@ inputs:
     description: 'Schema filepath. It can be a YAML, JSON or PHP. See examples on GitHub.'
     required: true
   report:
-    description: 'Report output format. Available options: text, table, github, gitlab, teamcity, junit'
+    description: 'Report format. Available options: text, table, github, gitlab, teamcity, junit'
     default: github
+    required: true
+  quick:
+    description: 'Quick mode. It will not validate all rows. It will stop after the first error.'
+    default: no
     required: true
 
 runs:
@@ -45,5 +48,7 @@ runs:
     - ${{ inputs.schema }}
     - '--report'
     - ${{ inputs.report }}
+    - '--quick'
+    - ${{ inputs.quick }}
     - '--ansi'
     - '-vvv'

--- a/src/Validators/ErrorSuite.php
+++ b/src/Validators/ErrorSuite.php
@@ -160,7 +160,7 @@ final class ErrorSuite
 
         $table->render();
 
-        return $buffer->fetch();
+        return \trim($buffer->fetch()) . "\n";
     }
 
     private function prepareSourceSuite(): SourceSuite

--- a/tests/Blueprint/GithubActionsTest.php
+++ b/tests/Blueprint/GithubActionsTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Blueprint;
+
+use JBZoo\CsvBlueprint\Validators\ErrorSuite;
+use JBZoo\PHPUnit\PHPUnit;
+
+use function JBZoo\Data\yml;
+use function JBZoo\PHPUnit\isFileContains;
+use function JBZoo\PHPUnit\isSame;
+
+final class GithubActionsTest extends PHPUnit
+{
+    public function testCreateCsvHelp(): void
+    {
+        $action = yml(PROJECT_ROOT . '/action.yml');
+
+        $availableOptions = \array_keys($action->findArray('inputs'));
+
+        $expectedArgs = ['validate:csv'];
+
+        foreach ($availableOptions as $option) {
+            $expectedArgs[] = "--{$option}";
+            $expectedArgs[] = '${{ inputs.' . $option . ' }}';
+        }
+
+        $expectedArgs[] = '--ansi';
+        $expectedArgs[] = '-vvv';
+
+        isSame($expectedArgs, $action->findArray('runs.args'));
+
+        isSame(
+            $action->findString('inputs.report.description'),
+            'Report format. Available options: ' . \implode(', ', ErrorSuite::getAvaiableRenderFormats()),
+        );
+    }
+
+    public function testGitHubActionsReadMe(): void
+    {
+        $inputs   = yml(PROJECT_ROOT . '/action.yml')->findArray('inputs');
+        $examples = [
+            'csv'    => './tests/**/*.csv',
+            'schema' => './tests/schema.yml',
+            'report' => 'github',
+            'quick'  => 'no',
+        ];
+
+        $expectedMessage = [
+            '```yml',
+            '- uses: jbzoo/csv-blueprint # See the specific version on releases page',
+            '  with:',
+        ];
+
+        foreach ($inputs as $key => $input) {
+            $expectedMessage[] = '    # ' . \trim($input['description']);
+
+            if (isset($input['default'])) {
+                $expectedMessage[] = "    # Default value: {$input['default']}";
+            }
+
+            if (isset($input['default']) && $examples[$key] === $input['default']) {
+                $expectedMessage[] = '    # You can skip it';
+            } elseif (isset($input['required']) && $input['required']) {
+                $expectedMessage[] = '    # Required: true';
+            }
+
+            $expectedMessage[] = "    {$key}: {$examples[$key]}";
+            $expectedMessage[] = '';
+        }
+
+        $expectedMessage[] = '```';
+
+        isFileContains(\implode("\n", $expectedMessage), PROJECT_ROOT . '/README.md');
+    }
+}

--- a/tests/Blueprint/ReadmeTest.php
+++ b/tests/Blueprint/ReadmeTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Blueprint;
+
+use JBZoo\PHPUnit\PHPUnit;
+use JBZoo\PHPUnit\TestTools;
+use JBZoo\Utils\Cli;
+use Symfony\Component\Console\Input\StringInput;
+
+use function JBZoo\PHPUnit\isFileContains;
+use function JBZoo\PHPUnit\isSame;
+
+final class ReadmeTest extends PHPUnit
+{
+    public function testCreateCsvHelp(): void
+    {
+        isFileContains(\implode("\n", [
+            '```',
+            './csv-blueprint validate:csv --help',
+            '',
+            '',
+            TestTools::realExecution('validate:csv', ['help' => null]),
+            '```',
+        ]), PROJECT_ROOT . '/README.md');
+    }
+
+    public function testTableOutputExample(): void
+    {
+        $options = [
+            'csv'    => './tests/fixtures/batch/*.csv',
+            'schema' => './tests/schemas/demo_invalid.yml',
+        ];
+        $optionsAsString     = new StringInput(Cli::build('', $options));
+        [$actual, $exitCode] = TestTools::virtualExecution('validate:csv', $options);
+
+        isSame(1, $exitCode, $actual);
+
+        isFileContains(\implode("\n", [
+            '```',
+            "./csv-blueprint validate:csv {$optionsAsString}",
+            '',
+            '',
+            $actual,
+            '```',
+        ]), PROJECT_ROOT . '/README.md');
+    }
+}

--- a/tests/TestTools.php
+++ b/tests/TestTools.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit;
+
+use JBZoo\Cli\CliApplication;
+use JBZoo\CsvBlueprint\Commands\ValidateCsv;
+use JBZoo\Utils\Cli;
+use JBZoo\Utils\Sys;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class TestTools
+{
+    public static function virtualExecution(string $action, array $params = []): array
+    {
+        $params['no-ansi'] = null;
+
+        $application = new CliApplication();
+        $application->add(new ValidateCsv());
+        $command = $application->find($action);
+
+        $buffer   = new BufferedOutput();
+        $args     = new StringInput(Cli::build('', $params));
+        $exitCode = $command->run($args, $buffer);
+
+        return [$buffer->fetch(), $exitCode];
+    }
+
+    public static function realExecution(string $action, array $params = [], string $extra = '--no-ansi'): string
+    {
+        $rootDir = PROJECT_ROOT;
+
+        return Cli::exec(
+            \implode(' ', [
+                Sys::getBinary(),
+                "{$rootDir}/csv-blueprint.php {$extra}",
+                $action,
+                '2>&1',
+            ]),
+            $params,
+            $rootDir,
+            false,
+        );
+    }
+
+    public static function dumpText($text): void
+    {
+        \file_put_contents(PROJECT_ROOT . '/build/dump.txt', $text);
+    }
+}


### PR DESCRIPTION
This commit introduces a new quick check option that terminates the CSV validation process as soon as the first error is detected, leading to faster checks but fewer error messages. Some modifications were made to improve handling of file paths and file counts. The console output was also tweaked to be more human-readable. Two new tests were added to check the documentation against the actual functionality.