### PR TITLE
Enhance `is_uuid` validation and descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ columns:
       is_url: true                      # Only URL format. Example: "https://example.com/page?query=string#anchor".
       is_email: true                    # Only email format. Example: "user@example.com".
       is_domain: true                   # Only domain name. Example: "example.com".
-      is_uuid: true                     # Only UUID4 format. Example: "550e8400-e29b-41d4-a716-446655440000".
+      is_uuid: true                     # Validates whether the input is a valid UUID. It also supports validation of specific versions 1, 3, 4 and 5.
       is_alias: true                    # Only alias format. Example: "my-alias-123". It can contain letters, numbers, and dashes.
       is_currency_code: true            # Validates an ISO 4217 currency code like GBP or EUR. Case-sensitive. See: https://en.wikipedia.org/wiki/ISO_4217.
 

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -124,7 +124,7 @@ columns:
       is_url: true                      # Only URL format. Example: "https://example.com/page?query=string#anchor".
       is_email: true                    # Only email format. Example: "user@example.com".
       is_domain: true                   # Only domain name. Example: "example.com".
-      is_uuid: true                     # Only UUID4 format. Example: "550e8400-e29b-41d4-a716-446655440000".
+      is_uuid: true                     # Validates whether the input is a valid UUID. It also supports validation of specific versions 1, 3, 4 and 5.
       is_alias: true                    # Only alias format. Example: "my-alias-123". It can contain letters, numbers, and dashes.
       is_currency_code: true            # Validates an ISO 4217 currency code like GBP or EUR. Case-sensitive. See: https://en.wikipedia.org/wiki/ISO_4217.
 

--- a/src/Rules/Cell/IsUuid.php
+++ b/src/Rules/Cell/IsUuid.php
@@ -16,18 +16,21 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Cell;
 
+use Respect\Validation\Validator;
+
 final class IsUuid extends AbstractCellRule
 {
     protected const HELP_OPTIONS = [
-        self::DEFAULT => ['true', 'Only UUID4 format. Example: "550e8400-e29b-41d4-a716-446655440000"'],
+        self::DEFAULT => [
+            'true',
+            'Validates whether the input is a valid UUID. It also supports validation of specific versions 1, 3, 4 and 5.',
+        ],
     ];
 
     public function validateRule(string $cellValue): ?string
     {
-        $uuid4 = '/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89ABab][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/';
-
-        if (\preg_match($uuid4, $cellValue) === 0) {
-            return 'Value is not a valid UUID v4';
+        if (!Validator::uuid()->validate($cellValue)) {
+            return 'Value is not a valid UUID';
         }
 
         return null;

--- a/src/Rules/Cell/IsUuid.php
+++ b/src/Rules/Cell/IsUuid.php
@@ -23,7 +23,8 @@ final class IsUuid extends AbstractCellRule
     protected const HELP_OPTIONS = [
         self::DEFAULT => [
             'true',
-            'Validates whether the input is a valid UUID. It also supports validation of specific versions 1, 3, 4 and 5.',
+            'Validates whether the input is a valid UUID. ' .
+            'It also supports validation of specific versions 1, 3, 4 and 5.',
         ],
     ];
 

--- a/tests/Rules/Cell/IsUuid4Test.php
+++ b/tests/Rules/Cell/IsUuid4Test.php
@@ -40,11 +40,11 @@ final class IsUuid4Test extends AbstractCellRule
     {
         $rule = $this->create(true);
         isSame(
-            'Value is not a valid UUID v4',
-            $rule->test('123e4567-e89b-12d3-a456-426655440000'),
+            'Value is not a valid UUID',
+            $rule->test('123e4567-e89b-12d3-a456-4266554400zz'),
         );
         isSame(
-            'Value is not a valid UUID v4',
+            'Value is not a valid UUID',
             $rule->test('123'),
         );
     }


### PR DESCRIPTION
UUID validation has been enhanced to support multiple versions (1,3,4,5) instead of just the previous UUID4 format. This update is reflected in code, comments, and README documentation. Updated test cases reflect the newly extended UUID validation.