### PR TITLE
Modify Docker release GitHub workflow triggers

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -13,36 +13,15 @@
 name: Publish Docker
 
 on:
-  release:
-    types: [ published ]
   push:
     branches:
-      - "*"
-  pull_request:
-    branches:
-      - "master"
+      - 'master'
 
 jobs:
   docker:
     name: Docker
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: jbzoo/csv-blueprint
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -50,7 +29,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        # if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -60,6 +38,5 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          # push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          tags: jbzoo/csv-blueprint:latest


### PR DESCRIPTION
Triggers for the Docker release GitHub workflow have been altered. It has been simplified to perform actions only on pushes to the 'master' branch. Authenticated Docker Hub login and automatic pushes are still operational, however, pull request triggers have been removed. Plugin-specific docker meta actions and related steps are also removed.