### PR TITLE
Update handling of null aggregate values

### DIFF
--- a/src/Rules/Aggregate/ComboAverage.php
+++ b/src/Rules/Aggregate/ComboAverage.php
@@ -24,12 +24,8 @@ final class ComboAverage extends AbstarctAggregateRuleCombo
 
     protected const HELP_TOP = ['Regular the arithmetic mean. The sum of the numbers divided by the count.'];
 
-    protected function getActualAggregate(array $colValues): float
+    protected function getActualAggregate(array $colValues): ?float
     {
-        try {
-            return Average::mean(self::stringsToFloat($colValues));
-        } catch (\Exception) {
-            return 0;
-        }
+        return Average::mean(self::stringsToFloat($colValues));
     }
 }

--- a/src/Rules/Aggregate/ComboCount.php
+++ b/src/Rules/Aggregate/ComboCount.php
@@ -32,7 +32,7 @@ final class ComboCount extends AbstarctAggregateRuleCombo
         self::MAX => ['10', ''],
     ];
 
-    protected function getActualAggregate(array $colValues): float
+    protected function getActualAggregate(array $colValues): ?float
     {
         return \count($colValues);
     }

--- a/src/Rules/Aggregate/ComboCountEmpty.php
+++ b/src/Rules/Aggregate/ComboCountEmpty.php
@@ -29,7 +29,7 @@ final class ComboCountEmpty extends AbstarctAggregateRuleCombo
         self::MAX => ['10', ''],
     ];
 
-    protected function getActualAggregate(array $colValues): float
+    protected function getActualAggregate(array $colValues): ?float
     {
         return \count(\array_filter($colValues, static fn ($colValue) => $colValue === ''));
     }

--- a/src/Rules/Aggregate/ComboCountNotEmpty.php
+++ b/src/Rules/Aggregate/ComboCountNotEmpty.php
@@ -29,7 +29,7 @@ final class ComboCountNotEmpty extends AbstarctAggregateRuleCombo
         self::MAX => ['10', ''],
     ];
 
-    protected function getActualAggregate(array $colValues): float
+    protected function getActualAggregate(array $colValues): ?float
     {
         return \count(\array_filter($colValues, static fn ($colValue) => $colValue !== ''));
     }

--- a/src/Rules/Aggregate/ComboMedian.php
+++ b/src/Rules/Aggregate/ComboMedian.php
@@ -24,12 +24,8 @@ final class ComboMedian extends AbstarctAggregateRuleCombo
 
     protected const HELP_TOP = ['Calculate the median average of a list of numbers.'];
 
-    protected function getActualAggregate(array $colValues): float
+    protected function getActualAggregate(array $colValues): ?float
     {
-        try {
-            return Average::median(self::stringsToFloat($colValues));
-        } catch (\Exception) {
-            return 0;
-        }
+        return Average::median(self::stringsToFloat($colValues));
     }
 }

--- a/src/Rules/Aggregate/ComboSum.php
+++ b/src/Rules/Aggregate/ComboSum.php
@@ -22,7 +22,7 @@ final class ComboSum extends AbstarctAggregateRuleCombo
 
     protected const HELP_TOP = ['Sum of the numbers in the column. Example: [1, 2, 3] => 6.'];
 
-    protected function getActualAggregate(array $colValues): float
+    protected function getActualAggregate(array $colValues): ?float
     {
         return \array_sum(self::stringsToFloat($colValues));
     }


### PR DESCRIPTION
Updated methods to handle null values for aggregate calculations by changing the return type of the getActualAggregate function to '?float', so that it can now allow null values. This change provides more flexibility by not forcing a 0 value return when the aggregate calculation is not possible and aids in better error management and debugging.