### PR TITLE
Add `count` aggregate rule. Update wording in error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,13 @@ columns:
       average_min: 1.123
       average_max: 10.123
 
+      # Total(!) count of rows in the CSV file.
+      # Since any values are taken into account, it only makes sense to use these rules once in any column.
+      count: 5
+      count_not: 4
+      count_min: 1
+      count_max: 10
+
   - name: "another_column"
 
   - name: "third_column"

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -84,7 +84,12 @@
                 "average"     : 5.123,
                 "average_not" : 4.123,
                 "average_min" : 1.123,
-                "average_max" : 10.123
+                "average_max" : 10.123,
+
+                "count"       : 5,
+                "count_not"   : 4,
+                "count_min"   : 1,
+                "count_max"   : 10
             }
         },
 

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -101,6 +101,11 @@ return [
                 'average_not' => 4.123,
                 'average_min' => 1.123,
                 'average_max' => 10.123,
+
+                'count'     => 5,
+                'count_not' => 4,
+                'count_min' => 1,
+                'count_max' => 10,
             ],
         ],
         ['name'        => 'another_column'],

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -154,6 +154,13 @@ columns:
       average_min: 1.123
       average_max: 10.123
 
+      # Total(!) count of rows in the CSV file.
+      # Since any values are taken into account, it only makes sense to use these rules once in any column.
+      count: 5
+      count_not: 4
+      count_min: 1
+      count_max: 10
+
   - name: "another_column"
 
   - name: "third_column"

--- a/src/Rules/Aggregate/AbstarctAggregateRuleCombo.php
+++ b/src/Rules/Aggregate/AbstarctAggregateRuleCombo.php
@@ -49,7 +49,7 @@ abstract class AbstarctAggregateRuleCombo extends AbstarctRuleCombo
         $verb   = static::VERBS[$mode];
         $name   = static::NAME;
 
-        $actual   = $this->getActual(\array_map('floatval', $colValues));
+        $actual   = $this->getActual($colValues);
         $expected = $this->getExpected();
 
         if (!self::compare($expected, $actual, $mode)) {
@@ -63,5 +63,10 @@ abstract class AbstarctAggregateRuleCombo extends AbstarctRuleCombo
     protected function getRuleCode(?string $mode = null): string
     {
         return 'ag:' . parent::getRuleCode($mode);
+    }
+
+    protected function convetrArrayToFloat(array $colValues): array
+    {
+        return \array_map('floatval', $colValues);
     }
 }

--- a/src/Rules/Aggregate/AbstarctAggregateRuleCombo.php
+++ b/src/Rules/Aggregate/AbstarctAggregateRuleCombo.php
@@ -65,7 +65,7 @@ abstract class AbstarctAggregateRuleCombo extends AbstarctRuleCombo
         return 'ag:' . parent::getRuleCode($mode);
     }
 
-    protected function convetrArrayToFloat(array $colValues): array
+    protected static function stringsToFloat(array $colValues): array
     {
         return \array_map('floatval', $colValues);
     }

--- a/src/Rules/Aggregate/AbstarctAggregateRuleCombo.php
+++ b/src/Rules/Aggregate/AbstarctAggregateRuleCombo.php
@@ -53,7 +53,7 @@ abstract class AbstarctAggregateRuleCombo extends AbstarctRuleCombo
         $expected = $this->getExpected();
 
         if (!self::compare($expected, $actual, $mode)) {
-            return "The {$name} of the column is \"<c>{$actual}</c>\", " .
+            return "The {$name} in the column is \"<c>{$actual}</c>\", " .
                 "which is {$verb} than the {$prefix}expected \"<green>{$expected}</green>\"";
         }
 

