### PR TITLE
Update ENTRYPOINT instruction in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ RUN chmod +x /app/csv-blueprint
 # Color output by default
 ENV TERM_PROGRAM=Hyper
 
-ENTRYPOINT ["sh", "-c", "/app/csv-blueprint"]
+ENTRYPOINT ["/app/csv-blueprint"]


### PR DESCRIPTION
In the Dockerfile, the ENTRYPOINT instruction has been updated to simplify the command's syntax. The change results in more direct execution without the need for "sh" and "-c". The modification now uses "/app/csv-blueprint" directly, resulting in improved containerization and execution efficiency.