### PR TITLE
Add `count_empty` function and update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ columns:
       count_min: 1
       count_max: 10
 
+      # Counts only empty values (string length is 0).
+      count_empty: 5
+      count_empty_not: 4
+      count_empty_min: 1
+      count_empty_max: 10
+
   - name: "another_column"
 
   - name: "third_column"

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -74,22 +74,27 @@
             },
 
             "aggregate_rules" : {
-                "is_unique"   : true,
+                "is_unique"       : true,
 
-                "sum"         : 5.123,
-                "sum_not"     : 4.123,
-                "sum_min"     : 1.123,
-                "sum_max"     : 10.123,
+                "sum"             : 5.123,
+                "sum_not"         : 4.123,
+                "sum_min"         : 1.123,
+                "sum_max"         : 10.123,
 
-                "average"     : 5.123,
-                "average_not" : 4.123,
-                "average_min" : 1.123,
-                "average_max" : 10.123,
+                "average"         : 5.123,
+                "average_not"     : 4.123,
+                "average_min"     : 1.123,
+                "average_max"     : 10.123,
 
-                "count"       : 5,
-                "count_not"   : 4,
-                "count_min"   : 1,
-                "count_max"   : 10
+                "count"           : 5,
+                "count_not"       : 4,
+                "count_min"       : 1,
+                "count_max"       : 10,
+
+                "count_empty"     : 5,
+                "count_empty_not" : 4,
+                "count_empty_min" : 1,
+                "count_empty_max" : 10
             }
         },
 

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -106,6 +106,11 @@ return [
                 'count_not' => 4,
                 'count_min' => 1,
                 'count_max' => 10,
+
+                'count_empty'     => 5,
+                'count_empty_not' => 4,
+                'count_empty_min' => 1,
+                'count_empty_max' => 10,
             ],
         ],
         ['name'        => 'another_column'],

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -161,6 +161,12 @@ columns:
       count_min: 1
       count_max: 10
 
+      # Counts only empty values (string length is 0).
+      count_empty: 5
+      count_empty_not: 4
+      count_empty_min: 1
+      count_empty_max: 10
+
   - name: "another_column"
 
   - name: "third_column"

--- a/src/Rules/Aggregate/ComboCountEmpty.php
+++ b/src/Rules/Aggregate/ComboCountEmpty.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Rules\Aggregate;
+
+final class ComboCountEmpty extends AbstarctAggregateRuleCombo
+{
+    protected const NAME = 'number of empty rows';
+
+    protected const HELP_TOP = ['Counts only empty values (string length is 0).'];
+
+    protected const HELP_OPTIONS = [
+        self::EQ  => ['5', ''],
+        self::NOT => ['4', ''],
+        self::MIN => ['1', ''],
+        self::MAX => ['10', ''],
+    ];
+
+    protected function getActualAggregate(array $colValues): float
+    {
+        return \count(\array_filter($colValues, static fn ($colValue) => $colValue === ''));
+    }
+}

--- a/tests/Rules/Aggregate/ComboCountEmptyTest.php
+++ b/tests/Rules/Aggregate/ComboCountEmptyTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Rules\Aggregate;
+
+use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\Aggregate\ComboCountEmpty;
+use JBZoo\PHPUnit\Rules\AbstractAggregateRuleCombo;
+
+use function JBZoo\PHPUnit\isSame;
+
+class ComboCountEmptyTest extends AbstractAggregateRuleCombo
+{
+    protected string $ruleClass = ComboCountEmpty::class;
+
+    public function testEqual(): void
+    {
+        $rule = $this->create(3, Combo::EQ);
+
+        isSame('', $rule->test(['', '', '']));
+        isSame('', $rule->test(['', '', '', '1']));
+        isSame('', $rule->test(['', '', '', ' ', '1']));
+
+        isSame(
+            'The number of empty rows in the column is "2", which is not equal than the expected "3"',
+            $rule->test(['', '', ' ', '1']),
+        );
+    }
+
+    public function testNotEqual(): void
+    {
+        $rule = $this->create(3, Combo::NOT);
+
+        isSame('', $rule->test(['', '']));
+
+        isSame(
+            'The number of empty rows in the column is "3", which is equal than the not expected "3"',
+            $rule->test(['', '', '']),
+        );
+    }
+
+    public function testMin(): void
+    {
+        $rule = $this->create(3, Combo::MIN);
+
+        isSame('', $rule->test(['', '', '']));
+        isSame('', $rule->test(['', '', '', '1']));
+
+        isSame(
+            'The number of empty rows in the column is "2", which is less than the expected "3"',
+            $rule->test(['', '', ' ']),
+        );
+    }
+
+    public function testMax(): void
+    {
+        $rule = $this->create(3, Combo::MAX);
+
+        isSame('', $rule->test(['', '', '']));
+        isSame('', $rule->test(['', '']));
+        isSame('', $rule->test([]));
+
+        isSame(
+            'The number of empty rows in the column is "4", which is greater than the expected "3"',
+            $rule->test(['', '', '', '']),
+        );
+    }
+
+    public function testInvalidOption(): void
+    {
+        $this->expectExceptionMessage(
+            'Invalid option "[1, 2]" for the "ag:count_empty_max" rule. It should be integer/float.',
+        );
+        $rule = $this->create([1, 2], Combo::MAX);
+        $rule->validate(['1', '2', '3']);
+    }
+
+    public function testInvalidParsing(): void
+    {
+        $rule = $this->create(0, Combo::EQ);
+        isSame('', $rule->test([]));
+    }
+}


### PR DESCRIPTION
Introduced count_empty function to count empty values in CSV files. This new feature has been reflected in all example files including full.json, full.php, and full.yml. Additionally, created accompanying ComboCountEmpty class and test file to ensure accurate implementation and functioning of this feature.