--- a/src/Rules/Aggregate/ComboAverage.php
+++ b/src/Rules/Aggregate/ComboAverage.php
@@ -27,7 +27,7 @@ final class ComboAverage extends AbstarctAggregateRuleCombo
     protected function getActualAggregate(array $colValues): float
     {
         try {
-            return Average::mean($this->convetrArrayToFloat($colValues));
+            return Average::mean(self::stringsToFloat($colValues));
         } catch (\Exception) {
             return 0;
         }

--- a/src/Rules/Aggregate/ComboAverage.php
+++ b/src/Rules/Aggregate/ComboAverage.php
@@ -27,7 +27,7 @@ final class ComboAverage extends AbstarctAggregateRuleCombo
     protected function getActualAggregate(array $colValues): float
     {
         try {
-            return Average::mean($colValues);
+            return Average::mean($this->convetrArrayToFloat($colValues));
         } catch (\Exception) {
             return 0;
         }

--- a/src/Rules/Aggregate/ComboCount.php
+++ b/src/Rules/Aggregate/ComboCount.php
@@ -16,14 +16,24 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-final class ComboSum extends AbstarctAggregateRuleCombo
+final class ComboCount extends AbstarctAggregateRuleCombo
 {
-    protected const NAME = 'sum';
+    protected const NAME = 'count of rows';
 
-    protected const HELP_TOP = ['Sum of the numbers in the column. Example: [1, 2, 3] => 6.'];
+    protected const HELP_TOP = [
+        'Total(!) count of rows in the CSV file.',
+        'Since any values are taken into account, it only makes sense to use these rules once in any column.',
+    ];
+
+    protected const HELP_OPTIONS = [
+        self::EQ  => ['5', ''],
+        self::NOT => ['4', ''],
+        self::MIN => ['1', ''],
+        self::MAX => ['10', ''],
+    ];
 
     protected function getActualAggregate(array $colValues): float
     {
-        return \array_sum($this->convetrArrayToFloat($colValues));
+        return \count($colValues);
     }
 }

--- a/src/Rules/Aggregate/ComboSum.php
+++ b/src/Rules/Aggregate/ComboSum.php
@@ -24,6 +24,6 @@ final class ComboSum extends AbstarctAggregateRuleCombo
 
     protected function getActualAggregate(array $colValues): float
     {
-        return \array_sum($this->convetrArrayToFloat($colValues));
+        return \array_sum(self::stringsToFloat($colValues));
     }
 }

--- a/src/Rules/Aggregate/ComboSum.php
+++ b/src/Rules/Aggregate/ComboSum.php
@@ -18,7 +18,7 @@ namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
 final class ComboSum extends AbstarctAggregateRuleCombo
 {
-    protected const NAME = 'sum';
+    protected const NAME = 'sum of numbers';
 
     protected const HELP_TOP = ['Sum of the numbers in the column. Example: [1, 2, 3] => 6.'];
 

--- a/tests/Rules/Aggregate/ComboAverageTest.php
+++ b/tests/Rules/Aggregate/ComboAverageTest.php
@@ -33,7 +33,7 @@ class ComboAverageTest extends AbstractAggregateRuleCombo
         isSame('', $rule->test(['1', '2', '3']));
 
         isSame(
-            'The average of the column is "2.625", which is not equal than the expected "2"',
+            'The average in the column is "2.625", which is not equal than the expected "2"',
             $rule->test(['1', '2', '3', '4.5']),
         );
     }
@@ -45,7 +45,7 @@ class ComboAverageTest extends AbstractAggregateRuleCombo
         isSame('', $rule->test(['1', '2', '3', '4.5']));
 
         isSame(
-            'The average of the column is "2", which is equal than the not expected "2"',
+            'The average in the column is "2", which is equal than the not expected "2"',
             $rule->test(['1', '2', '3']),
         );
     }
@@ -57,7 +57,7 @@ class ComboAverageTest extends AbstractAggregateRuleCombo
         isSame('', $rule->test(['1', '2', '3']));
 
         isSame(
-            'The average of the column is "1.5", which is less than the expected "1.999"',
+            'The average in the column is "1.5", which is less than the expected "1.999"',
             $rule->test(['1', '2']),
         );
     }
