### PR TITLE
Update numeric values and precision in schemas and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,12 +164,12 @@ columns:
       ends_with: " suffix"              # Example: "Hello World suffix".
 
       # Under the hood it convertes and compares as float values.
-      # Comparison accuracy is 12 digits after a dot.
+      # Comparison accuracy is 10 digits after a dot.
       # Scientific number format is also supported. Example: "1.2e3".
-      num: 5
-      num_not: 4
-      num_min: 1
-      num_max: 10
+      num: 5.1
+      num_not: 4.2
+      num_min: 1.3
+      num_max: 10.4
       is_int: true                      # Check format only. Can be negative and positive. Without any separators.
       is_float: true                    # Check format only. Can be negative and positive. Dot as decimal separator.
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ It's also covered by tests, so it's always up-to-date.
 * You are always free to add your option anywhere (except the `rules` list) and it will be ignored. I find it convenient for additional integrations and customization.
 
 
+<!-- full.yml -->
 ```yml
 # It's a full example of the CSV schema file in YAML format.
 
@@ -166,10 +167,10 @@ columns:
       # Under the hood it convertes and compares as float values.
       # Comparison accuracy is 10 digits after a dot.
       # Scientific number format is also supported. Example: "1.2e3".
-      num: 5.1
-      num_not: 4.2
-      num_min: 1.3
-      num_max: 10.4
+      num: 5                            # You can use integers.
+      num_not: 4.123                    # Float numbers.
+      num_min: 1.2e3                    # And even scientific format.
+      num_max: -10.123                  # Negative and positive, zero is also supported.
       is_int: true                      # Check format only. Can be negative and positive. Without any separators.
       is_float: true                    # Check format only. Can be negative and positive. Dot as decimal separator.
 
@@ -218,16 +219,16 @@ columns:
       is_unique: true                   # All values in the column are unique.
 
       # Sum of the numbers in the column. Example: [1, 2, 3] => 6.
-      sum: 5
-      sum_not: 4
-      sum_min: 1
-      sum_max: 10
+      sum: 5.123
+      sum_not: 4.123
+      sum_min: 1.123
+      sum_max: 10.123
 
       # Regular the arithmetic mean. The sum of the numbers divided by the count.
-      average: 5
-      average_not: 4
-      average_min: 1
-      average_max: 10
+      average: 5.123
+      average_not: 4.123
+      average_min: 1.123
+      average_max: 10.123
 
   - name: "another_column"
 
@@ -236,7 +237,7 @@ columns:
   - description: "Column with description only. Undefined header name."
 
 ```
-
+<!-- /full.yml -->
 
 ## Usage
 

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -39,10 +39,10 @@
                 "starts_with"           : "prefix ",
                 "ends_with"             : " suffix",
 
-                "num"                   : 5,
-                "num_not"               : 4,
-                "num_min"               : 1,
-                "num_max"               : 10,
+                "num"                   : 5.1,
+                "num_not"               : 4.2,
+                "num_min"               : 1.3,
+                "num_max"               : 10.4,
                 "is_int"                : true,
                 "is_float"              : true,
 

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -39,10 +39,10 @@
                 "starts_with"           : "prefix ",
                 "ends_with"             : " suffix",
 
-                "num"                   : 5.1,
-                "num_not"               : 4.2,
-                "num_min"               : 1.3,
-                "num_max"               : 10.4,
+                "num"                   : 5,
+                "num_not"               : 4.123,
+                "num_min"               : 1200,
+                "num_max"               : -10.123,
                 "is_int"                : true,
                 "is_float"              : true,
 
