### PR TITLE
Add `country_code` validation rule

### DIFF
--- a/.phan.php
+++ b/.phan.php
@@ -28,8 +28,9 @@ return \array_merge($default, [
         'vendor/jbzoo/data/src',
         'vendor/jbzoo/utils/src',
         'vendor/league/csv/src',
-        'vendor/markrogoyski/math-php/src',
         'vendor/symfony/console',
         'vendor/symfony/finder',
+        'vendor/markrogoyski/math-php/src',
+        'vendor/respect/validation',
     ],
 ]);

--- a/README.md
+++ b/README.md
@@ -210,6 +210,11 @@ columns:
       is_cardinal_direction: true       # Valid cardinal direction. Examples: "N", "S", "NE", "SE", "none", "".
       is_usa_market_name: true          # Check if the value is a valid USA market name. Example: "New York, NY".
 
+      # Validates whether the input is a country code in ISO 3166-1 standard.
+      # Available options: "alpha-2" (Ex: "US"), "alpha-3" (Ex: "USA"), "numeric" (Ex: "840").
+      # The rule uses data from iso-codes: https://salsa.debian.org/iso-codes-team/iso-codes.
+      country_code: alpha-2             # Country code in ISO 3166-1 standard. Examples: "US", "USA", "840".
+
 
     ####################################################################################################################
     # Data validation for the entire(!) column using different data aggregation methods.

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "symfony/filesystem"        : ">=6.4",
         "symfony/finder"            : ">=6.4",
 