@@ -69,7 +69,7 @@ class ComboAverageTest extends AbstractAggregateRuleCombo
         isSame('', $rule->test(['1', '2', '3']));
 
         isSame(
-            'The average of the column is "2.625", which is greater than the expected "2"',
+            'The average in the column is "2.625", which is greater than the expected "2"',
             $rule->test(['1', '2', '3', '4.5']),
         );
     }

--- a/tests/Rules/Aggregate/ComboCountTest.php
+++ b/tests/Rules/Aggregate/ComboCountTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Rules\Aggregate;
+
+use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\Aggregate\ComboAverage;
+use JBZoo\CsvBlueprint\Rules\Aggregate\ComboCount;
+use JBZoo\PHPUnit\Rules\AbstractAggregateRuleCombo;
+
+use function JBZoo\PHPUnit\isSame;
+
+class ComboCountTest extends AbstractAggregateRuleCombo
+{
+    protected string $ruleClass = ComboCount::class;
+
+    public function testEqual(): void
+    {
+        $rule = $this->create(3, Combo::EQ);
+
+        isSame('', $rule->test(['1', '2', '3']));
+
+        isSame(
+            'The count of rows of the column is "4", which is not equal than the expected "3"',
+            $rule->test(['1', '2', '3', '4.5']),
+        );
+    }
+
+    public function testNotEqual(): void
+    {
+        $rule = $this->create(3, Combo::NOT);
+
+        isSame('', $rule->test(['1', '2', '3', '4.5']));
+
+        isSame(
+            'The count of rows of the column is "3", which is equal than the not expected "3"',
+            $rule->test(['1', '2', '3']),
+        );
+    }
+
+    public function testMin(): void
+    {
+        $rule = $this->create(3, Combo::MIN);
+
+        isSame('', $rule->test(['1', '2', '3']));
+
+        isSame(
+            'The count of rows of the column is "2", which is less than the expected "3"',
+            $rule->test(['1', '2']),
+        );
+    }
+
+    public function testMax(): void
+    {
+        $rule = $this->create(3, Combo::MAX);
+
+        isSame('', $rule->test(['1', '2', '3']));
+
+        isSame(
+            'The count of rows of the column is "4", which is greater than the expected "3"',
+            $rule->test(['1', '2', '3', '4.5']),
+        );
+    }
+
+    public function testInvalidOption(): void
+    {
+        $this->expectExceptionMessage(
+            'Invalid option "[1, 2]" for the "ag:count_max" rule. It should be integer/float.',
+        );
+        $rule = $this->create([1, 2], Combo::MAX);
+        $rule->validate(['1', '2', '3']);
+    }
+
+    public function testInvalidParsing(): void
+    {
+        $rule = $this->create(0, Combo::EQ);
+        isSame('', $rule->test([]));
+    }
+}

--- a/tests/Rules/Aggregate/ComboCountTest.php
+++ b/tests/Rules/Aggregate/ComboCountTest.php
@@ -33,7 +33,7 @@ class ComboCountTest extends AbstractAggregateRuleCombo
         isSame('', $rule->test(['1', '2', '3']));
 
         isSame(
-            'The count of rows of the column is "4", which is not equal than the expected "3"',
+            'The count of rows in the column is "4", which is not equal than the expected "3"',
             $rule->test(['1', '2', '3', '4.5']),
         );
     }
@@ -45,7 +45,7 @@ class ComboCountTest extends AbstractAggregateRuleCombo
         isSame('', $rule->test(['1', '2', '3', '4.5']));
 
         isSame(
-            'The count of rows of the column is "3", which is equal than the not expected "3"',
+            'The count of rows in the column is "3", which is equal than the not expected "3"',
             $rule->test(['1', '2', '3']),
         );
     }
