### PR TITLE
Refactor test suite structure and update namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,8 @@ Integrating CSV validation into CI processes promotes higher data integrity, rel
 * [demo.csv](tests/fixtures/demo.csv)
 
 
-## Usage
-
-Also see demo in the [GitHub Actions](https://github.com/JBZoo/Csv-Blueprint/actions/workflows/demo.yml) file.
-
 ### Schema Definition
-Define your CSV validation schema in a YAML file.
+Define your CSV validation schema in a [YAML](schema-examples/full.yml). Other formats are also available: , [JSON](schema-examples/full.json), [PHP](schema-examples/full.php).
 
 This example defines a simple schema for a CSV file with a header row, specifying that the `id` column must not be empty and must contain integer values.
 Also, it checks that the `name` column has a minimum length of 3 characters.
@@ -74,6 +70,9 @@ columns:
 
 ```
 
+
+### Full description of the scheme
+
 In the [example Yml file](schema-examples/full.yml) you can find a detailed description of all features.
 It's also covered by tests, so it's always up-to-date.
 
@@ -84,10 +83,6 @@ It's also covered by tests, so it's always up-to-date.
 * All fields (unless explicitly stated otherwise) are optional, and you can choose not to declare them. Up to you.
 * You are always free to add your option anywhere (except the `rules` list) and it will be ignored. I find it convenient for additional integrations and customization.
 
-
-### Schema file examples
-
-Available formats: [YAML](schema-examples/full.yml), [JSON](schema-examples/full.json), [PHP](schema-examples/full.php).
 
 ```yml
 # It's a full example of the CSV schema file in YAML format.
@@ -221,6 +216,11 @@ columns:
   - description: "Column with description only. Undefined header name."
 
 ```
+
+
+## Usage
+
+You can find launch examples in the [workflow demo](https://github.com/JBZoo/Csv-Blueprint/actions/workflows/demo.yml).
 
 
 ### As GitHub Action
@@ -436,6 +436,8 @@ It's random ideas and plans. No orderings and deadlines. <u>But batch processing
 
 **Validation**
 * More aggregate rules.
+* More cell rules.
+* `required` flag for the column.
 * Custom cell rule as a callback. It's useful when you have a complex rule that can't be described in the schema file.
 * Custom agregate rule as a callback. It's useful when you have a complex rule that can't be described in the schema file.
 * Configurable keyword for null/empty values. By default, it's an empty string. But you will use `null`, `nil`, `none`, `empty`, etc. Overridable on the column level.

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ It's random ideas and plans. No orderings and deadlines. <u>But batch processing
 **Batch processing**
 * If option `--csv` is not specified, then the STDIN is used. To build a pipeline in Unix-like systems.
 * Discovering CSV files by `filename_pattern` in the schema file. In case you have a lot of schemas and a lot of CSV files and want to automate the process as one command.
-* Flag to ignore file name pattern. It's useful when you have a lot of files and you don't want to validate the file name.
+* Flag to ignore file name pattern. It's useful when you have a lot of files, and you don't want to validate the file name.
 
 **Validation**
 * More aggregate rules.

--- a/README.md
+++ b/README.md
@@ -124,12 +124,12 @@ columns:
       # 5. The order of rules execution is the same as in the scheme. But it doesn't matter.
       #    The result will be the same in any order.
       # 6. Most of the rules are case-sensitive. Unless otherwise specified.
-      # 7. As backup plan, you alsways can use the "regex" rule.
+      # 7. As backup plan, you always can use the "regex" rule.
 
       # General rules
       not_empty: true                   # Value is not an empty string. Actually checks if the string length is not 0.
-      exact_value: Some string          # Case-sensitive. Exact value for string in the column.
-      allow_values: [ y, n, "" ]        # Strict set of values that are allowed. Case-sensitive.
+      exact_value: Some string          # Exact value for string in the column.
+      allow_values: [ y, n, "" ]        # Strict set of values that are allowed.
 
       # Any valid regex pattern. See https://www.php.net/manual/en/reference.pcre.pattern.syntax.php.
       # Of course it's an ultimatum to verify any sort of string data.
@@ -158,11 +158,11 @@ columns:
       word_count_max: 10
 
       # Contains rules
-      contains: Hello                   # Case-sensitive. Example: "Hello World".
-      contains_one: [ a, b ]            # At least one of the string must be in the CSV value. Case-sensitive.
-      contains_all: [ a, b, c ]         # All the strings must be part of a CSV value. Case-sensitive.
-      starts_with: "prefix "            # Case-sensitive. Example: "prefix Hello World".
-      ends_with: " suffix"              # Case-sensitive. Example: "Hello World suffix".
+      contains: Hello                   # Example: "Hello World".
+      contains_one: [ a, b ]            # At least one of the string must be in the CSV value.
+      contains_all: [ a, b, c ]         # All the strings must be part of a CSV value.
+      starts_with: "prefix "            # Example: "prefix Hello World".
+      ends_with: " suffix"              # Example: "Hello World suffix".
 
       # Under the hood it convertes and compares as float values.
       # Comparison accuracy is 12 digits after a dot.

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -44,12 +44,12 @@ columns:
       # 5. The order of rules execution is the same as in the scheme. But it doesn't matter.
       #    The result will be the same in any order.
       # 6. Most of the rules are case-sensitive. Unless otherwise specified.
-      # 7. As backup plan, you alsways can use the "regex" rule.
+      # 7. As backup plan, you always can use the "regex" rule.
 
       # General rules
       not_empty: true                   # Value is not an empty string. Actually checks if the string length is not 0.
-      exact_value: Some string          # Case-sensitive. Exact value for string in the column.
-      allow_values: [ y, n, "" ]        # Strict set of values that are allowed. Case-sensitive.
+      exact_value: Some string          # Exact value for string in the column.
+      allow_values: [ y, n, "" ]        # Strict set of values that are allowed.
 
       # Any valid regex pattern. See https://www.php.net/manual/en/reference.pcre.pattern.syntax.php.
       # Of course it's an ultimatum to verify any sort of string data.
@@ -78,11 +78,11 @@ columns:
       word_count_max: 10
 
       # Contains rules
-      contains: Hello                   # Case-sensitive. Example: "Hello World".
-      contains_one: [ a, b ]            # At least one of the string must be in the CSV value. Case-sensitive.
-      contains_all: [ a, b, c ]         # All the strings must be part of a CSV value. Case-sensitive.
-      starts_with: "prefix "            # Case-sensitive. Example: "prefix Hello World".
-      ends_with: " suffix"              # Case-sensitive. Example: "Hello World suffix".
+      contains: Hello                   # Example: "Hello World".
+      contains_one: [ a, b ]            # At least one of the string must be in the CSV value.
+      contains_all: [ a, b, c ]         # All the strings must be part of a CSV value.
+      starts_with: "prefix "            # Example: "prefix Hello World".
+      ends_with: " suffix"              # Example: "Hello World suffix".
 
       # Under the hood it convertes and compares as float values.
       # Comparison accuracy is 12 digits after a dot.

--- a/src/Rules/Cell/AllowValues.php
+++ b/src/Rules/Cell/AllowValues.php
@@ -19,7 +19,7 @@ namespace JBZoo\CsvBlueprint\Rules\Cell;
 class AllowValues extends AbstarctCellRule
 {
     protected const HELP_OPTIONS = [
-        self::DEFAULT => ['[ y, n, "" ]', 'Strict set of values that are allowed. Case-sensitive.'],
+        self::DEFAULT => ['[ y, n, "" ]', 'Strict set of values that are allowed.'],
     ];
 
     public function validateRule(string $cellValue): ?string

--- a/src/Rules/Cell/Contains.php
+++ b/src/Rules/Cell/Contains.php
@@ -19,7 +19,7 @@ namespace JBZoo\CsvBlueprint\Rules\Cell;
 final class Contains extends AbstarctCellRule
 {
     protected const HELP_OPTIONS = [
-        self::DEFAULT => ['Hello', 'Case-sensitive. Example: "Hello World".'],
+        self::DEFAULT => ['Hello', 'Example: "Hello World".'],
     ];
 
     public function validateRule(string $cellValue): ?string

--- a/src/Rules/Cell/ContainsAll.php
+++ b/src/Rules/Cell/ContainsAll.php
@@ -19,7 +19,7 @@ namespace JBZoo\CsvBlueprint\Rules\Cell;
 final class ContainsAll extends AbstarctCellRule
 {
     protected const HELP_OPTIONS = [
-        self::DEFAULT => ['[ a, b, c ]', 'All the strings must be part of a CSV value. Case-sensitive.'],
+        self::DEFAULT => ['[ a, b, c ]', 'All the strings must be part of a CSV value.'],
     ];
 
     public function validateRule(string $cellValue): ?string

--- a/src/Rules/Cell/ContainsOne.php
+++ b/src/Rules/Cell/ContainsOne.php
@@ -19,7 +19,7 @@ namespace JBZoo\CsvBlueprint\Rules\Cell;
 final class ContainsOne extends AbstarctCellRule
 {
     protected const HELP_OPTIONS = [
-        self::DEFAULT => ['[ a, b ]', 'At least one of the string must be in the CSV value. Case-sensitive.'],
+        self::DEFAULT => ['[ a, b ]', 'At least one of the string must be in the CSV value.'],
     ];
 
     public function validateRule(string $cellValue): ?string

--- a/src/Rules/Cell/EndsWith.php
+++ b/src/Rules/Cell/EndsWith.php
@@ -19,7 +19,7 @@ namespace JBZoo\CsvBlueprint\Rules\Cell;
 final class EndsWith extends AbstarctCellRule
 {
     protected const HELP_OPTIONS = [
-        self::DEFAULT => ['" suffix"', 'Case-sensitive. Example: "Hello World suffix".'],
+        self::DEFAULT => ['" suffix"', 'Example: "Hello World suffix".'],
     ];
 
     public function validateRule(string $cellValue): ?string

--- a/src/Rules/Cell/ExactValue.php
+++ b/src/Rules/Cell/ExactValue.php
@@ -19,7 +19,7 @@ namespace JBZoo\CsvBlueprint\Rules\Cell;
 final class ExactValue extends AbstarctCellRule
 {
     protected const HELP_OPTIONS = [
-        self::DEFAULT => ['Some string', 'Case-sensitive. Exact value for string in the column.'],
+        self::DEFAULT => ['Some string', 'Exact value for string in the column.'],
     ];
 
     public function validateRule(string $cellValue): ?string

--- a/src/Rules/Cell/StartsWith.php
+++ b/src/Rules/Cell/StartsWith.php
@@ -19,7 +19,7 @@ namespace JBZoo\CsvBlueprint\Rules\Cell;
 final class StartsWith extends AbstarctCellRule
 {
     protected const HELP_OPTIONS = [
-        self::DEFAULT => ['"prefix "', 'Case-sensitive. Example: "prefix Hello World".'],
+        self::DEFAULT => ['"prefix "', 'Example: "prefix Hello World".'],
     ];
 
     public function validateRule(string $cellValue): ?string

--- a/tests/Commands/ValidateCsvTest.php
+++ b/tests/Commands/ValidateCsvTest.php
@@ -14,9 +14,9 @@
 
 declare(strict_types=1);
 
-namespace JBZoo\PHPUnit\Blueprint;
+namespace JBZoo\PHPUnit\Commands;
 
-use JBZoo\PHPUnit\PHPUnit;
+use JBZoo\PHPUnit\TestCase;
 use JBZoo\PHPUnit\Tools;
 use JBZoo\Utils\Cli;
 use Symfony\Component\Console\Input\StringInput;
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Input\StringInput;
 use function JBZoo\PHPUnit\isNotEmpty;
 use function JBZoo\PHPUnit\isSame;
 
-final class ValidateCsvTest extends PHPUnit
+final class ValidateCsvTest extends TestCase
 {
     public function testValidateOneFilePositive(): void
     {

--- a/tests/Commands/ValidateCsvTest.php
+++ b/tests/Commands/ValidateCsvTest.php
@@ -57,8 +57,6 @@ final class ValidateCsvTest extends TestCase
             'schema' => './tests/schemas/demo_invalid.yml',    // Relative path
         ]);
 
-        Tools::dumpText($actual);
-
         $expected = <<<'TXT'
             Schema: ./tests/schemas/demo_invalid.yml
             Found CSV files: 1
@@ -98,8 +96,6 @@ final class ValidateCsvTest extends TestCase
         ];
         $optionsAsString     = new StringInput(Cli::build('', $options));
         [$actual, $exitCode] = Tools::virtualExecution('validate:csv', $options);
-
-        Tools::dumpText($actual);
 
         $expected = <<<'TXT'
             Schema: ./tests/schemas/demo_invalid.yml
@@ -151,8 +147,6 @@ final class ValidateCsvTest extends TestCase
             'schema' => './tests/schemas/demo_invalid.yml',
             'report' => 'text',
         ]);
-
-        Tools::dumpText($actual);
 
         $expected = <<<'TXT'
             Schema: ./tests/schemas/demo_invalid.yml
@@ -280,8 +274,6 @@ final class ValidateCsvTest extends TestCase
             'schema' => './tests/schemas/demo_invalid.yml',
             'report' => 'teamcity',
         ]);
-
-        Tools::dumpText($actual);
 
         $expected = <<<'TXT'
             Schema: ./tests/schemas/demo_invalid.yml

--- a/tests/Csv/CsvFileTest.php
+++ b/tests/Csv/CsvFileTest.php
@@ -21,7 +21,7 @@ use JBZoo\PHPUnit\PHPUnit;
 
 use function JBZoo\PHPUnit\isSame;
 
-final class CsvReaderTest extends PHPUnit
+final class CsvFileTest extends PHPUnit
 {
     private const CSV_SIMPLE_HEADER    = PROJECT_TESTS . '/fixtures/simple_header.csv';
     private const CSV_SIMPLE_NO_HEADER = PROJECT_TESTS . '/fixtures/simple_no_header.csv';

--- a/tests/Csv/CsvFileTest.php
+++ b/tests/Csv/CsvFileTest.php
@@ -17,22 +17,17 @@ declare(strict_types=1);
 namespace JBZoo\PHPUnit\Csv;
 
 use JBZoo\CsvBlueprint\Csv\CsvFile;
-use JBZoo\PHPUnit\PHPUnit;
+use JBZoo\PHPUnit\TestCase;
+use JBZoo\PHPUnit\Tools;
 
 use function JBZoo\PHPUnit\isSame;
 
-final class CsvFileTest extends PHPUnit
+final class CsvFileTest extends TestCase
 {
-    private const CSV_SIMPLE_HEADER    = PROJECT_TESTS . '/fixtures/simple_header.csv';
-    private const CSV_SIMPLE_NO_HEADER = PROJECT_TESTS . '/fixtures/simple_no_header.csv';
-
-    private const SCHEMA_SIMPLE_HEADER    = PROJECT_TESTS . '/schemas/simple_header.yml';
-    private const SCHEMA_SIMPLE_NO_HEADER = PROJECT_TESTS . '/schemas/simple_no_header.yml';
-
     public function testReadCsvFileWithoutHeader(): void
     {
-        $csv = new CsvFile(self::CSV_SIMPLE_NO_HEADER, self::SCHEMA_SIMPLE_NO_HEADER);
-        isSame(self::CSV_SIMPLE_NO_HEADER, $csv->getCsvFilename());
+        $csv = new CsvFile(Tools::CSV_SIMPLE_NO_HEADER, Tools::SCHEMA_SIMPLE_NO_HEADER);
+        isSame(Tools::CSV_SIMPLE_NO_HEADER, $csv->getCsvFilename());
 
         isSame([], $csv->getHeader());
 
@@ -49,8 +44,8 @@ final class CsvFileTest extends PHPUnit
 
     public function testReadCsvFileWithHeader(): void
     {
-        $csv = new CsvFile(self::CSV_SIMPLE_HEADER, self::SCHEMA_SIMPLE_HEADER);
-        isSame(self::CSV_SIMPLE_HEADER, $csv->getCsvFilename());
+        $csv = new CsvFile(Tools::CSV_SIMPLE_HEADER, Tools::SCHEMA_SIMPLE_HEADER);
+        isSame(Tools::CSV_SIMPLE_HEADER, $csv->getCsvFilename());
 
         isSame(['seq', 'bool', 'exact'], $csv->getHeader());
 

--- a/tests/Csv/CsvReaderTest.php
+++ b/tests/Csv/CsvReaderTest.php
@@ -14,7 +14,7 @@
 
 declare(strict_types=1);
 
-namespace JBZoo\PHPUnit\Blueprint;
+namespace JBZoo\PHPUnit\Csv;
 
 use JBZoo\CsvBlueprint\Csv\CsvFile;
 use JBZoo\PHPUnit\PHPUnit;

--- a/tests/ExampleSchemasTest.php
+++ b/tests/ExampleSchemasTest.php
@@ -28,7 +28,7 @@ final class ExampleSchemasTest extends TestCase
 {
     public function testFullListOfRules(): void
     {
-        $rulesInConfig = yml(PROJECT_ROOT . '/schema-examples/full.yml')->findArray('columns.0.rules');
+        $rulesInConfig = yml(Tools::SCHEMA_FULL)->findArray('columns.0.rules');
         $rulesInConfig = \array_keys($rulesInConfig);
         \sort($rulesInConfig);
 
@@ -87,7 +87,7 @@ final class ExampleSchemasTest extends TestCase
 
     public function testCsvStrutureDefaultValues(): void
     {
-        $defaultsInDoc = yml(PROJECT_ROOT . '/schema-examples/full.yml')->findArray('csv');
+        $defaultsInDoc = yml(Tools::SCHEMA_FULL)->findArray('csv');
 
         $schema = new Schema([]);
         $schema->getCsvStructure()->getArrayCopy();
@@ -98,15 +98,15 @@ final class ExampleSchemasTest extends TestCase
     public function testCompareExamplesWithOrig(): void
     {
         $basepath = PROJECT_ROOT . '/schema-examples/full';
-        $origYml  = yml("{$basepath}.yml")->getArrayCopy();
+        $origYml  = yml(Tools::SCHEMA_FULL)->getArrayCopy();
 
-        isSame((string)phpArray($origYml), (string)phpArray("{$basepath}.php"), 'PHP config is invalid');
-        isSame((string)json($origYml), (string)json("{$basepath}.json"), 'JSON config is invalid');
+        isSame((string)phpArray(Tools::SCHEMA_FULL_PHP), (string)phpArray($origYml), 'PHP config is invalid');
+        isSame((string)json(Tools::SCHEMA_FULL_JSON), (string)json($origYml), 'JSON config is invalid');
     }
 
     public function testUniqueNameOfRules(): void
     {
-        $yml = yml(PROJECT_ROOT . '/schema-examples/full.yml');
+        $yml = yml(Tools::SCHEMA_FULL);
 
         $rules     = \array_keys($yml->findArray('columns.0.rules'));
         $agRules   = \array_keys($yml->findArray('columns.0.aggregate_rules'));
@@ -117,7 +117,7 @@ final class ExampleSchemasTest extends TestCase
 
     public function testRuleNaming(): void
     {
-        $yml = yml(PROJECT_ROOT . '/schema-examples/full.yml');
+        $yml = yml(Tools::SCHEMA_FULL);
 
         $rules = $yml->findArray('columns.0.rules');
 
@@ -135,7 +135,7 @@ final class ExampleSchemasTest extends TestCase
     {
         $filepath = \implode(
             "\n",
-            \array_slice(\explode("\n", \file_get_contents(PROJECT_ROOT . '/schema-examples/full.yml')), 12),
+            \array_slice(\explode("\n", \file_get_contents(Tools::SCHEMA_FULL)), 12),
         );
 
         $tmpl = \implode("\n", ['```yml', $filepath, '```']);

--- a/tests/ExampleSchemasTest.php
+++ b/tests/ExampleSchemasTest.php
@@ -24,7 +24,7 @@ use function JBZoo\Data\json;
 use function JBZoo\Data\phpArray;
 use function JBZoo\Data\yml;
 
-final class ExampleSchemasTest extends PHPUnit
+final class ExampleSchemasTest extends TestCase
 {
     public function testFullListOfRules(): void
     {
@@ -95,16 +95,6 @@ final class ExampleSchemasTest extends PHPUnit
         isSame($defaultsInDoc, $schema->getCsvStructure()->getArrayCopy());
     }
 
-    public function testCheckYmlSchemaExampleInReadme(): void
-    {
-        $this->testCheckExampleInReadme(
-            PROJECT_ROOT . '/schema-examples/full.yml',
-            'yml',
-            'YAML format (with comment)',
-            12,
-        );
-    }
-
     public function testCompareExamplesWithOrig(): void
     {
         $basepath = PROJECT_ROOT . '/schema-examples/full';
@@ -141,40 +131,15 @@ final class ExampleSchemasTest extends PHPUnit
         }
     }
 
-    private function testCheckExampleInReadme(
-        string $filepath,
-        string $type,
-        string $title,
-        int $skipFirstLines = 0,
-    ): void {
+    public function testCheckYmlSchemaExampleInReadme(): void
+    {
         $filepath = \implode(
             "\n",
-            \array_slice(\explode("\n", \file_get_contents($filepath)), $skipFirstLines),
+            \array_slice(\explode("\n", \file_get_contents(PROJECT_ROOT . '/schema-examples/full.yml')), 12),
         );
 
-        if ($type === 'php') {
-            $tmpl = \implode("\n", ['```php', '<?php', $filepath, '```']);
-        } else {
-            $tmpl = \implode("\n", ["```{$type}", $filepath, '```']);
-        }
-
-        if ($type !== 'yml') {
-            $tmpl = $this->getSpoiler("Click to see: {$title}", $tmpl);
-        }
+        $tmpl = \implode("\n", ['```yml', $filepath, '```']);
 
         isFileContains($tmpl, PROJECT_ROOT . '/README.md');
