### PR TITLE
Add 'count_not_empty' rules to aggregate functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,12 @@ columns:
       count_empty_min: 1
       count_empty_max: 10
 
+      # Counts only not empty values (string length is not 0).
+      count_not_empty: 5
+      count_not_empty_not: 4
+      count_not_empty_min: 1
+      count_not_empty_max: 10
+
   - name: "another_column"
 
   - name: "third_column"

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -74,27 +74,32 @@
             },
 
             "aggregate_rules" : {
-                "is_unique"       : true,
+                "is_unique"           : true,
 
-                "sum"             : 5.123,
-                "sum_not"         : 4.123,
-                "sum_min"         : 1.123,
-                "sum_max"         : 10.123,
+                "sum"                 : 5.123,
+                "sum_not"             : 4.123,
+                "sum_min"             : 1.123,
+                "sum_max"             : 10.123,
 
-                "average"         : 5.123,
-                "average_not"     : 4.123,
-                "average_min"     : 1.123,
-                "average_max"     : 10.123,
+                "average"             : 5.123,
+                "average_not"         : 4.123,
+                "average_min"         : 1.123,
+                "average_max"         : 10.123,
 
-                "count"           : 5,
-                "count_not"       : 4,
-                "count_min"       : 1,
-                "count_max"       : 10,
+                "count"               : 5,
+                "count_not"           : 4,
+                "count_min"           : 1,
+                "count_max"           : 10,
 
-                "count_empty"     : 5,
-                "count_empty_not" : 4,
-                "count_empty_min" : 1,
-                "count_empty_max" : 10
+                "count_empty"         : 5,
+                "count_empty_not"     : 4,
+                "count_empty_min"     : 1,
+                "count_empty_max"     : 10,
+
+                "count_not_empty"     : 5,
+                "count_not_empty_not" : 4,
+                "count_not_empty_min" : 1,
+                "count_not_empty_max" : 10
             }
         },
 

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -111,6 +111,11 @@ return [
                 'count_empty_not' => 4,
                 'count_empty_min' => 1,
                 'count_empty_max' => 10,
+
+                'count_not_empty'     => 5,
+                'count_not_empty_not' => 4,
+                'count_not_empty_min' => 1,
+                'count_not_empty_max' => 10,
             ],
         ],
         ['name'        => 'another_column'],

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -167,6 +167,12 @@ columns:
       count_empty_min: 1
       count_empty_max: 10
 
+      # Counts only not empty values (string length is not 0).
+      count_not_empty: 5
+      count_not_empty_not: 4
+      count_not_empty_min: 1
+      count_not_empty_max: 10
+
   - name: "another_column"
 
   - name: "third_column"

--- a/src/Rules/Aggregate/ComboCountNotEmpty.php
+++ b/src/Rules/Aggregate/ComboCountNotEmpty.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Rules\Aggregate;
+
+final class ComboCountNotEmpty extends AbstarctAggregateRuleCombo
+{
+    protected const NAME = 'number of not empty rows';
+
+    protected const HELP_TOP = ['Counts only not empty values (string length is not 0).'];
+
+    protected const HELP_OPTIONS = [
+        self::EQ  => ['5', ''],
+        self::NOT => ['4', ''],
+        self::MIN => ['1', ''],
+        self::MAX => ['10', ''],
+    ];
+
+    protected function getActualAggregate(array $colValues): float
+    {
+        return \count(\array_filter($colValues, static fn ($colValue) => $colValue !== ''));
+    }
+}

--- a/tests/ExampleSchemasTest.php
+++ b/tests/ExampleSchemasTest.php
@@ -90,12 +90,19 @@ final class ExampleSchemasTest extends TestCase
         isSame($defaultsInDoc, $schema->getCsvStructure()->getArrayCopy());
     }
 
-    public function testCompareExamplesWithOrig(): void
+    public function testCheckPhpExample(): void
     {
         $basepath = PROJECT_ROOT . '/schema-examples/full';
         $origYml  = yml(Tools::SCHEMA_FULL)->getArrayCopy();
 
         isSame((string)phpArray(Tools::SCHEMA_FULL_PHP), (string)phpArray($origYml), 'PHP config is invalid');
+    }
+
+    public function testCheckJsonExample(): void
+    {
+        $basepath = PROJECT_ROOT . '/schema-examples/full';
+        $origYml  = yml(Tools::SCHEMA_FULL)->getArrayCopy();
+
         isSame((string)json(Tools::SCHEMA_FULL_JSON), (string)json($origYml), 'JSON config is invalid');
     }
 

--- a/tests/Rules/Aggregate/ComboCountNotEmptyTest.php
+++ b/tests/Rules/Aggregate/ComboCountNotEmptyTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Rules\Aggregate;
+
+use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\Aggregate\ComboCountNotEmpty;
+use JBZoo\PHPUnit\Rules\AbstractAggregateRuleCombo;
+
+use function JBZoo\PHPUnit\isSame;
+
+class ComboCountNotEmptyTest extends AbstractAggregateRuleCombo
+{
+    protected string $ruleClass = ComboCountNotEmpty::class;
+
+    public function testEqual(): void
+    {
+        $rule = $this->create(1, Combo::EQ);
+
+        isSame('', $rule->test(['', '', ' ']));
+        isSame('', $rule->test(['', '', '', '1']));
+
+        isSame(
+            'The number of not empty rows in the column is "2", which is not equal than the expected "1"',
+            $rule->test(['', '', ' ', '1']),
+        );
+    }
+
+    public function testNotEqual(): void
+    {
+        $rule = $this->create(1, Combo::NOT);
+
+        isSame('', $rule->test(['', '']));
+
+        isSame(
+            'The number of not empty rows in the column is "1", which is equal than the not expected "1"',
+            $rule->test(['', '1']),
+        );
+    }
+
+    public function testMin(): void
+    {
+        $rule = $this->create(1, Combo::MIN);
+
+        isSame('', $rule->test(['', '', '', '1']));
+
+        isSame(
+            'The number of not empty rows in the column is "0", which is less than the expected "1"',
+            $rule->test(['']),
+        );
+    }
+
+    public function testMax(): void
+    {
+        $rule = $this->create(3, Combo::MAX);
+
+        isSame('', $rule->test(['', '', '']));
+        isSame('', $rule->test(['', '']));
+        isSame('', $rule->test([]));
+
+        isSame(
+            'The number of not empty rows in the column is "5", which is greater than the expected "3"',
+            $rule->test([1, 2, 3, 4, 5]),
+        );
+    }
+
+    public function testInvalidOption(): void
+    {
+        $this->expectExceptionMessage(
+            'Invalid option "[1, 2]" for the "ag:count_not_empty_max" rule. It should be integer/float.',
+        );
+        $rule = $this->create([1, 2], Combo::MAX);
+        $rule->validate(['1', '2', '3']);
+    }
+
+    public function testInvalidParsing(): void
+    {
+        $rule = $this->create(0, Combo::EQ);
+        isSame('', $rule->test([]));
+    }
+}


### PR DESCRIPTION
Expanded the aggregate functions by including 'count_not_empty' in the application schema to count only not empty values. This new functionality is accurately portrayed in the updated files full.json, full.php, and full.yml. To support this change, a new class 'ComboCountNotEmpty' is added in Csv-Blueprint along with its corresponding unit test.