@@ -76,15 +76,15 @@
             "aggregate_rules" : {
                 "is_unique"   : true,
 
-                "sum"         : 5,
-                "sum_not"     : 4,
-                "sum_min"     : 1,
-                "sum_max"     : 10,
+                "sum"         : 5.123,
+                "sum_not"     : 4.123,
+                "sum_min"     : 1.123,
+                "sum_max"     : 10.123,
 
-                "average"     : 5,
-                "average_not" : 4,
-                "average_min" : 1,
-                "average_max" : 10
+                "average"     : 5.123,
+                "average_not" : 4.123,
+                "average_min" : 1.123,
+                "average_max" : 10.123
             }
         },
 

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -55,10 +55,10 @@ return [
                 'starts_with'  => 'prefix ',
                 'ends_with'    => ' suffix',
 
-                'num'      => 5,
-                'num_not'  => 4,
-                'num_min'  => 1,
-                'num_max'  => 10,
+                'num'      => 5.1,
+                'num_not'  => 4.2,
+                'num_min'  => 1.3,
+                'num_max'  => 10.4,
                 'is_int'   => true,
                 'is_float' => true,
 

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -55,10 +55,10 @@ return [
                 'starts_with'  => 'prefix ',
                 'ends_with'    => ' suffix',
 
-                'num'      => 5.1,
-                'num_not'  => 4.2,
-                'num_min'  => 1.3,
-                'num_max'  => 10.4,
+                'num'      => 5,
+                'num_not'  => 4.123,
+                'num_min'  => 1.2e3,
+                'num_max'  => -10.123,
                 'is_int'   => true,
                 'is_float' => true,
 
@@ -92,15 +92,15 @@ return [
             'aggregate_rules' => [
                 'is_unique' => true,
 
-                'sum'     => 5,
-                'sum_not' => 4,
-                'sum_min' => 1,
-                'sum_max' => 10,
+                'sum'     => 5.123,
+                'sum_not' => 4.123,
+                'sum_min' => 1.123,
+                'sum_max' => 10.123,
 
-                'average'     => 5,
-                'average_not' => 4,
-                'average_min' => 1,
-                'average_max' => 10,
+                'average'     => 5.123,
+                'average_not' => 4.123,
+                'average_min' => 1.123,
+                'average_max' => 10.123,
             ],
         ],
         ['name'        => 'another_column'],

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -91,10 +91,10 @@ columns:
       # Under the hood it convertes and compares as float values.
       # Comparison accuracy is 10 digits after a dot.
       # Scientific number format is also supported. Example: "1.2e3".
-      num: 5.1
-      num_not: 4.2
-      num_min: 1.3
-      num_max: 10.4
+      num: 5                            # You can use integers.
+      num_not: 4.123                    # Float numbers.
+      num_min: 1.2e3                    # And even scientific format.
+      num_max: -10.123                  # Negative and positive, zero is also supported.
       is_int: true                      # Check format only. Can be negative and positive. Without any separators.
       is_float: true                    # Check format only. Can be negative and positive. Dot as decimal separator.
 
@@ -143,16 +143,16 @@ columns:
       is_unique: true                   # All values in the column are unique.
 
       # Sum of the numbers in the column. Example: [1, 2, 3] => 6.
-      sum: 5
-      sum_not: 4
-      sum_min: 1
-      sum_max: 10
+      sum: 5.123
+      sum_not: 4.123
+      sum_min: 1.123
+      sum_max: 10.123
 
       # Regular the arithmetic mean. The sum of the numbers divided by the count.
-      average: 5
-      average_not: 4
-      average_min: 1
-      average_max: 10
+      average: 5.123
+      average_not: 4.123
+      average_min: 1.123
+      average_max: 10.123
 
   - name: "another_column"
 

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -89,12 +89,12 @@ columns:
       ends_with: " suffix"              # Example: "Hello World suffix".
 
       # Under the hood it convertes and compares as float values.
-      # Comparison accuracy is 12 digits after a dot.
+      # Comparison accuracy is 10 digits after a dot.
       # Scientific number format is also supported. Example: "1.2e3".
-      num: 5
-      num_not: 4
-      num_min: 1
-      num_max: 10
+      num: 5.1
+      num_not: 4.2
+      num_min: 1.3
+      num_max: 10.4
       is_int: true                      # Check format only. Can be negative and positive. Without any separators.
       is_float: true                    # Check format only. Can be negative and positive. Dot as decimal separator.
 

--- a/src/Rules/Aggregate/AbstarctAggregateRuleCombo.php
+++ b/src/Rules/Aggregate/AbstarctAggregateRuleCombo.php
@@ -20,6 +20,13 @@ use JBZoo\CsvBlueprint\Rules\AbstarctRuleCombo;
 
 abstract class AbstarctAggregateRuleCombo extends AbstarctRuleCombo
 {
+    protected const HELP_OPTIONS = [
+        self::EQ  => ['5.123', ''],
+        self::NOT => ['4.123', ''],
+        self::MIN => ['1.123', ''],
+        self::MAX => ['10.123', ''],
+    ];
+
     abstract protected function getActualAggregate(array $colValues): float;
 
     protected function getActual(array|string $value): float

--- a/src/Rules/Cell/ComboNum.php
+++ b/src/Rules/Cell/ComboNum.php
@@ -29,10 +29,10 @@ final class ComboNum extends AbstractCellRuleCombo
     ];
 
     protected const HELP_OPTIONS = [
-        self::EQ  => ['5.1', ''],
-        self::NOT => ['4.2', ''],
-        self::MIN => ['1.3', ''],
-        self::MAX => ['10.4', ''],
+        self::EQ  => ['5', 'You can use integers'],
+        self::NOT => ['4.123', 'Float numbers'],
+        self::MIN => ['1.2e3', 'And even scientific format'],
+        self::MAX => ['-10.123', 'Negative and positive, zero is also supported'],
     ];
 
     private const PRECISION = 10;

--- a/src/Rules/Cell/ComboNum.php
+++ b/src/Rules/Cell/ComboNum.php
@@ -28,7 +28,14 @@ final class ComboNum extends AbstractCellRuleCombo
         'Scientific number format is also supported. Example: "1.2e3"',
     ];
 
-    private const PRECISION = 12;
+    protected const HELP_OPTIONS = [
+        self::EQ  => ['5.1', ''],
+        self::NOT => ['4.2', ''],
+        self::MIN => ['1.3', ''],
+        self::MAX => ['10.4', ''],
+    ];
+
+    private const PRECISION = 10;
 
     protected function getExpected(): float
     {

--- a/tests/ExampleSchemasTest.php
+++ b/tests/ExampleSchemasTest.php
@@ -126,6 +126,33 @@ final class ExampleSchemasTest extends TestCase
         }
     }
 