-    }
-
-    private function getSpoiler(string $title, string $body): string
-    {
-        return \implode("\n", [
-            '<details>',
-            "  <summary>{$title}</summary>",
-            '',
-            "{$body}",
-            '',
-            '</details>',
-            '',
-        ]);
     }
 }

--- a/tests/ExampleSchemasTest.php
+++ b/tests/ExampleSchemasTest.php
@@ -14,21 +14,17 @@
 
 declare(strict_types=1);
 
-namespace JBZoo\PHPUnit\Blueprint;
+namespace JBZoo\PHPUnit;
 
 use JBZoo\CsvBlueprint\Schema;
 use JBZoo\CsvBlueprint\Utils;
-use JBZoo\PHPUnit\PHPUnit;
 use Symfony\Component\Finder\Finder;
 
 use function JBZoo\Data\json;
 use function JBZoo\Data\phpArray;
 use function JBZoo\Data\yml;
-use function JBZoo\PHPUnit\isFileContains;
-use function JBZoo\PHPUnit\isSame;
-use function JBZoo\PHPUnit\isTrue;
 
-final class MiscTest extends PHPUnit
+final class ExampleSchemasTest extends PHPUnit
 {
     public function testFullListOfRules(): void
     {

--- a/tests/GithubActionsTest.php
+++ b/tests/GithubActionsTest.php
@@ -14,14 +14,11 @@
 
 declare(strict_types=1);
 
-namespace JBZoo\PHPUnit\Blueprint;
+namespace JBZoo\PHPUnit;
 
 use JBZoo\CsvBlueprint\Validators\ErrorSuite;
-use JBZoo\PHPUnit\PHPUnit;
 
 use function JBZoo\Data\yml;
-use function JBZoo\PHPUnit\isFileContains;
-use function JBZoo\PHPUnit\isSame;
 
 final class GithubActionsTest extends PHPUnit
 {

--- a/tests/GithubActionsTest.php
+++ b/tests/GithubActionsTest.php
@@ -20,7 +20,7 @@ use JBZoo\CsvBlueprint\Validators\ErrorSuite;
 
 use function JBZoo\Data\yml;
 
-final class GithubActionsTest extends PHPUnit
+final class GithubActionsTest extends TestCase
 {
     public function testCreateCsvHelp(): void
     {

--- a/tests/PackageTest.php
+++ b/tests/PackageTest.php
@@ -18,7 +18,7 @@ namespace JBZoo\PHPUnit;
 
 use function JBZoo\Data\json;
 
-final class CsvBlueprintPackageTest extends \JBZoo\Codestyle\PHPUnit\AbstractPackageTest
+final class PackageTest extends \JBZoo\Codestyle\PHPUnit\AbstractPackageTest
 {
     protected string $packageName = 'Csv-Blueprint';
 

--- a/tests/PhpStormProxyTest.php
+++ b/tests/PhpStormProxyTest.php
@@ -16,6 +16,6 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit;
 
-final class CsvBlueprintPhpStormProxyTest extends \JBZoo\Codestyle\PHPUnit\AbstractPhpStormProxyTest
+final class PhpStormProxyTest extends \JBZoo\Codestyle\PHPUnit\AbstractPhpStormProxyTest
 {
 }

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -14,15 +14,10 @@
 
 declare(strict_types=1);
 
-namespace JBZoo\PHPUnit\Blueprint;
+namespace JBZoo\PHPUnit;
 
-use JBZoo\PHPUnit\PHPUnit;
-use JBZoo\PHPUnit\Tools;
 use JBZoo\Utils\Cli;
 use Symfony\Component\Console\Input\StringInput;
-
-use function JBZoo\PHPUnit\isFileContains;
-use function JBZoo\PHPUnit\isSame;
 
 final class ReadmeTest extends PHPUnit
 {

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -19,7 +19,7 @@ namespace JBZoo\PHPUnit;
 use JBZoo\Utils\Cli;
 use Symfony\Component\Console\Input\StringInput;
 
-final class ReadmeTest extends PHPUnit
+final class ReadmeTest extends TestCase
 {
     public function testCreateCsvHelp(): void
     {

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -30,7 +30,7 @@ final class ReadmeTest extends TestCase
             '',
             Tools::realExecution('validate:csv', ['help' => null]),
             '```',
-        ]), PROJECT_ROOT . '/README.md');
+        ]), Tools::README);
     }
 
     public function testTableOutputExample(): void
@@ -51,6 +51,6 @@ final class ReadmeTest extends TestCase
             '',
             $actual,
             '```',
-        ]), PROJECT_ROOT . '/README.md');
+        ]), Tools::README);
     }
 }

