### PR TITLE
Added `not_allow_values` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ columns:
       not_empty: true                   # Value is not an empty string. Actually checks if the string length is not 0.
       exact_value: Some string          # Exact value for string in the column.
       allow_values: [ y, n, "" ]        # Strict set of values that are allowed.
+      not_allow_values: [ invalid ]     # Strict set of values that are NOT allowed.
 
       # Any valid regex pattern. See https://www.php.net/manual/en/reference.pcre.pattern.syntax.php.
       # Of course it's an ultimatum to verify any sort of string data.
@@ -480,7 +481,7 @@ It's random ideas and plans. No orderings and deadlines. <u>But batch processing
 * Flag to ignore file name pattern. It's useful when you have a lot of files, and you don't want to validate the file name.
 
 **Validation**
-* More aggregate rules.
+* [More aggregate rules](https://github.com/markrogoyski/math-php#statistics---descriptive).
 * More cell rules.
 * `required` flag for the column.
 * Custom cell rule as a callback. It's useful when you have a complex rule that can't be described in the schema file.

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -16,6 +16,8 @@
                 "not_empty"             : true,
                 "exact_value"           : "Some string",
                 "allow_values"          : ["y", "n", ""],
+                "not_allow_values"      : ["invalid"],
+
                 "regex"                 : "\/^[\\d]{2}$\/",
 
                 "length"                : 5,

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -25,14 +25,16 @@ return [
         'bom'        => false,
     ],
     'columns' => [
-        0 => [
+        [
             'name'        => 'Column Name (header)',
             'description' => 'Lorem ipsum',
             'rules'       => [
-                'not_empty'    => true,
-                'exact_value'  => 'Some string',
-                'allow_values' => ['y', 'n', ''],
-                'regex'        => '/^[\\d]{2}$/',
+                'not_empty'        => true,
+                'exact_value'      => 'Some string',
+                'allow_values'     => ['y', 'n', ''],
+                'not_allow_values' => ['invalid'],
+
+                'regex' => '/^[\\d]{2}$/',
 
                 'length'     => 5,
                 'length_not' => 4,
@@ -123,8 +125,11 @@ return [
                 'median_max' => 10.123,
             ],
         ],
-        ['name'        => 'another_column'],
-        ['name'        => 'third_column'],
+
+        ['name' => 'another_column'],
+
+        ['name' => 'third_column'],
+
         ['description' => 'Column with description only. Undefined header name.'],
     ],
 ];

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -54,6 +54,7 @@ columns:
       not_empty: true                   # Value is not an empty string. Actually checks if the string length is not 0.
       exact_value: Some string          # Exact value for string in the column.
       allow_values: [ y, n, "" ]        # Strict set of values that are allowed.
+      not_allow_values: [ invalid ]     # Strict set of values that are NOT allowed.
 
       # Any valid regex pattern. See https://www.php.net/manual/en/reference.pcre.pattern.syntax.php.
       # Of course it's an ultimatum to verify any sort of string data.

--- a/src/Rules/Cell/NotAllowValues.php
+++ b/src/Rules/Cell/NotAllowValues.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Rules\Cell;
+
+class NotAllowValues extends AbstractCellRule
+{
+    protected const HELP_OPTIONS = [
+        self::DEFAULT => ['[ invalid ]', 'Strict set of values that are NOT allowed.'],
+    ];
+
+    public function validateRule(string $cellValue): ?string
+    {
+        $notAllowedValues = $this->getOptionAsArray();
+
+        if (\count($notAllowedValues) === 0) {
+            return 'Not allowed values are not defined';
+        }
+
+        if (\in_array($cellValue, $notAllowedValues, true)) {
+            return "Value \"<c>{$cellValue}</c>\" is not allowed";
+        }
+
+        return null;
+    }
+}

--- a/tests/Rules/Cell/NotAllowValuesTest.php
+++ b/tests/Rules/Cell/NotAllowValuesTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Rules\Cell;
+
+use JBZoo\CsvBlueprint\Rules\Cell\NotAllowValues;
+use JBZoo\PHPUnit\Rules\AbstractCellRule;
+
+use function JBZoo\PHPUnit\isSame;
+
+final class NotAllowValuesTest extends AbstractCellRule
+{
+    protected string $ruleClass = NotAllowValues::class;
+
+    public function testPositive(): void
+    {
+        $rule = $this->create(['1', '2', '3']);
+        isSame('', $rule->test(''));
+        isSame('', $rule->test(' '));
+        isSame('', $rule->test('4'));
+        isSame('', $rule->test('1qwerty'));
+
+        $rule = $this->create([' ']);
+        isSame('', $rule->test(''));
+    }
+
+    public function testNegative(): void
+    {
+        $rule = $this->create(['invalid', ' ']);
+
+        isSame(
+            'Value "invalid" is not allowed',
+            $rule->test('invalid'),
+        );
+
+        isSame(
+            'Value " " is not allowed',
+            $rule->test(' '),
+        );
+    }
+
+    public function testInvalidOption(): void
+    {
+        $this->expectExceptionMessage(
+            'Invalid option "qwe" for the "not_allow_values" rule. It should be array of strings.',
+        );
+
+        $rule = $this->create('qwe');
+        $rule->validate('true');
+    }
+}

--- a/tests/schemas/todo.yml
+++ b/tests/schemas/todo.yml
@@ -48,16 +48,11 @@ columns:
       is_timezone_offset: true
       not_allow_values: [ ]           # Strict set of values that are not allowed
     aggregate_rules:
-      sum_: true
-      avg_: true
-      median_: true
       mode_: true
-      range_: true
       variance_: true
       stddev_: true
       percentile_: true
       quantile_: true
-      count_: true
       count_distinct_: true
       count_empty_: true
       count_not_empty_: true


### PR DESCRIPTION
Introduced a new NotAllowValues rule that indicates the set of values which are not allowed. This rule was added to full.json, full.php, and full.yml files. Accommodating this new rule required the creation of corresponding classes and test files. The enhancement provides a more robust and configurable data validation effort.