### PR TITLE
New Aggregate Rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "league/csv"                : "^9.15",
         "symfony/yaml"              : "^6.4.3",
         "symfony/filesystem"        : "^6.4",
-        "symfony/finder"            : "^6.4"
+        "symfony/finder"            : "^6.4",
+        "markrogoyski/math-php": "^2.9"
     },
 
     "require-dev"       : {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8f84bb595c9bcc066f1d026f986eab7f",
+    "content-hash": "2a87eb346efcc6206dbca601973b5abd",
     "packages": [
         {
             "name": "bluepsyduck/symfony-process-manager",
@@ -611,6 +611,81 @@
                 }
             ],
             "time": "2024-02-20T20:00:00+00:00"
+        },
+        {
+            "name": "markrogoyski/math-php",
+            "version": "v2.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/markrogoyski/math-php.git",
+                "reference": "4d4bfad5cd5f2d5dd851fc2c350438325776593c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/markrogoyski/math-php/zipball/4d4bfad5cd5f2d5dd851fc2c350438325776593c",
+                "reference": "4d4bfad5cd5f2d5dd851fc2c350438325776593c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.2.0"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phploc/phploc": "*",
+                "phpmd/phpmd": "^2.6",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^8.5",
+                "squizlabs/php_codesniffer": "3.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MathPHP\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Rogoyski",
+                    "email": "mark@rogoyski.com",
+                    "homepage": "https://github.com/markrogoyski",
+                    "role": "Lead developer"
+                },
+                {
+                    "name": "Kevin Nowaczyk",
+                    "homepage": "https://github.com/Beakerboy",
+                    "role": "Developer"
+                },
+                {
+                    "name": "MathPHP Community of Contributors",
+                    "homepage": "https://github.com/markrogoyski/math-php/graphs/contributors"
+                }
+            ],
+            "description": "Math Library for PHP. Features descriptive statistics and regressions; Continuous and discrete probability distributions; Linear algebra with matrices and vectors, Numerical analysis; special mathematical functions; Algebra",
+            "homepage": "https://github.com/markrogoyski/math-php/",
+            "keywords": [
+                "algebra",
+                "combinatorics",
+                "distributions",
+                "linear algebra",
+                "math",
+                "mathematics",
+                "matrix",
+                "numerical analysis",
+                "probability",
+                "regressions",
+                "statistics"
+            ],
+            "support": {
+                "issues": "https://github.com/markrogoyski/math-php/issues",
+                "source": "https://github.com/markrogoyski/math-php/tree/v2.9.0"
+            },
+            "time": "2024-03-03T00:21:15+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/src/AggregateRules/AbstarctAggregateRule.php
+++ b/src/AggregateRules/AbstarctAggregateRule.php
@@ -23,11 +23,11 @@ abstract class AbstarctAggregateRule extends AbstarctRule
     /**
      * Validate the rule.
      *
-     * This method takes an array reference &$columnValues as input and returns a nullable string.
-     * We use a reference to the array to avoid copying the array. Important memory optimization!
-     * Please DO NOT change the array in this method!
+     * TODO: This method takes an array reference &$columnValues as input and returns a nullable string.
+     * TODO: We use a reference to the array to avoid copying the array. Important memory optimization!
+     * TODO: Please DO NOT change the array in this method!
      *
      * @param string[] $columnValues
      */
-    abstract public function validateRule(array &$columnValues): ?string;
+    abstract public function validateRule(array $columnValues): ?string;
 }

--- a/src/AggregateRules/Average.php
+++ b/src/AggregateRules/Average.php
@@ -16,16 +16,22 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\AggregateRules;
 