--- a/tests/Rules/AbstractCellRuleComboTest.php
+++ b/tests/Rules/AbstractCellRuleComboTest.php
@@ -18,7 +18,6 @@ namespace JBZoo\PHPUnit\Rules;
 
 use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
 use JBZoo\PHPUnit\TestCase;
-
 use JBZoo\PHPUnit\Tools;
 
 use function JBZoo\PHPUnit\isFileContains;

--- a/tests/Rules/AbstractCellRuleComboTest.php
+++ b/tests/Rules/AbstractCellRuleComboTest.php
@@ -16,9 +16,10 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules;
 
-use JBZoo\CsvBlueprint\Rules\AbstractCombo;
-use JBZoo\CsvBlueprint\Rules\AbstractCombo as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
 use JBZoo\PHPUnit\TestCase;
+
+use JBZoo\PHPUnit\Tools;
 
 use function JBZoo\PHPUnit\isFileContains;
 
@@ -40,10 +41,10 @@ abstract class AbstractCellRuleComboTest extends TestCase
 
     public function testHelpMessageInExample(): void
     {
-        isFileContains($this->create(6, Combo::MAX)->getHelp(), PROJECT_ROOT . '/schema-examples/full.yml');
+        isFileContains($this->create(6, Combo::MAX)->getHelp(), Tools::SCHEMA_FULL);
     }
 