@@ -57,7 +57,7 @@ class ComboCountTest extends AbstractAggregateRuleCombo
         isSame('', $rule->test(['1', '2', '3']));
 
         isSame(
-            'The count of rows of the column is "2", which is less than the expected "3"',
+            'The count of rows in the column is "2", which is less than the expected "3"',
             $rule->test(['1', '2']),
         );
     }
@@ -69,7 +69,7 @@ class ComboCountTest extends AbstractAggregateRuleCombo
         isSame('', $rule->test(['1', '2', '3']));
 
         isSame(
-            'The count of rows of the column is "4", which is greater than the expected "3"',
+            'The count of rows in the column is "4", which is greater than the expected "3"',
             $rule->test(['1', '2', '3', '4.5']),
         );
     }

--- a/tests/Rules/Aggregate/ComboCountTest.php
+++ b/tests/Rules/Aggregate/ComboCountTest.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
 use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
-use JBZoo\CsvBlueprint\Rules\Aggregate\ComboAverage;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboCount;
 use JBZoo\PHPUnit\Rules\AbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboSumTest.php
+++ b/tests/Rules/Aggregate/ComboSumTest.php
@@ -33,7 +33,7 @@ class ComboSumTest extends AbstractAggregateRuleCombo
         isSame('', $rule->test(['1', '2', '3']));
 
         isSame(
-            'The sum of the column is "10.5", which is not equal than the expected "6"',
+            'The sum of numbers in the column is "10.5", which is not equal than the expected "6"',
             $rule->test(['1', '2', '3', '4.5']),
         );
     }
@@ -45,7 +45,7 @@ class ComboSumTest extends AbstractAggregateRuleCombo
         isSame('', $rule->test(['1', '2', '3', '4.5']));
 
         isSame(
-            'The sum of the column is "6", which is equal than the not expected "6"',
+            'The sum of numbers in the column is "6", which is equal than the not expected "6"',
             $rule->test(['1', '2', '3']),
         );
     }
@@ -57,7 +57,7 @@ class ComboSumTest extends AbstractAggregateRuleCombo
         isSame('', $rule->test(['1', '2', '3']));
 
         isSame(
-            'The sum of the column is "3", which is less than the expected "6"',
+            'The sum of numbers in the column is "3", which is less than the expected "6"',
             $rule->test(['1', '2']),
         );
     }
@@ -69,7 +69,7 @@ class ComboSumTest extends AbstractAggregateRuleCombo
         isSame('', $rule->test(['1', '2', '3']));
 
         isSame(
-            'The sum of the column is "10.5", which is greater than the expected "6"',
+            'The sum of numbers in the column is "10.5", which is greater than the expected "6"',
             $rule->test(['1', '2', '3', '4.5']),
         );
     }

--- a/tests/Validators/CsvValidatorTest.php
+++ b/tests/Validators/CsvValidatorTest.php
@@ -103,9 +103,9 @@ final class CsvValidatorTest extends TestCase
 
         $csv = new CsvFile(Tools::DEMO_CSV, Tools::getAggregateRule('Float', 'sum', 20));
         isSame(
-            '"ag:sum" at line 1, column "0:Float". The sum of the column is "4691.3235", ' .
-            'which is not equal than the expected "20".' . "\n",
-            \strip_tags((string)$csv->validate()),
+            '"ag:sum" at line <red>1</red>, column "0:Float". The sum of numbers in the column is ' .
+            '"<c>4691.3235</c>", which is not equal than the expected "<green>20</green>".' . "\n",
+            (string)$csv->validate(),
         );
     }
 


### PR DESCRIPTION
Introduced a new aggregate rule, ComboCount in Csv-Blueprint. This counts the total number of rows in the CSV file. Also updated the existing 'average' aggregate rules to convert array values to float before calculation. The schema examples and README are updated to demonstrate the new 'count' aggregate rule. A new test case for the 'count' rule has also been added.