-final class IsUnique extends AbstarctAggregateRule
+use MathPHP\Statistics\Average as AverageMath;
+
+final class Average extends AbstarctAggregateRule
 {
     public function validateRule(array $columnValues): ?string
     {
-        $uValuesCount = \count(\array_unique($columnValues));
-        $valuesCount  = \count($columnValues);
+        if (\count($columnValues) === 0) {
+            return null; // Cannot find the average of an empty list of numbers
+        }
 
-        if ($uValuesCount !== $valuesCount) {
-            return "Column has non-unique values. " .
-                "Unique: <c>{$uValuesCount}</c>, total: <green>{$valuesCount}</green>";
+        $expAverage = $this->getOptionAsFloat();
+        $average    = AverageMath::mean($columnValues);
+
+        if ($expAverage !== $average) {
+            return 'Column average is not equal to expected. ' .
+                "Actual: <c>{$average}</c>, expected: <green>{$expAverage}</green>";
         }
 
         return null;

--- a/src/AggregateRules/AverageMax.php
+++ b/src/AggregateRules/AverageMax.php
@@ -16,16 +16,22 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\AggregateRules;
 
-final class IsUnique extends AbstarctAggregateRule
+use MathPHP\Statistics\Average;
+
+final class AverageMax extends AbstarctAggregateRule
 {
     public function validateRule(array $columnValues): ?string
     {
-        $uValuesCount = \count(\array_unique($columnValues));
-        $valuesCount  = \count($columnValues);
+        if (\count($columnValues) === 0) {
+            return null; // Cannot find the average of an empty list of numbers
+        }
 
-        if ($uValuesCount !== $valuesCount) {
-            return "Column has non-unique values. " .
-                "Unique: <c>{$uValuesCount}</c>, total: <green>{$valuesCount}</green>";
+        $expMax  = $this->getOptionAsFloat();
+        $average = Average::mean($columnValues);
+
+        if ($expMax < $average) {
+            return 'Column average is greater than expected. ' .
+                "Actual: <c>{$average}</c>, expected: <green>{$expMax}</green>";
         }
 
         return null;

--- a/src/AggregateRules/AverageMin.php
+++ b/src/AggregateRules/AverageMin.php
@@ -16,16 +16,22 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\AggregateRules;
 
-final class IsUnique extends AbstarctAggregateRule
+use MathPHP\Statistics\Average;
+
+final class AverageMin extends AbstarctAggregateRule
 {
     public function validateRule(array $columnValues): ?string
     {
-        $uValuesCount = \count(\array_unique($columnValues));
-        $valuesCount  = \count($columnValues);
+        if (\count($columnValues) === 0) {
+            return null; // Cannot find the average of an empty list of numbers
+        }
 
-        if ($uValuesCount !== $valuesCount) {
-            return "Column has non-unique values. " .
-                "Unique: <c>{$uValuesCount}</c>, total: <green>{$valuesCount}</green>";
+        $expMin  = $this->getOptionAsFloat();
+        $average = Average::mean($columnValues);
+
+        if ($expMin > $average) {
+            return 'Column average is less than expected. ' .
+                "Actual: <c>{$average}</c>, expected: <green>{$expMin}</green>";
         }
 
         return null;

--- a/src/AggregateRules/Count.php
+++ b/src/AggregateRules/Count.php
@@ -16,16 +16,16 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\AggregateRules;
 
-final class IsUnique extends AbstarctAggregateRule
+final class Count extends AbstarctAggregateRule
 {
     public function validateRule(array $columnValues): ?string
     {
-        $uValuesCount = \count(\array_unique($columnValues));
-        $valuesCount  = \count($columnValues);
+        $expCount = $this->getOptionAsInt();
+        $count    = \count($columnValues);
 
-        if ($uValuesCount !== $valuesCount) {
-            return "Column has non-unique values. " .
-                "Unique: <c>{$uValuesCount}</c>, total: <green>{$valuesCount}</green>";
+        if ($expCount !== $count) {
+            return 'Column count is not equal to expected. ' .
+                "Actual: <c>{$count}</c>, expected: <green>{$expCount}</green>";
         }
 
         return null;

--- a/src/AggregateRules/CountEmpty.php
+++ b/src/AggregateRules/CountEmpty.php
@@ -16,16 +16,16 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\AggregateRules;
 
-final class IsUnique extends AbstarctAggregateRule
+final class CountEmpty extends AbstarctAggregateRule
 {
     public function validateRule(array $columnValues): ?string
     {
-        $uValuesCount = \count(\array_unique($columnValues));
-        $valuesCount  = \count($columnValues);
+        $expCountEmptyLines = $this->getOptionAsInt();
+        $countEmptyLines    = \count(\array_filter($columnValues, static fn ($value) => $value === ''));
 
-        if ($uValuesCount !== $valuesCount) {
-            return "Column has non-unique values. " .
-                "Unique: <c>{$uValuesCount}</c>, total: <green>{$valuesCount}</green>";
+        if ($expCountEmptyLines !== $countEmptyLines) {
+            return 'Column count of empty lines is not equal to expected. ' .
+                "Actual: <c>{$countEmptyLines}</c>, expected: <green>{$expCountEmptyLines}</green>";
         }
 
         return null;

--- a/src/AggregateRules/CountEmptyMax.php
+++ b/src/AggregateRules/CountEmptyMax.php
@@ -16,16 +16,16 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\AggregateRules;
 
-final class IsUnique extends AbstarctAggregateRule
+final class CountEmptyMax extends AbstarctAggregateRule
 {
     public function validateRule(array $columnValues): ?string
     {
-        $uValuesCount = \count(\array_unique($columnValues));
-        $valuesCount  = \count($columnValues);
+        $maxCountEmptyLines = $this->getOptionAsInt();
+        $countEmptyLines    = \count(\array_filter($columnValues, static fn ($value) => $value === ''));
 
-        if ($uValuesCount !== $valuesCount) {
-            return "Column has non-unique values. " .
-                "Unique: <c>{$uValuesCount}</c>, total: <green>{$valuesCount}</green>";
+        if ($maxCountEmptyLines < $countEmptyLines) {
+            return 'Column count of empty lines is more than expected. ' .
+                "Actual: <c>{$countEmptyLines}</c>, expected: <green>{$maxCountEmptyLines}</green>";
         }
 
         return null;

--- a/src/AggregateRules/CountEmptyMin.php
+++ b/src/AggregateRules/CountEmptyMin.php
@@ -16,16 +16,16 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\AggregateRules;
 
-final class IsUnique extends AbstarctAggregateRule
+final class CountEmptyMin extends AbstarctAggregateRule
 {
     public function validateRule(array $columnValues): ?string
     {
-        $uValuesCount = \count(\array_unique($columnValues));
-        $valuesCount  = \count($columnValues);
+        $minCountEmptyLines = $this->getOptionAsInt();
+        $countEmptyLines    = \count(\array_filter($columnValues, static fn ($value) => $value === ''));
 
-        if ($uValuesCount !== $valuesCount) {
-            return "Column has non-unique values. " .
-                "Unique: <c>{$uValuesCount}</c>, total: <green>{$valuesCount}</green>";
+        if ($minCountEmptyLines > $countEmptyLines) {
+            return 'Column count of empty lines is less than expected. ' .
+                "Actual: <c>{$countEmptyLines}</c>, expected: <green>{$minCountEmptyLines}</green>";
         }
 
         return null;

--- a/src/AggregateRules/CountFilled.php
+++ b/src/AggregateRules/CountFilled.php
@@ -16,16 +16,16 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\AggregateRules;
 
-final class IsUnique extends AbstarctAggregateRule
+final class CountFilled extends AbstarctAggregateRule
 {
     public function validateRule(array $columnValues): ?string
     {
-        $uValuesCount = \count(\array_unique($columnValues));
-        $valuesCount  = \count($columnValues);
+        $expCountFilled   = $this->getOptionAsInt();
+        $countFilledLines = \count(\array_filter($columnValues, static fn ($value) => $value !== ''));
 
-        if ($uValuesCount !== $valuesCount) {
-            return "Column has non-unique values. " .
-                "Unique: <c>{$uValuesCount}</c>, total: <green>{$valuesCount}</green>";
+        if ($expCountFilled !== $countFilledLines) {
+            return 'Column count of filled lines is not equal to expected. ' .
+                "Actual: <c>{$countFilledLines}</c>, expected: <green>{$expCountFilled}</green>";
         }
 
         return null;

--- a/src/AggregateRules/CountMax.php
+++ b/src/AggregateRules/CountMax.php
@@ -16,16 +16,16 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\AggregateRules;
 
-final class IsUnique extends AbstarctAggregateRule
+final class CountMax extends AbstarctAggregateRule
 {
     public function validateRule(array $columnValues): ?string
     {
-        $uValuesCount = \count(\array_unique($columnValues));
-        $valuesCount  = \count($columnValues);
+        $expMax = $this->getOptionAsInt();
+        $count  = \count($columnValues);
 
-        if ($uValuesCount !== $valuesCount) {
-            return "Column has non-unique values. " .
-                "Unique: <c>{$uValuesCount}</c>, total: <green>{$valuesCount}</green>";
+        if ($expMax < $count) {
+            return 'Column count is greater than expected. ' .
+                "Actual: <c>{$count}</c>, expected: <green>{$expMax}</green>";
         }
 
         return null;

--- a/src/AggregateRules/CountMin.php
+++ b/src/AggregateRules/CountMin.php
@@ -16,16 +16,16 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\AggregateRules;
 
-final class IsUnique extends AbstarctAggregateRule
+final class CountMin extends AbstarctAggregateRule
 {
     public function validateRule(array $columnValues): ?string
     {
-        $uValuesCount = \count(\array_unique($columnValues));
-        $valuesCount  = \count($columnValues);
+        $expMin = $this->getOptionAsInt();
+        $count  = \count($columnValues);
 
-        if ($uValuesCount !== $valuesCount) {
-            return "Column has non-unique values. " .
-                "Unique: <c>{$uValuesCount}</c>, total: <green>{$valuesCount}</green>";
+        if ($expMin > $count) {
+            return 'Column count is less than expected. ' .
+                "Actual: <c>{$count}</c>, expected: <green>{$expMin}</green>";
         }
 
         return null;

--- a/src/AggregateRules/Median.php
+++ b/src/AggregateRules/Median.php
@@ -16,16 +16,22 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\AggregateRules;
 
-final class IsUnique extends AbstarctAggregateRule
+use MathPHP\Statistics\Average;
+
+final class Median extends AbstarctAggregateRule
 {
     public function validateRule(array $columnValues): ?string
     {
-        $uValuesCount = \count(\array_unique($columnValues));
-        $valuesCount  = \count($columnValues);
+        if (\count($columnValues) === 0) {
+            return null; // Cannot find the median of an empty list of numbers
+        }
 
-        if ($uValuesCount !== $valuesCount) {
-            return "Column has non-unique values. " .
-                "Unique: <c>{$uValuesCount}</c>, total: <green>{$valuesCount}</green>";
+        $expMedian = $this->getOptionAsFloat();
+        $median    = Average::median($columnValues);
+
+        if ($expMedian !== $median) {
+            return 'Column median is not equal to expected. ' .
+                "Actual: <c>{$median}</c>, expected: <green>{$expMedian}</green>";
         }
 
         return null;

--- a/src/AggregateRules/MedianMax.php
+++ b/src/AggregateRules/MedianMax.php
@@ -16,16 +16,22 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\AggregateRules;
 
-final class IsUnique extends AbstarctAggregateRule
+use MathPHP\Statistics\Average;
+
+final class MedianMax extends AbstarctAggregateRule
 {
     public function validateRule(array $columnValues): ?string
     {
-        $uValuesCount = \count(\array_unique($columnValues));
-        $valuesCount  = \count($columnValues);
+        if (\count($columnValues) === 0) {
+            return null; // Cannot find the median of an empty list of numbers
+        }
 
-        if ($uValuesCount !== $valuesCount) {
-            return "Column has non-unique values. " .
-                "Unique: <c>{$uValuesCount}</c>, total: <green>{$valuesCount}</green>";
+        $expMax = $this->getOptionAsFloat();
+        $median = Average::median($columnValues);
+
+        if ($expMax < $median) {
+            return 'Column median is greater than expected. ' .
+                "Actual: <c>{$median}</c>, expected: <green>{$expMax}</green>";
         }
 
         return null;

--- a/src/AggregateRules/MedianMin.php
+++ b/src/AggregateRules/MedianMin.php
@@ -16,16 +16,22 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\AggregateRules;
 
-final class IsUnique extends AbstarctAggregateRule
+use MathPHP\Statistics\Average;
+
+final class MedianMin extends AbstarctAggregateRule
 {
     public function validateRule(array $columnValues): ?string
     {
-        $uValuesCount = \count(\array_unique($columnValues));
-        $valuesCount  = \count($columnValues);
+        if (\count($columnValues) === 0) {
+            return null; // Cannot find the median of an empty list of numbers
+        }
 
-        if ($uValuesCount !== $valuesCount) {
-            return "Column has non-unique values. " .
-                "Unique: <c>{$uValuesCount}</c>, total: <green>{$valuesCount}</green>";
+        $expMin = $this->getOptionAsFloat();
+        $median = Average::median($columnValues);
+
+        if ($expMin > $median) {
+            return 'Column median is less than expected. ' .
+                "Actual: <c>{$median}</c>, expected: <green>{$expMin}</green>";
         }
 
         return null;

--- a/src/AggregateRules/Sum.php
+++ b/src/AggregateRules/Sum.php
@@ -16,16 +16,16 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\AggregateRules;
 
-final class IsUnique extends AbstarctAggregateRule
+final class Sum extends AbstarctAggregateRule
 {
     public function validateRule(array $columnValues): ?string
     {
-        $uValuesCount = \count(\array_unique($columnValues));
-        $valuesCount  = \count($columnValues);
+        $expSum = $this->getOptionAsFloat();
+        $sum    = (float)\array_sum($columnValues);
 
-        if ($uValuesCount !== $valuesCount) {
-            return "Column has non-unique values. " .
-                "Unique: <c>{$uValuesCount}</c>, total: <green>{$valuesCount}</green>";
+        if ($expSum !== $sum) {
+            return 'Column sum is not equal to expected. ' .
+                "Actual: <c>{$sum}</c>, expected: <green>{$expSum}</green>";
         }
 
         return null;

--- a/src/AggregateRules/SumMax.php
+++ b/src/AggregateRules/SumMax.php
@@ -16,16 +16,16 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\AggregateRules;
 
-final class IsUnique extends AbstarctAggregateRule
+final class SumMax extends AbstarctAggregateRule
 {
     public function validateRule(array $columnValues): ?string
     {
-        $uValuesCount = \count(\array_unique($columnValues));
-        $valuesCount  = \count($columnValues);
+        $expMax = $this->getOptionAsFloat();
+        $sum    = (float)\array_sum($columnValues);
 
-        if ($uValuesCount !== $valuesCount) {
-            return "Column has non-unique values. " .
-                "Unique: <c>{$uValuesCount}</c>, total: <green>{$valuesCount}</green>";
+        if ($expMax < $sum) {
+            return 'Column sum is greater than expected. ' .
+                "Actual: <c>{$sum}</c>, expected: <green>{$expMax}</green>";
         }
 
         return null;

--- a/src/AggregateRules/SumMin.php
+++ b/src/AggregateRules/SumMin.php
@@ -16,16 +16,16 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\AggregateRules;
 
-final class IsUnique extends AbstarctAggregateRule
+final class SumMin extends AbstarctAggregateRule
 {
     public function validateRule(array $columnValues): ?string
     {
-        $uValuesCount = \count(\array_unique($columnValues));
-        $valuesCount  = \count($columnValues);
+        $expMin = $this->getOptionAsFloat();
+        $sum    = (float)\array_sum($columnValues);
 
-        if ($uValuesCount !== $valuesCount) {
-            return "Column has non-unique values. " .
-                "Unique: <c>{$uValuesCount}</c>, total: <green>{$valuesCount}</green>";
+        if ($expMin > $sum) {
+            return 'Column sum is less than expected. ' .
+                "Actual: <c>{$sum}</c>, expected: <green>{$expMin}</green>";
         }
 
         return null;

--- a/tests/Blueprint/AggregateRulesTest.php
+++ b/tests/Blueprint/AggregateRulesTest.php
@@ -16,7 +16,14 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Blueprint;
 
+use JBZoo\CsvBlueprint\AggregateRules\Average;
+use JBZoo\CsvBlueprint\AggregateRules\AverageMax;
+use JBZoo\CsvBlueprint\AggregateRules\AverageMin;
 use JBZoo\CsvBlueprint\AggregateRules\IsUnique;
+use JBZoo\CsvBlueprint\AggregateRules\Median;
+use JBZoo\CsvBlueprint\AggregateRules\Sum;
+use JBZoo\CsvBlueprint\AggregateRules\SumMax;
+use JBZoo\CsvBlueprint\AggregateRules\SumMin;
 use JBZoo\PHPUnit\PHPUnit;
 
 use function JBZoo\PHPUnit\isSame;
@@ -37,6 +44,120 @@ final class AggregateRulesTest extends PHPUnit
         isSame(
             '"ag:is_unique" at line 1, column "prop". Column has non-unique values. Unique: 3, total: 4.',
             \strip_tags((string)$rule->validate(['1', '2', '3', '3'])),
+        );
+    }
+
+    public function testSum(): void
+    {
+        $rule = new Sum('prop', 6);
+        isSame(null, $rule->validate(['1', '2', '3']));
+        isSame(null, $rule->validate(['1', '2', '3', '', ' ']));
+        isSame(null, $rule->validate(['1.5', '2.5', '2']));
+
+        isSame(
+            '"ag:sum" at line 1, column "prop". Column sum is not equal to expected. Actual: 0, expected: 6.',
+            \strip_tags((string)$rule->validate([])),
+        );
+        isSame(
+            '"ag:sum" at line 1, column "prop". Column sum is not equal to expected. Actual: 11, expected: 6.',
+            \strip_tags((string)$rule->validate(['1', '2', '3', '3', '1 ', ' 1'])),
+        );
+    }
+
+    public function testSumMin(): void
+    {
+        $rule = new SumMin('prop', 6);
+        isSame(null, $rule->validate(['1', '2', '3']));
+        isSame(null, $rule->validate(['1.5', '2.5', '2', '', ' ', ' 1']));
+        isSame(null, $rule->validate(['1.5', '2.5', '10']));
+
+        isSame(
+            '"ag:sum_min" at line 1, column "prop". Column sum is less than expected. Actual: 0, expected: 6.',
+            \strip_tags((string)$rule->validate([])),
+        );
+        isSame(
+            '"ag:sum_min" at line 1, column "prop". Column sum is less than expected. Actual: 3, expected: 6.',
+            \strip_tags((string)$rule->validate(['1', '2'])),
+        );
+    }
+
+    public function testSumMax(): void
+    {
+        $rule = new SumMax('prop', 6);
+        isSame(null, $rule->validate([]));
+        isSame(null, $rule->validate(['1', '2', '3']));
+        isSame(null, $rule->validate(['1.5', '2.5', '2', '', ' ', ' 0']));
+
+        isSame(
+            '"ag:sum_max" at line 1, column "prop". Column sum is greater than expected. Actual: 14, expected: 6.',
+            \strip_tags((string)$rule->validate(['1.5', '2.5', '10'])),
+        );
+    }
+
+    public function testAverage(): void
+    {
+        $rule = new Average('prop', 0);
+        isSame(null, $rule->validate([]));
+
+        $rule = new Average('prop', 1);
+        isSame(null, $rule->validate(['1']));
+        isSame(null, $rule->validate(['1', '1']));
+        isSame(null, $rule->validate(['0.0', '2']));
+
+        isSame(
+            '"ag:average" at line 1, column "prop". Column average is not equal to expected. Actual: 2, expected: 1.',
+            \strip_tags((string)$rule->validate(['1', '2', '3'])),
+        );
+    }
+
+    public function testAverageMin(): void
+    {
+        $rule = new AverageMin('prop', 0);
+        isSame(null, $rule->validate([]));
+
+        $rule = new AverageMin('prop', 1);
+        isSame(null, $rule->validate(['1']));
+        isSame(null, $rule->validate(['1', '1']));
+        isSame(null, $rule->validate(['0.0', '2']));
+
+        isSame(
+            '"ag:average_min" at line 1, column "prop". ' .
+            'Column average is less than expected. Actual: -0.5, expected: 1.',
+            \strip_tags((string)$rule->validate(['-1', '0'])),
+        );
+    }
+
+    public function testAverageMax(): void
+    {
+        $rule = new AverageMax('prop', 0);
+        isSame(null, $rule->validate([]));
+
+        $rule = new AverageMax('prop', 1);
+        isSame(null, $rule->validate(['1']));
+        isSame(null, $rule->validate(['1', '1']));
+        isSame(null, $rule->validate(['0.0', '2']));
+
+        isSame(
+            '"ag:average_max" at line 1, column "prop". ' .
+            'Column average is greater than expected. Actual: 5, expected: 1.',
+            \strip_tags((string)$rule->validate(['10', '0'])),
+        );
+    }
+
+    public function testMedian(): void
+    {
+        $rule = new Median('prop', 0);
+        isSame(null, $rule->validate([]));
+
+        $rule = new Median('prop', 1);
+        isSame(null, $rule->validate(['1']));
+        isSame(null, $rule->validate(['1', '1']));
+        isSame(null, $rule->validate(['0.0', '2']));
+
+        isSame(
+            '"ag:median" at line 1, column "prop". ' .
+            'Column median is not equal to expected. Actual: 4.5, expected: 1.',
+            \strip_tags((string)$rule->validate(['1', '2', '3', '4', '5', '8', '10', '20'])),
         );
     }
 }


### PR DESCRIPTION
Add aggregate rules for sum minimum, sum maximum, average, average minimum, and average maximum in their separate PHP classes. Refactor 'validateRule' method in 'IsCardinalDirection' to remove duplicated functionality. Offer more test coverage in 'AggregateRulesTest.php'. Ensure the newly added rules are covered by tests.