-    protected function create(array|float|int|string $value, string $mode): AbstractCombo
+    protected function create(array|float|int|string $value, string $mode): Combo
     {
         return new $this->ruleClass('prop', $value, $mode);
     }

--- a/tests/Rules/AbstractCellRuleTest.php
+++ b/tests/Rules/AbstractCellRuleTest.php
@@ -19,6 +19,8 @@ namespace JBZoo\PHPUnit\Rules;
 use JBZoo\CsvBlueprint\Rules\Cell\AbstarctCellRule;
 use JBZoo\PHPUnit\TestCase;
 
+use JBZoo\PHPUnit\Tools;
+
 use function JBZoo\PHPUnit\isFileContains;
 
 abstract class AbstractCellRuleTest extends TestCase
@@ -35,7 +37,7 @@ abstract class AbstractCellRuleTest extends TestCase
 
     public function testHelpMessageInExample(): void
     {
-        isFileContains($this->create(6)->getHelp(), PROJECT_ROOT . '/schema-examples/full.yml');
+        isFileContains($this->create(6)->getHelp(), Tools::SCHEMA_FULL);
     }
 
     protected function create(array|bool|float|int|string $value): AbstarctCellRule

--- a/tests/Rules/AbstractCellRuleTest.php
+++ b/tests/Rules/AbstractCellRuleTest.php
@@ -18,7 +18,6 @@ namespace JBZoo\PHPUnit\Rules;
 
 use JBZoo\CsvBlueprint\Rules\Cell\AbstarctCellRule;
 use JBZoo\PHPUnit\TestCase;
-
 use JBZoo\PHPUnit\Tools;
 
 use function JBZoo\PHPUnit\isFileContains;

--- a/tests/Rules/AggregateRulesTest.php
+++ b/tests/Rules/AggregateRulesTest.php
@@ -17,11 +17,11 @@ declare(strict_types=1);
 namespace JBZoo\PHPUnit\Rules;
 
 use JBZoo\CsvBlueprint\Rules\Aggregate\IsUnique;
-use JBZoo\PHPUnit\PHPUnit;
+use JBZoo\PHPUnit\TestCase;
 
 use function JBZoo\PHPUnit\isSame;
 
-final class AggregateRulesTest extends PHPUnit
+final class AggregateRulesTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Rules/AggregateRulesTest.php
+++ b/tests/Rules/AggregateRulesTest.php
@@ -14,7 +14,7 @@
 
 declare(strict_types=1);
 
-namespace JBZoo\PHPUnit\Blueprint;
+namespace JBZoo\PHPUnit\Rules;
 
 use JBZoo\CsvBlueprint\Rules\Aggregate\IsUnique;
 use JBZoo\PHPUnit\PHPUnit;

--- a/tests/Rules/Cell/RegexTest.php
+++ b/tests/Rules/Cell/RegexTest.php
@@ -32,6 +32,7 @@ final class RegexTest extends AbstractCellRuleTest
         isSame('', $rule->test('abc'));
         isSame('', $rule->test('aaa'));
         isSame('', $rule->test('a'));