-        "markrogoyski/math-php"     : "^2.9"
+        "markrogoyski/math-php"     : "^2.9",
+        "respect/validation": "^2.3"
     },
 
     "require-dev"       : {

--- a/composer.json
+++ b/composer.json
@@ -29,25 +29,21 @@
     "require"           : {
         "php"                       : "^8.1",
         "ext-mbstring"              : "*",
-
-        "league/csv"                : "^9.15",
-
-        "jbzoo/data"                : "^7.1",
-        "jbzoo/cli"                 : "^7.1",
-        "jbzoo/utils"               : "^7.1",
-        "jbzoo/ci-report-converter" : "^7.2",
-
-        "symfony/yaml"              : ">=6.4",
-        "symfony/filesystem"        : ">=6.4",
-        "symfony/finder"            : ">=6.4",
-
-        "markrogoyski/math-php"     : "^2.9",
-        "respect/validation": "^2.3"
+        "league/csv"                : "^9.15.0",
+        "jbzoo/data"                : "^7.1.1",
+        "jbzoo/cli"                 : "^7.1.8",
+        "jbzoo/utils"               : "^7.1.2",
+        "jbzoo/ci-report-converter" : "^7.2.1",
+        "symfony/yaml"              : ">=6.4.3",
+        "symfony/filesystem"        : ">=6.4.3",
+        "symfony/finder"            : ">=6.4.0",
+        "markrogoyski/math-php"     : "^2.9.0",
+        "respect/validation"        : "^2.3.5"
     },
 
     "require-dev"       : {
         "roave/security-advisories" : "dev-latest",
-        "jbzoo/toolbox-dev"         : "^7.1"
+        "jbzoo/toolbox-dev"         : "^7.1.0"
     },
 
     "bin"               : ["csv-blueprint"],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ff53242147ac024c1e782e9682d5a802",
+    "content-hash": "73f508dbee977154396862e9f673beec",
     "packages": [
         {
             "name": "bluepsyduck/symfony-process-manager",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "476159426507f7c81657eeccffba93d2",
+    "content-hash": "ff53242147ac024c1e782e9682d5a802",
     "packages": [
         {
             "name": "bluepsyduck/symfony-process-manager",
@@ -890,6 +890,128 @@
                 "source": "https://github.com/php-fig/log/tree/2.0.0"
             },
             "time": "2021-07-14T16:41:46+00:00"
+        },
+        {
+            "name": "respect/stringifier",
+            "version": "0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Respect/Stringifier.git",
+                "reference": "e55af3c8aeaeaa2abb5fa47a58a8e9688cc23b59"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Respect/Stringifier/zipball/e55af3c8aeaeaa2abb5fa47a58a8e9688cc23b59",
+                "reference": "e55af3c8aeaeaa2abb5fa47a58a8e9688cc23b59",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.8",
+                "malukenho/docheader": "^0.1.7",
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/stringify.php"
+                ],
+                "psr-4": {
+                    "Respect\\Stringifier\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Respect/Stringifier Contributors",
+                    "homepage": "https://github.com/Respect/Stringifier/graphs/contributors"
+                }
+            ],
+            "description": "Converts any value to a string",
+            "homepage": "http://respect.github.io/Stringifier/",
+            "keywords": [
+                "respect",
+                "stringifier",
+                "stringify"
+            ],
+            "support": {
+                "issues": "https://github.com/Respect/Stringifier/issues",
+                "source": "https://github.com/Respect/Stringifier/tree/0.2.0"
+            },
+            "time": "2017-12-29T19:39:25+00:00"
+        },
+        {
+            "name": "respect/validation",
+            "version": "2.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Respect/Validation.git",
+                "reference": "ccec34cf21ca4c0a3acb0968aea295290bcb8fc6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Respect/Validation/zipball/ccec34cf21ca4c0a3acb0968aea295290bcb8fc6",
+                "reference": "ccec34cf21ca4c0a3acb0968aea295290bcb8fc6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1 || ^8.2",
+                "respect/stringifier": "^0.2.0",
+                "symfony/polyfill-mbstring": "^1.2"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^3.0",
+                "giggsey/libphonenumber-for-php-lite": "^8.13",
+                "malukenho/docheader": "^1.0",
+                "mikey179/vfsstream": "^1.6",
+                "phpstan/phpstan": "^1.9",
+                "phpstan/phpstan-deprecation-rules": "^1.1",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.6",
+                "psr/http-message": "^1.0",
+                "respect/coding-standard": "^4.0",
+                "squizlabs/php_codesniffer": "^3.7"
+            },
+            "suggest": {
+                "egulias/email-validator": "Improves the Email rule if available",
+                "ext-bcmath": "Arbitrary Precision Mathematics",
+                "ext-fileinfo": "File Information",
+                "ext-mbstring": "Multibyte String Functions",
+                "giggsey/libphonenumber-for-php-lite": "Enables the phone rule if available"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Respect\\Validation\\": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Respect/Validation Contributors",
+                    "homepage": "https://github.com/Respect/Validation/graphs/contributors"
+                }
+            ],
+            "description": "The most awesome validation engine ever created for PHP",
+            "homepage": "http://respect.github.io/Validation/",
+            "keywords": [
+                "respect",
+                "validation",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/Respect/Validation/issues",
+                "source": "https://github.com/Respect/Validation/tree/2.3.5"
+            },
+            "time": "2024-03-15T10:45:30+00:00"
         },
         {
             "name": "symfony/console",

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -72,7 +72,9 @@
                 "is_longitude"          : true,
                 "is_geohash"            : true,
                 "is_cardinal_direction" : true,
-                "is_usa_market_name"    : true
+                "is_usa_market_name"    : true,
+
+                "country_code"          : "alpha-2"
             },
 
             "aggregate_rules" : {

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -89,6 +89,8 @@ return [
                 'is_geohash'            => true,
                 'is_cardinal_direction' => true,
                 'is_usa_market_name'    => true,
+
+                'country_code' => 'alpha-2',
             ],
 
             'aggregate_rules' => [

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -134,6 +134,11 @@ columns:
       is_cardinal_direction: true       # Valid cardinal direction. Examples: "N", "S", "NE", "SE", "none", "".
       is_usa_market_name: true          # Check if the value is a valid USA market name. Example: "New York, NY".
 
+      # Validates whether the input is a country code in ISO 3166-1 standard.
+      # Available options: "alpha-2" (Ex: "US"), "alpha-3" (Ex: "USA"), "numeric" (Ex: "840").
+      # The rule uses data from iso-codes: https://salsa.debian.org/iso-codes-team/iso-codes.
+      country_code: alpha-2             # Country code in ISO 3166-1 standard. Examples: "US", "USA", "840".
+
 
     ####################################################################################################################
     # Data validation for the entire(!) column using different data aggregation methods.

--- a/src/Rules/Cell/CountryCode.php
+++ b/src/Rules/Cell/CountryCode.php
@@ -47,7 +47,7 @@ class CountryCode extends AbstractCellRule
 
         if (!\in_array($set, $validSets, true)) {
             return "Unknown country set: \"<c>{$set}</c>\". " .
-                'Available options: "[<green>' . \implode(', ', $validSets) . '</green>]';
+                'Available options: [<green>' . \implode(', ', $validSets) . '</green>]';
         }
 
         if (!Validator::countryCode($set)->validate($cellValue)) {

--- a/src/Rules/Cell/CountryCode.php
+++ b/src/Rules/Cell/CountryCode.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Rules\Cell;
+
+use Respect\Validation\Rules\CountryCode as RespectCountryCode;
+use Respect\Validation\Validator;
+
+class CountryCode extends AbstractCellRule
+{
+    protected const HELP_TOP = [
+        'Validates whether the input is a country code in ISO 3166-1 standard.',
+        'Available options: "alpha-2" (Ex: "US"), "alpha-3" (Ex: "USA"), "numeric" (Ex: "840").',
+        'The rule uses data from iso-codes: https://salsa.debian.org/iso-codes-team/iso-codes.',
+    ];
+
+    protected const HELP_OPTIONS = [
+        self::DEFAULT => ['alpha-2', 'Country code in ISO 3166-1 standard. Examples: "US", "USA", "840"'],
+    ];
+
+    public function validateRule(string $cellValue): ?string
+    {
+        if ($cellValue === '') {
+            return null;
+        }
+
+        $validSets = [
+            RespectCountryCode::ALPHA2,
+            RespectCountryCode::ALPHA3,
+            RespectCountryCode::NUMERIC,
+        ];
+
+        $set = $this->getOptionAsString();
+
+        if (!\in_array($set, $validSets, true)) {
+            return "Unknown country set: \"<c>{$set}</c>\". " .
+                'Available options: "[<green>' . \implode(', ', $validSets) . '</green>]';
+        }
+
+        if (!Validator::countryCode($set)->validate($cellValue)) {
+            return "Value \"<c>{$cellValue}</c>\" is not a valid {$set} country code.";
+        }
+
+        return null;
+    }
+}

--- a/tests/Rules/Cell/CountryCodeTest.php
+++ b/tests/Rules/Cell/CountryCodeTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Rules\Cell;
+
+use JBZoo\CsvBlueprint\Rules\Cell\CountryCode;
+use JBZoo\PHPUnit\Rules\AbstractCellRule;
+use Respect\Validation\Rules\CountryCode as RespectCountryCode;
+
+use function JBZoo\PHPUnit\isSame;
+
+final class CountryCodeTest extends AbstractCellRule
+{
+    protected string $ruleClass = CountryCode::class;
+
+    public function testPositive(): void
+    {
+        $rule = $this->create(RespectCountryCode::ALPHA2);
+        isSame('', $rule->test(''));
+        isSame('', $rule->test('US'));
+
+        $rule = $this->create(RespectCountryCode::ALPHA3);
+        isSame('', $rule->test('USA'));
+
+        $rule = $this->create(RespectCountryCode::NUMERIC);
+        isSame('', $rule->test('840'));
+    }
+
+    public function testNegative(): void
+    {
+        $rule = $this->create(RespectCountryCode::ALPHA2);
+        isSame(
+            'Value "qq" is not a valid alpha-2 country code.',
+            $rule->test('qq'),
+        );
+
+        $rule = $this->create(RespectCountryCode::ALPHA3);
+        isSame(
+            'Value "QQQ" is not a valid alpha-3 country code.',
+            $rule->test('QQQ'),
+        );
+
+        $rule = $this->create(RespectCountryCode::NUMERIC);
+        isSame(
+            'Value "101010101" is not a valid numeric country code.',
+            $rule->test('101010101'),
+        );
+    }
+}

--- a/tests/Rules/Cell/CountryCodeTest.php
+++ b/tests/Rules/Cell/CountryCodeTest.php
@@ -59,4 +59,13 @@ final class CountryCodeTest extends AbstractCellRule
             $rule->test('101010101'),
         );
     }
+
+    public function testInvalidOption(): void
+    {
+        $rule = $this->create('qwerty');
+        isSame(
+            'Unknown country set: "qwerty". Available options: [alpha-2, alpha-3, numeric]',
+            $rule->test('US'),
+        );
+    }
 }


### PR DESCRIPTION
Implemented a new CountryCode rule which validates the input against the ISO 3166-1 standard. This new rule is applied in full.json, full.php, and full.yml files, and is supported by a new source code file, CountryCode.php, and its corresponding test file, CountryCodeTest.php. Composer dependencies were updated to accommodate this enhancement.