+    public function testUpdateYmlExampleInReadme(): void
+    {
+        $filepath = \implode(
+            "\n",
+            \array_slice(\explode("\n", \file_get_contents(Tools::SCHEMA_FULL)), 12),
+        );
+
+        $replacement = \implode("\n", [
+            '<!-- full.yml -->',
+            '```yml',
+            $filepath,
+            '```',
+            '<!-- /full.yml -->',
+        ]);
+
+        $result = \preg_replace(
+            '/<\!-- full\.yml -->(.*?)<\!-- \/full\.yml -->/s',
+            $replacement,
+            \file_get_contents(Tools::README),
+        );
+
+        isTrue(\file_put_contents(Tools::README, $result) > 0);
+    }
+
+    /**
+     * @depends testUpdateYmlExampleInReadme
+     */
     public function testCheckYmlSchemaExampleInReadme(): void
     {
         $filepath = \implode(

--- a/tests/Rules/Cell/ComboNumTest.php
+++ b/tests/Rules/Cell/ComboNumTest.php
@@ -36,6 +36,9 @@ class ComboNumTest extends AbstractCellRuleCombo
             'The number of the value "12345", which is not equal than the expected "6"',
             $rule->test('12345'),
         );
+
+        $rule = $this->create(1.2e3, Combo::EQ);
+        isSame('', $rule->test('1.2e3'));
     }
 
     public function testMin(): void
@@ -91,7 +94,9 @@ class ComboNumTest extends AbstractCellRuleCombo
 
     public function testInvalidOption2(): void
     {
-        $this->expectExceptionMessage('Invalid option "1, 2, 3" for the "num_not" rule. It should be int/float/string.');
+        $this->expectExceptionMessage(
+            'Invalid option "1, 2, 3" for the "num_not" rule. It should be int/float/string.',
+        );
 
         $rule = $this->create([1, 2, 3], Combo::NOT);
         $rule->validate('true');


### PR DESCRIPTION
Numeric values in full.json, full.php and full.yml schemas have been modified to use decimal points, alongside changing the precision from 12 to 10 digits after the dot. These changes extend to the README and ComboNum.php, aligning the documentation and code with the updated schema constraints.