+        isSame('', $rule->test(''));
 
         $rule = $this->create('^a');
         isSame('', $rule->test('abc'));

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -20,30 +20,27 @@ use JBZoo\CsvBlueprint\Schema;
 
 final class SchemaTest extends TestCase
 {
-    private const SCHEMA_EXAMPLE_EMPTY = PROJECT_TESTS . '/schemas/example_empty.yml';
-    private const SCHEMA_EXAMPLE_FULL  = PROJECT_ROOT . '/schema-examples/full.yml';
-
     public function testFilename(): void
     {
-        $schemaEmpty = new Schema(self::SCHEMA_EXAMPLE_EMPTY);
-        isSame(self::SCHEMA_EXAMPLE_EMPTY, $schemaEmpty->getFilename());
+        $schemaEmpty = new Schema(Tools::SCHEMA_EXAMPLE_EMPTY);
+        isSame(Tools::SCHEMA_EXAMPLE_EMPTY, $schemaEmpty->getFilename());
 
-        $schemaFull = new Schema(self::SCHEMA_EXAMPLE_FULL);
-        isSame(self::SCHEMA_EXAMPLE_FULL, $schemaFull->getFilename());
+        $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_FULL);
+        isSame(Tools::SCHEMA_EXAMPLE_FULL, $schemaFull->getFilename());
     }
 
     public function testGetFinenamePattern(): void
     {
-        $schemaEmpty = new Schema(self::SCHEMA_EXAMPLE_EMPTY);
+        $schemaEmpty = new Schema(Tools::SCHEMA_EXAMPLE_EMPTY);
         isSame(null, $schemaEmpty->getFilenamePattern());
 
-        $schemaFull = new Schema(self::SCHEMA_EXAMPLE_FULL);
+        $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_FULL);
         isSame('/demo(-\d+)?\.csv$/i', $schemaFull->getFilenamePattern());
     }
 
     public function testScvStruture(): void
     {
-        $schemaEmpty = new Schema(self::SCHEMA_EXAMPLE_EMPTY);
+        $schemaEmpty = new Schema(Tools::SCHEMA_EXAMPLE_EMPTY);
         isSame([
             // 'inherit'                => null,
             'header'     => true,
@@ -56,7 +53,7 @@ final class SchemaTest extends TestCase
             // 'other_columns_possible' => false,
         ], $schemaEmpty->getCsvStructure()->getArrayCopy());
 
-        $schemaFull = new Schema(self::SCHEMA_EXAMPLE_FULL);
+        $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_FULL);
         isSame([
             // 'inherit'                => 'alias_1',
             'header'     => true,
@@ -72,10 +69,10 @@ final class SchemaTest extends TestCase
 
     public function testColumns(): void
     {
-        $schemaEmpty = new Schema(self::SCHEMA_EXAMPLE_EMPTY);
+        $schemaEmpty = new Schema(Tools::SCHEMA_EXAMPLE_EMPTY);
         isSame([], $schemaEmpty->getColumns());
 
-        $schemaFull = new Schema(self::SCHEMA_EXAMPLE_FULL);
+        $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_FULL);
         isSame([
             0 => 'Column Name (header)',
             1 => 'another_column',
@@ -86,7 +83,7 @@ final class SchemaTest extends TestCase
 
     public function testColumnByNameAndId(): void
     {
-        $schemaFull = new Schema(self::SCHEMA_EXAMPLE_FULL);
+        $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_FULL);
         isNotNull($schemaFull->getColumn(0));
         isNotNull($schemaFull->getColumn('Column Name (header)'));
 
@@ -99,10 +96,10 @@ final class SchemaTest extends TestCase
     public function testIncludes(): void
     {
         skip('Implement me!');
-        $schemaEmpty = new Schema(self::SCHEMA_EXAMPLE_EMPTY);
+        $schemaEmpty = new Schema(Tools::SCHEMA_EXAMPLE_EMPTY);
         isSame([], $schemaEmpty->getIncludes());
 
-        $schemaFull = new Schema(self::SCHEMA_EXAMPLE_FULL);
+        $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_FULL);
         isSame([
             'alias_1' => '/path/schema_1.yml',
             'alias_2' => './path/schema_2.yml',
@@ -113,24 +110,24 @@ final class SchemaTest extends TestCase
     public function testGetUndefinedColumnById(): void
     {
         $this->expectExceptionMessage(
-            'Column "1000" not found in schema "' . self::SCHEMA_EXAMPLE_EMPTY . '"',
+            'Column "1000" not found in schema "' . Tools::SCHEMA_EXAMPLE_EMPTY . '"',
         );
-        $schemaFull = new Schema(self::SCHEMA_EXAMPLE_EMPTY);
+        $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_EMPTY);
         isNull($schemaFull->getColumn(1000));
     }
 
     public function testGetUndefinedColumnByName(): void
     {
         $this->expectExceptionMessage(
-            'Column "undefined_column" not found in schema "' . self::SCHEMA_EXAMPLE_EMPTY . '"',
+            'Column "undefined_column" not found in schema "' . Tools::SCHEMA_EXAMPLE_EMPTY . '"',
         );
-        $schemaFull = new Schema(self::SCHEMA_EXAMPLE_EMPTY);
+        $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_EMPTY);
         isNull($schemaFull->getColumn('undefined_column'));
     }
 
     public function testGetColumnMinimal(): void
     {
-        $schemaFull = new Schema(self::SCHEMA_EXAMPLE_FULL);
+        $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_FULL);
         $column     = $schemaFull->getColumn(0);
 
         isSame('Column Name (header)', $column->getName());
@@ -147,7 +144,7 @@ final class SchemaTest extends TestCase
 
     public function testGetColumnProps(): void
     {
-        $schemaFull = new Schema(self::SCHEMA_EXAMPLE_FULL);
+        $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_FULL);
         $column     = $schemaFull->getColumn(0);
 
         isSame('Column Name (header)', $column->getName());
@@ -164,7 +161,7 @@ final class SchemaTest extends TestCase
 
     public function testGetColumnRules(): void
     {
-        $schemaFull   = new Schema(self::SCHEMA_EXAMPLE_FULL);
+        $schemaFull   = new Schema(Tools::SCHEMA_EXAMPLE_FULL);
         $columnByName = $schemaFull->getColumn('Column Name (header)');
         $columnById   = $schemaFull->getColumn(0);
 
@@ -225,7 +222,7 @@ final class SchemaTest extends TestCase
 
     public function testGetColumnAggregateRules(): void
     {
-        $schemaFull = new Schema(self::SCHEMA_EXAMPLE_FULL);
+        $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_FULL);
         $column     = $schemaFull->getColumn(0);
 
         isSame([

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -14,20 +14,11 @@
 
 declare(strict_types=1);
 
-namespace JBZoo\PHPUnit\Blueprint;
+namespace JBZoo\PHPUnit;
 
 use JBZoo\CsvBlueprint\Schema;
-use JBZoo\PHPUnit\PHPUnit;
 
-use function JBZoo\PHPUnit\isFalse;
-use function JBZoo\PHPUnit\isNotEmpty;
-use function JBZoo\PHPUnit\isNotNull;
-use function JBZoo\PHPUnit\isNull;
-use function JBZoo\PHPUnit\isSame;
-use function JBZoo\PHPUnit\isTrue;
-use function JBZoo\PHPUnit\skip;
-
-final class SchemaTest extends PHPUnit
+final class SchemaTest extends TestCase
 {
     private const SCHEMA_EXAMPLE_EMPTY = PROJECT_TESTS . '/schemas/example_empty.yml';
     private const SCHEMA_EXAMPLE_FULL  = PROJECT_ROOT . '/schema-examples/full.yml';

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -25,8 +25,8 @@ final class SchemaTest extends TestCase
         $schemaEmpty = new Schema(Tools::SCHEMA_EXAMPLE_EMPTY);
         isSame(Tools::SCHEMA_EXAMPLE_EMPTY, $schemaEmpty->getFilename());
 
-        $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_FULL);
-        isSame(Tools::SCHEMA_EXAMPLE_FULL, $schemaFull->getFilename());
+        $schemaFull = new Schema(Tools::SCHEMA_FULL);
+        isSame(Tools::SCHEMA_FULL, $schemaFull->getFilename());
     }
 
     public function testGetFinenamePattern(): void
@@ -34,7 +34,7 @@ final class SchemaTest extends TestCase
         $schemaEmpty = new Schema(Tools::SCHEMA_EXAMPLE_EMPTY);
         isSame(null, $schemaEmpty->getFilenamePattern());
 
-        $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_FULL);
+        $schemaFull = new Schema(Tools::SCHEMA_FULL);
         isSame('/demo(-\d+)?\.csv$/i', $schemaFull->getFilenamePattern());
     }
 
@@ -53,7 +53,7 @@ final class SchemaTest extends TestCase
             // 'other_columns_possible' => false,
         ], $schemaEmpty->getCsvStructure()->getArrayCopy());
 
-        $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_FULL);
+        $schemaFull = new Schema(Tools::SCHEMA_FULL);
         isSame([
             // 'inherit'                => 'alias_1',
             'header'     => true,
@@ -72,7 +72,7 @@ final class SchemaTest extends TestCase
         $schemaEmpty = new Schema(Tools::SCHEMA_EXAMPLE_EMPTY);
         isSame([], $schemaEmpty->getColumns());
 
-        $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_FULL);
+        $schemaFull = new Schema(Tools::SCHEMA_FULL);
         isSame([
             0 => 'Column Name (header)',
             1 => 'another_column',
@@ -83,7 +83,7 @@ final class SchemaTest extends TestCase
 
     public function testColumnByNameAndId(): void
     {
-        $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_FULL);
+        $schemaFull = new Schema(Tools::SCHEMA_FULL);
         isNotNull($schemaFull->getColumn(0));
         isNotNull($schemaFull->getColumn('Column Name (header)'));
 
@@ -99,7 +99,7 @@ final class SchemaTest extends TestCase
         $schemaEmpty = new Schema(Tools::SCHEMA_EXAMPLE_EMPTY);
         isSame([], $schemaEmpty->getIncludes());
 
-        $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_FULL);
+        $schemaFull = new Schema(Tools::SCHEMA_FULL);
         isSame([
             'alias_1' => '/path/schema_1.yml',
             'alias_2' => './path/schema_2.yml',
@@ -127,7 +127,7 @@ final class SchemaTest extends TestCase
 
     public function testGetColumnMinimal(): void
     {
-        $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_FULL);
+        $schemaFull = new Schema(Tools::SCHEMA_FULL);
         $column     = $schemaFull->getColumn(0);
 
         isSame('Column Name (header)', $column->getName());
@@ -144,7 +144,7 @@ final class SchemaTest extends TestCase
 
     public function testGetColumnProps(): void
     {
-        $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_FULL);
+        $schemaFull = new Schema(Tools::SCHEMA_FULL);
         $column     = $schemaFull->getColumn(0);
 
         isSame('Column Name (header)', $column->getName());
@@ -161,7 +161,7 @@ final class SchemaTest extends TestCase
 
     public function testGetColumnRules(): void
     {
-        $schemaFull   = new Schema(Tools::SCHEMA_EXAMPLE_FULL);
+        $schemaFull   = new Schema(Tools::SCHEMA_FULL);
         $columnByName = $schemaFull->getColumn('Column Name (header)');
         $columnById   = $schemaFull->getColumn(0);
 
@@ -222,7 +222,7 @@ final class SchemaTest extends TestCase
 
     public function testGetColumnAggregateRules(): void
     {
-        $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_FULL);
+        $schemaFull = new Schema(Tools::SCHEMA_FULL);
         $column     = $schemaFull->getColumn(0);
 
         isSame([

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,5 +23,6 @@ abstract class TestCase extends PHPUnit
         parent::setUp();
 
         \date_default_timezone_set('UTC');
+        \chdir(PROJECT_ROOT);
     }
 }

--- a/tests/Tools.php
+++ b/tests/Tools.php
@@ -61,4 +61,17 @@ final class Tools
     {
         \file_put_contents(PROJECT_ROOT . '/build/dump.txt', $text);
     }
+
+    public static function getRule(?string $columnName, ?string $ruleName, array|bool|float|int|string $options): array
+    {
+        return ['columns' => [['name' => $columnName, 'rules' => [$ruleName => $options]]]];
+    }
+
+    public static function getAggregateRule(
+        ?string $columnName,
+        ?string $ruleName,
+        array|bool|float|int|string $options,
+    ): array {
+        return ['columns' => [['name' => $columnName, 'aggregate_rules' => [$ruleName => $options]]]];
+    }
 }

--- a/tests/Tools.php
+++ b/tests/Tools.php
@@ -36,7 +36,11 @@ final class Tools
     public const SCHEMA_SIMPLE_HEADER_JSON = './tests/schemas/simple_header.json';
     public const SCHEMA_EXAMPLE_EMPTY      = './tests/schemas/example_empty.yml';
 
-    public const SCHEMA_EXAMPLE_FULL = './schema-examples/full.yml';
+    public const SCHEMA_FULL      = './schema-examples/full.yml';
+    public const SCHEMA_FULL_JSON = './schema-examples/full.json';
+    public const SCHEMA_FULL_PHP  = './schema-examples/full.php';
+
+    public const README = './README.md';
 
     public static function virtualExecution(string $action, array $params = []): array
     {

--- a/tests/Tools.php
+++ b/tests/Tools.php
@@ -25,6 +25,19 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 final class Tools
 {
+    public const CSV_SIMPLE_HEADER    = './tests/fixtures/simple_header.csv';
+    public const CSV_SIMPLE_NO_HEADER = './tests/fixtures/simple_no_header.csv';
+    public const CSV_COMPLEX          = './tests/fixtures/complex_header.csv';
+    public const CSV_DEMO             = './tests/fixtures/demo.csv';
+
+    public const SCHEMA_SIMPLE_HEADER      = './tests/schemas/simple_header.yml';
+    public const SCHEMA_SIMPLE_NO_HEADER   = './tests/schemas/simple_no_header.yml';
+    public const SCHEMA_SIMPLE_HEADER_PHP  = './tests/schemas/simple_header.php';
+    public const SCHEMA_SIMPLE_HEADER_JSON = './tests/schemas/simple_header.json';
+    public const SCHEMA_EXAMPLE_EMPTY      = './tests/schemas/example_empty.yml';
+
+    public const SCHEMA_EXAMPLE_FULL = './schema-examples/full.yml';
+
     public static function virtualExecution(string $action, array $params = []): array
     {
         $params['no-ansi'] = null;

--- a/tests/Validators/CsvValidatorTest.php
+++ b/tests/Validators/CsvValidatorTest.php
@@ -24,50 +24,34 @@ use function JBZoo\PHPUnit\isSame;
 
 final class CsvValidatorTest extends TestCase
 {
-    private const CSV_SIMPLE_HEADER    = './tests/fixtures/simple_header.csv';
-    private const CSV_SIMPLE_NO_HEADER = './tests/fixtures/simple_no_header.csv';
-    private const CSV_COMPLEX          = './tests/fixtures/complex_header.csv';
-    private const CSV_DEMO             = './tests/fixtures/demo.csv';
-
-    private const SCHEMA_SIMPLE_HEADER    = './tests/schemas/simple_header.yml';
-    private const SCHEMA_SIMPLE_NO_HEADER = './tests/schemas/simple_no_header.yml';
-
-    private const SCHEMA_SIMPLE_HEADER_PHP  = './tests/schemas/simple_header.php';
-    private const SCHEMA_SIMPLE_HEADER_JSON = './tests/schemas/simple_header.json';
-
-    protected function setUp(): void
-    {
-        \date_default_timezone_set('UTC');
-    }
-
     public function testUndefinedRule(): void
     {
         $this->expectExceptionMessage('Rule "undefined_rule" not found.');
-        $csv = new CsvFile(self::CSV_COMPLEX, Tools::getRule('seq', 'undefined_rule', true));
+        $csv = new CsvFile(Tools::CSV_COMPLEX, Tools::getRule('seq', 'undefined_rule', true));
         $csv->validate();
     }
 
     public function testValidWithHeader(): void
     {
-        $csv = new CsvFile(self::CSV_SIMPLE_HEADER, self::SCHEMA_SIMPLE_HEADER);
+        $csv = new CsvFile(Tools::CSV_SIMPLE_HEADER, Tools::SCHEMA_SIMPLE_HEADER);
         isSame('', \strip_tags((string)$csv->validate()));
     }
 
     public function testValidWithoutHeader(): void
     {
-        $csv = new CsvFile(self::CSV_SIMPLE_NO_HEADER, self::SCHEMA_SIMPLE_NO_HEADER);
+        $csv = new CsvFile(Tools::CSV_SIMPLE_NO_HEADER, Tools::SCHEMA_SIMPLE_NO_HEADER);
         isSame('', \strip_tags((string)$csv->validate()));
     }
 
     public function testInvalidSchemaFile(): void
     {
         $this->expectExceptionMessage('Invalid schema data: undefined_file_name.yml');
-        $csv = new CsvFile(self::CSV_SIMPLE_HEADER, 'undefined_file_name.yml');
+        $csv = new CsvFile(Tools::CSV_SIMPLE_HEADER, 'undefined_file_name.yml');
     }
 
     public function testSchemaAsPhpFile(): void
     {
-        $csv = new CsvFile(self::CSV_SIMPLE_HEADER, self::SCHEMA_SIMPLE_HEADER_PHP);
+        $csv = new CsvFile(Tools::CSV_SIMPLE_HEADER, Tools::SCHEMA_SIMPLE_HEADER_PHP);
         isSame(
             '"num_min" at line 2, column "0:seq". ' .
             'The number of the value "1", which is less than the expected "2".' . "\n",
@@ -77,7 +61,7 @@ final class CsvValidatorTest extends TestCase
 
     public function testSchemaAsJsonFile(): void
     {
-        $csv = new CsvFile(self::CSV_SIMPLE_HEADER, self::SCHEMA_SIMPLE_HEADER_JSON);
+        $csv = new CsvFile(Tools::CSV_SIMPLE_HEADER, Tools::SCHEMA_SIMPLE_HEADER_JSON);
         isSame(
             '"num_min" at line 2, column "0:seq". ' .
             'The number of the value "1", which is less than the expected "2".' . "\n",
@@ -87,10 +71,10 @@ final class CsvValidatorTest extends TestCase
 
     public function testCellRule(): void
     {
-        $csv = new CsvFile(self::CSV_COMPLEX, Tools::getRule('seq', 'not_empty', true));
+        $csv = new CsvFile(Tools::CSV_COMPLEX, Tools::getRule('seq', 'not_empty', true));
         isSame('', \strip_tags((string)$csv->validate()));
 
-        $csv = new CsvFile(self::CSV_COMPLEX, Tools::getRule('integer', 'not_empty', true));
+        $csv = new CsvFile(Tools::CSV_COMPLEX, Tools::getRule('integer', 'not_empty', true));
         isSame(
             '"not_empty" at line 19, column "0:integer". Value is empty.' . "\n",
             \strip_tags((string)$csv->validate()),
@@ -99,22 +83,22 @@ final class CsvValidatorTest extends TestCase
 
     public function testAggregateRule(): void
     {
-        $csv = new CsvFile(self::CSV_DEMO, Tools::getAggregateRule('Name', 'is_unique', true));
+        $csv = new CsvFile(Tools::CSV_DEMO, Tools::getAggregateRule('Name', 'is_unique', true));
         isSame('', \strip_tags((string)$csv->validate()));
 
-        $csv = new CsvFile(self::CSV_DEMO, Tools::getAggregateRule('City', 'is_unique', true));
+        $csv = new CsvFile(Tools::CSV_DEMO, Tools::getAggregateRule('City', 'is_unique', true));
         isSame(
             '"ag:is_unique" at line 1, column "0:City". Column has non-unique values. Unique: 9, total: 10.' . "\n",
             \strip_tags((string)$csv->validate()),
         );
 
-        $csv = new CsvFile(self::CSV_DEMO, Tools::getAggregateRule('City', 'is_unique', false));
+        $csv = new CsvFile(Tools::CSV_DEMO, Tools::getAggregateRule('City', 'is_unique', false));
         isSame('', \strip_tags((string)$csv->validate()));
     }
 
     public function testCellRuleNoName(): void
     {
-        $csv = new CsvFile(self::CSV_COMPLEX, Tools::getRule(null, 'not_empty', true));
+        $csv = new CsvFile(Tools::CSV_COMPLEX, Tools::getRule(null, 'not_empty', true));
         isSame(
             '"csv.header" at line 1, column "0:". ' .
             'Property "name" is not defined in schema: "_custom_array_".' . "\n",
@@ -124,19 +108,19 @@ final class CsvValidatorTest extends TestCase
 
     public function testQuickStop(): void
     {
-        $csv = new CsvFile(self::CSV_COMPLEX, Tools::getRule('yn', 'is_email', true));
+        $csv = new CsvFile(Tools::CSV_COMPLEX, Tools::getRule('yn', 'is_email', true));
         isSame(1, $csv->validate(true)->count());
 
-        $csv = new CsvFile(self::CSV_COMPLEX, Tools::getRule('yn', 'is_email', true));
+        $csv = new CsvFile(Tools::CSV_COMPLEX, Tools::getRule('yn', 'is_email', true));
         isSame(100, $csv->validate(false)->count());
 
-        $csv = new CsvFile(self::CSV_COMPLEX, Tools::getRule('yn', 'is_email', true));
+        $csv = new CsvFile(Tools::CSV_COMPLEX, Tools::getRule('yn', 'is_email', true));
         isSame(100, $csv->validate()->count());
     }
 
     public function testErrorToArray(): void
     {
-        $csv = new CsvFile(self::CSV_COMPLEX, Tools::getRule('yn', 'is_email', true));
+        $csv = new CsvFile(Tools::CSV_COMPLEX, Tools::getRule('yn', 'is_email', true));
         isSame([
             'ruleCode'   => 'is_email',
             'message'    => 'Value "<c>N</c>" is not a valid email',
@@ -147,20 +131,20 @@ final class CsvValidatorTest extends TestCase
 
     public function testFilenamePattern(): void
     {
-        $csv = new CsvFile(self::CSV_COMPLEX, ['filename_pattern' => '/demo(-\\d+)?\\.csv$/']);
+        $csv = new CsvFile(Tools::CSV_COMPLEX, ['filename_pattern' => '/demo(-\\d+)?\\.csv$/']);
         isSame(
             '"filename_pattern" at line 1, column "". ' .
             'Filename "./tests/fixtures/complex_header.csv" does not match pattern: "/demo(-\d+)?\.csv$/".',
             \strip_tags((string)$csv->validate()->get(0)),
         );
 
-        $csv = new CsvFile(self::CSV_COMPLEX, ['filename_pattern' => '']);
+        $csv = new CsvFile(Tools::CSV_COMPLEX, ['filename_pattern' => '']);
         isSame('', (string)$csv->validate());
 
-        $csv = new CsvFile(self::CSV_COMPLEX, ['filename_pattern' => null]);
+        $csv = new CsvFile(Tools::CSV_COMPLEX, ['filename_pattern' => null]);
         isSame('', (string)$csv->validate());
 
-        $csv = new CsvFile(self::CSV_COMPLEX, ['filename_pattern' => '/.*\.csv$/']);
+        $csv = new CsvFile(Tools::CSV_COMPLEX, ['filename_pattern' => '/.*\.csv$/']);
         isSame('', (string)$csv->validate());
     }
 }

--- a/tests/Validators/CsvValidatorTest.php
+++ b/tests/Validators/CsvValidatorTest.php
@@ -1,0 +1,166 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Validators;
+
+use JBZoo\CsvBlueprint\Csv\CsvFile;
+use JBZoo\PHPUnit\TestCase;
+use JBZoo\PHPUnit\Tools;
+
+use function JBZoo\PHPUnit\isSame;
+
+final class CsvValidatorTest extends TestCase
+{
+    private const CSV_SIMPLE_HEADER    = './tests/fixtures/simple_header.csv';
+    private const CSV_SIMPLE_NO_HEADER = './tests/fixtures/simple_no_header.csv';
+    private const CSV_COMPLEX          = './tests/fixtures/complex_header.csv';
+    private const CSV_DEMO             = './tests/fixtures/demo.csv';
+
+    private const SCHEMA_SIMPLE_HEADER    = './tests/schemas/simple_header.yml';
+    private const SCHEMA_SIMPLE_NO_HEADER = './tests/schemas/simple_no_header.yml';
+
+    private const SCHEMA_SIMPLE_HEADER_PHP  = './tests/schemas/simple_header.php';
+    private const SCHEMA_SIMPLE_HEADER_JSON = './tests/schemas/simple_header.json';
+
+    protected function setUp(): void
+    {
+        \date_default_timezone_set('UTC');
+    }
+
+    public function testUndefinedRule(): void
+    {
+        $this->expectExceptionMessage('Rule "undefined_rule" not found.');
+        $csv = new CsvFile(self::CSV_COMPLEX, Tools::getRule('seq', 'undefined_rule', true));
+        $csv->validate();
+    }
+
+    public function testValidWithHeader(): void
+    {
+        $csv = new CsvFile(self::CSV_SIMPLE_HEADER, self::SCHEMA_SIMPLE_HEADER);
+        isSame('', \strip_tags((string)$csv->validate()));
+    }
+
+    public function testValidWithoutHeader(): void
+    {
+        $csv = new CsvFile(self::CSV_SIMPLE_NO_HEADER, self::SCHEMA_SIMPLE_NO_HEADER);
+        isSame('', \strip_tags((string)$csv->validate()));
+    }
+
+    public function testInvalidSchemaFile(): void
+    {
+        $this->expectExceptionMessage('Invalid schema data: undefined_file_name.yml');
+        $csv = new CsvFile(self::CSV_SIMPLE_HEADER, 'undefined_file_name.yml');
+    }
+
+    public function testSchemaAsPhpFile(): void
+    {
+        $csv = new CsvFile(self::CSV_SIMPLE_HEADER, self::SCHEMA_SIMPLE_HEADER_PHP);
+        isSame(
+            '"num_min" at line 2, column "0:seq". ' .
+            'The number of the value "1", which is less than the expected "2".' . "\n",
+            \strip_tags((string)$csv->validate()),
+        );
+    }
+
+    public function testSchemaAsJsonFile(): void
+    {
+        $csv = new CsvFile(self::CSV_SIMPLE_HEADER, self::SCHEMA_SIMPLE_HEADER_JSON);
+        isSame(
+            '"num_min" at line 2, column "0:seq". ' .
+            'The number of the value "1", which is less than the expected "2".' . "\n",
+            \strip_tags((string)$csv->validate()),
+        );
+    }
+
+    public function testCellRule(): void
+    {
+        $csv = new CsvFile(self::CSV_COMPLEX, Tools::getRule('seq', 'not_empty', true));
+        isSame('', \strip_tags((string)$csv->validate()));
+
+        $csv = new CsvFile(self::CSV_COMPLEX, Tools::getRule('integer', 'not_empty', true));
+        isSame(
+            '"not_empty" at line 19, column "0:integer". Value is empty.' . "\n",
+            \strip_tags((string)$csv->validate()),
+        );
+    }
+
+    public function testAggregateRule(): void
+    {
+        $csv = new CsvFile(self::CSV_DEMO, Tools::getAggregateRule('Name', 'is_unique', true));
+        isSame('', \strip_tags((string)$csv->validate()));
+
+        $csv = new CsvFile(self::CSV_DEMO, Tools::getAggregateRule('City', 'is_unique', true));
+        isSame(
+            '"ag:is_unique" at line 1, column "0:City". Column has non-unique values. Unique: 9, total: 10.' . "\n",
+            \strip_tags((string)$csv->validate()),
+        );
+
+        $csv = new CsvFile(self::CSV_DEMO, Tools::getAggregateRule('City', 'is_unique', false));
+        isSame('', \strip_tags((string)$csv->validate()));
+    }
+
+    public function testCellRuleNoName(): void
+    {
+        $csv = new CsvFile(self::CSV_COMPLEX, Tools::getRule(null, 'not_empty', true));
+        isSame(
+            '"csv.header" at line 1, column "0:". ' .
+            'Property "name" is not defined in schema: "_custom_array_".' . "\n",
+            \strip_tags((string)$csv->validate()),
+        );
+    }
+
+    public function testQuickStop(): void
+    {
+        $csv = new CsvFile(self::CSV_COMPLEX, Tools::getRule('yn', 'is_email', true));
+        isSame(1, $csv->validate(true)->count());
+
+        $csv = new CsvFile(self::CSV_COMPLEX, Tools::getRule('yn', 'is_email', true));
+        isSame(100, $csv->validate(false)->count());
+
+        $csv = new CsvFile(self::CSV_COMPLEX, Tools::getRule('yn', 'is_email', true));
+        isSame(100, $csv->validate()->count());
+    }
+
+    public function testErrorToArray(): void
+    {
+        $csv = new CsvFile(self::CSV_COMPLEX, Tools::getRule('yn', 'is_email', true));
+        isSame([
+            'ruleCode'   => 'is_email',
+            'message'    => 'Value "<c>N</c>" is not a valid email',
+            'columnName' => '0:yn',
+            'line'       => 2,
+        ], $csv->validate(true)->get(0)->toArray());
+    }
+
+    public function testFilenamePattern(): void
+    {
+        $csv = new CsvFile(self::CSV_COMPLEX, ['filename_pattern' => '/demo(-\\d+)?\\.csv$/']);
+        isSame(
+            '"filename_pattern" at line 1, column "". ' .
+            'Filename "./tests/fixtures/complex_header.csv" does not match pattern: "/demo(-\d+)?\.csv$/".',
+            \strip_tags((string)$csv->validate()->get(0)),
+        );
+
+        $csv = new CsvFile(self::CSV_COMPLEX, ['filename_pattern' => '']);
+        isSame('', (string)$csv->validate());
+
+        $csv = new CsvFile(self::CSV_COMPLEX, ['filename_pattern' => null]);
+        isSame('', (string)$csv->validate());
+
+        $csv = new CsvFile(self::CSV_COMPLEX, ['filename_pattern' => '/.*\.csv$/']);
+        isSame('', (string)$csv->validate());
+    }
+}

--- a/tests/Validators/ErrorSuiteTest.php
+++ b/tests/Validators/ErrorSuiteTest.php
@@ -26,12 +26,9 @@ use function JBZoo\PHPUnit\isSame;
 
 final class ErrorSuiteTest extends TestCase
 {
-    private const CSV_SIMPLE_HEADER = './tests/fixtures/simple_header.csv';
-    private const CSV_DEMO          = './tests/fixtures/demo.csv';
-
     public function testRenderText(): void
     {
-        $csv = new CsvFile(self::CSV_SIMPLE_HEADER, Tools::getRule('seq', 'num_min', 3));
+        $csv = new CsvFile(Tools::CSV_SIMPLE_HEADER, Tools::getRule('seq', 'num_min', 3));
         isSame(
             '"num_min" at line 2, column "0:seq". ' .
             'The number of the value "1", which is less than the expected "3".' . "\n",
@@ -50,7 +47,7 @@ final class ErrorSuiteTest extends TestCase
 
     public function testRenderTable(): void
     {
-        $csv = new CsvFile(self::CSV_SIMPLE_HEADER, Tools::getRule('seq', 'num_min', 3));
+        $csv = new CsvFile(Tools::CSV_SIMPLE_HEADER, Tools::getRule('seq', 'num_min', 3));
         isSame(
             <<<'TABLE'
                 +------+-----------+---------+--------- simple_header.csv --------------------------------------+
@@ -79,9 +76,9 @@ final class ErrorSuiteTest extends TestCase
 
     public function testRenderTeamCity(): void
     {
-        $csv  = new CsvFile(self::CSV_SIMPLE_HEADER, Tools::getRule('seq', 'num_min', 3));
+        $csv  = new CsvFile(Tools::CSV_SIMPLE_HEADER, Tools::getRule('seq', 'num_min', 3));
         $out  = $csv->validate()->render(ErrorSuite::REPORT_TEAMCITY);
-        $path = self::CSV_SIMPLE_HEADER;
+        $path = Tools::CSV_SIMPLE_HEADER;
 
         $expected = <<<'TEAMCITY'
 
@@ -106,7 +103,7 @@ final class ErrorSuiteTest extends TestCase
 
     public function testRenderGithub(): void
     {
-        $path = self::CSV_SIMPLE_HEADER;
+        $path = Tools::CSV_SIMPLE_HEADER;
         $csv  = new CsvFile($path, Tools::getRule('seq', 'num_min', 3));
         isSame(
             <<<'GITHUB'
@@ -118,7 +115,7 @@ final class ErrorSuiteTest extends TestCase
             $csv->validate()->render(ErrorSuite::REPORT_GITHUB),
         );
 
-        $path = self::CSV_DEMO;
+        $path = Tools::CSV_DEMO;
         $csv  = new CsvFile($path, Tools::getAggregateRule('City', 'is_unique', true));
         isSame(
             \implode("\n", [
@@ -132,8 +129,8 @@ final class ErrorSuiteTest extends TestCase
 
     public function testRenderGitlab(): void
     {
-        $csv  = new CsvFile(self::CSV_SIMPLE_HEADER, Tools::getRule('seq', 'num_min', 3));
-        $path = self::CSV_SIMPLE_HEADER;
+        $csv  = new CsvFile(Tools::CSV_SIMPLE_HEADER, Tools::getRule('seq', 'num_min', 3));
+        $path = Tools::CSV_SIMPLE_HEADER;
 
         $cleanJson = json($csv->validate()->render(ErrorSuite::REPORT_GITLAB))->getArrayCopy();
         unset($cleanJson[0]['fingerprint'], $cleanJson[1]['fingerprint']);
@@ -159,8 +156,8 @@ final class ErrorSuiteTest extends TestCase
 
     public function testRenderJUnit(): void
     {
-        $csv  = new CsvFile(self::CSV_SIMPLE_HEADER, Tools::getRule('seq', 'num_min', 3));
-        $path = self::CSV_SIMPLE_HEADER;
+        $csv  = new CsvFile(Tools::CSV_SIMPLE_HEADER, Tools::getRule('seq', 'num_min', 3));
+        $path = Tools::CSV_SIMPLE_HEADER;
         isSame(
             <<<'JUNIT'
                 <?xml version="1.0" encoding="UTF-8"?>

--- a/tests/schemas/example_full.yml
+++ b/tests/schemas/example_full.yml
@@ -34,7 +34,46 @@ csv: # How to parse file before validation
 columns:
   - name: General available options # Can be optional if csv\header: false. If set, then header must contain this value
     required: true                  # If true, then column must be present in the file
+    rules:
+      is_ip6: true
+      dateperiod_: true
+      dateinterval_: true
+      bic: true
+      iban: true
+      card_number: true
+      country_code: true
+      currency_code: true
+      is_positive: true
+      is_negative: true
+      is_zero: true
+      is_even: true
+      is_odd: true
+      is_prime: true
+      is_time: true
+      is_timezone: true
+      is_timezone_offset: true
     aggregate_rules:
+      sum_: true
+      avg_: true
+      median_: true
+      mode_: true
+      range_: true
+      variance_: true
+      stddev_: true
+      percentile_: true
+      quantile_: true
+      count_: true
+      count_distinct_: true
+      count_empty_: true
+      count_not_empty_: true
+      count_null_: true
+      count_not_null_: true
+      count_zero_: true
+      count_positive_: true
+      count_negative_: true
+      count_even_: true
+      count_odd_: true
+      count_prime_: true
       sorted: asc                   # asc, desc, none
       sorted_flag: SORT_NATURAL     # See sort flags: https://www.php.net/manual/en/function.sort.php
       count_min: 1


### PR DESCRIPTION
The commit renames and restructures test files, shifting them from the `Blueprint` namespace to more specific and relevant namespaces. This includes updating of `use` statements and class extensions accordingly. It also relocates certain utility functions to a central `Tools` class for shared use.