### PR TITLE
Add `is_json` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Stable Version](https://poser.pugx.org/jbzoo/csv-blueprint/version)](https://packagist.org/packages/jbzoo/csv-blueprint/)    [![Total Downloads](https://poser.pugx.org/jbzoo/csv-blueprint/downloads)](https://packagist.org/packages/jbzoo/csv-blueprint/stats)    [![Docker Pulls](https://img.shields.io/docker/pulls/jbzoo/csv-blueprint.svg)](https://hub.docker.com/r/jbzoo/csv-blueprint)    [![Dependents](https://poser.pugx.org/jbzoo/csv-blueprint/dependents)](https://packagist.org/packages/jbzoo/csv-blueprint/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/csv-blueprint)](https://github.com/JBZoo/Csv-Blueprint/blob/master/LICENSE)
 
 <!-- rules-counter -->
-![Static Badge](https://img.shields.io/badge/Total_Rules-78-green?label=Total%20Rules&color=green)    ![Static Badge](https://img.shields.io/badge/Cell_Rules-53-green?label=Cell%20Rules&color=green)    ![Static Badge](https://img.shields.io/badge/Aggregate_Rules-25-green?label=Aggregate%20Rules&color=green)
+![Static Badge](https://img.shields.io/badge/Total_Rules-79-green?label=Total%20Rules&color=green)    ![Static Badge](https://img.shields.io/badge/Cell_Rules-54-green?label=Cell%20Rules&color=green)    ![Static Badge](https://img.shields.io/badge/Aggregate_Rules-25-green?label=Aggregate%20Rules&color=green)
 <!-- /rules-counter -->
 
 ## Introduction
@@ -207,6 +207,10 @@ columns:
       is_alias: true                    # Only alias format. Example: "my-alias-123". It can contain letters, numbers, and dashes.
       is_currency_code: true            # Validates an ISO 4217 currency code like GBP or EUR. Case-sensitive. See: https://en.wikipedia.org/wiki/ISO_4217.
       is_base64: true                   # Validate if a string is Base64-encoded. Example: "cmVzcGVjdCE=".
+
+      # Validates if the given input is a valid JSON.
+      # This is possible if you escape all special characters correctly and use a special CSV format.
+      is_json: true                     # Example: {"foo":"bar"}.
 
       # Geography
       is_latitude: true                 # Can be integer or float. Example: 50.123456.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Stable Version](https://poser.pugx.org/jbzoo/csv-blueprint/version)](https://packagist.org/packages/jbzoo/csv-blueprint/)    [![Total Downloads](https://poser.pugx.org/jbzoo/csv-blueprint/downloads)](https://packagist.org/packages/jbzoo/csv-blueprint/stats)    [![Docker Pulls](https://img.shields.io/docker/pulls/jbzoo/csv-blueprint.svg)](https://hub.docker.com/r/jbzoo/csv-blueprint)    [![Dependents](https://poser.pugx.org/jbzoo/csv-blueprint/dependents)](https://packagist.org/packages/jbzoo/csv-blueprint/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/csv-blueprint)](https://github.com/JBZoo/Csv-Blueprint/blob/master/LICENSE)
 
 <!-- rules-counter -->
-![Static Badge](https://img.shields.io/badge/Total_Rules-79-green?label=Total%20Rules&color=green)    ![Static Badge](https://img.shields.io/badge/Cell_Rules-54-green?label=Cell%20Rules&color=green)    ![Static Badge](https://img.shields.io/badge/Aggregate_Rules-25-green?label=Aggregate%20Rules&color=green)
+![Static Badge](https://img.shields.io/badge/Rules-79-green?label=Total%20Number%20of%20Rules&labelColor=blue&color=gray)    ![Static Badge](https://img.shields.io/badge/Rules-54-green?label=Cell%20Rules&labelColor=blue&color=gray)    ![Static Badge](https://img.shields.io/badge/Rules-25-green?label=Aggregate%20Rules&labelColor=blue&color=gray)
 <!-- /rules-counter -->
 
 ## Introduction

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -69,6 +69,7 @@
                 "is_alias"              : true,
                 "is_currency_code"      : true,
                 "is_base64"             : true,
+                "is_json"               : true,
 
                 "is_latitude"           : true,
                 "is_longitude"          : true,

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -85,6 +85,7 @@ return [
                 'is_alias'         => true,
                 'is_currency_code' => true,
                 'is_base64'        => true,
+                'is_json'          => true,
 
                 'is_latitude'           => true,
                 'is_longitude'          => true,

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -129,6 +129,10 @@ columns:
       is_currency_code: true            # Validates an ISO 4217 currency code like GBP or EUR. Case-sensitive. See: https://en.wikipedia.org/wiki/ISO_4217.
       is_base64: true                   # Validate if a string is Base64-encoded. Example: "cmVzcGVjdCE=".
 
+      # Validates if the given input is a valid JSON.
+      # This is possible if you escape all special characters correctly and use a special CSV format.
+      is_json: true                     # Example: {"foo":"bar"}.
+
       # Geography
       is_latitude: true                 # Can be integer or float. Example: 50.123456.
       is_longitude: true                # Can be integer or float. Example: -89.123456.

--- a/src/Rules/Cell/IsJson.php
+++ b/src/Rules/Cell/IsJson.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Rules\Cell;
+
+use Respect\Validation\Validator;
+
+final class IsJson extends AbstractCellRule
+{
+    protected const HELP_TOP = [
+        'Validates if the given input is a valid JSON.',
+        'This is possible if you escape all special characters correctly and use a special CSV format.',
+    ];
+
+    protected const HELP_OPTIONS = [
+        self::DEFAULT => [
+            'true',
+            'Example: {"foo":"bar"}',
+        ],
+    ];
+
+    public function validateRule(string $cellValue): ?string
+    {
+        if (!Validator::json()->validate($cellValue)) {
+            return "Value \"<c>{$cellValue}</c>\" is not a valid JSON";
+        }
+
+        return null;
+    }
+}

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -66,15 +66,17 @@ final class ReadmeTest extends TestCase
         $aggRules   = \count(yml(Tools::SCHEMA_FULL)->findArray('columns.0.aggregate_rules'));
         $totalRules = $cellRules + $aggRules;
 
-        $text = \implode('', [
-            "![Static Badge](https://img.shields.io/badge/Total_Rules-{$totalRules}-" .
-            'green?label=Total%20Rules&color=green)',
-            '    ',
-            "![Static Badge](https://img.shields.io/badge/Cell_Rules-{$cellRules}-" .
-            'green?label=Cell%20Rules&color=green)',
-            '    ',
-            "![Static Badge](https://img.shields.io/badge/Aggregate_Rules-{$aggRules}-" .
-            'green?label=Aggregate%20Rules&color=green)',
+        $badge = static function (string $label, int $count): string {
+            $label = \str_replace(' ', '%20', $label);
+
+            return "![Static Badge](https://img.shields.io/badge/Rules-{$count}-green" .
+                "?label={$label}&labelColor=blue&color=gray)";
+        };
+
+        $text = \implode('    ', [
+            $badge('Total Number of Rules', $totalRules),
+            $badge('Cell Rules', $cellRules),
+            $badge('Aggregate Rules', $aggRules),
         ]);
 
         Tools::insertInReadme('rules-counter', $text);

--- a/tests/Rules/Cell/IsJsonTest.php
+++ b/tests/Rules/Cell/IsJsonTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Rules\Cell;
+
+use JBZoo\CsvBlueprint\Rules\Cell\IsJson;
+use JBZoo\PHPUnit\Rules\AbstractCellRule;
+
+use function JBZoo\PHPUnit\isSame;
+
+final class IsJsonTest extends AbstractCellRule
+{
+    protected string $ruleClass = IsJson::class;
+
+    public function testPositive(): void
+    {
+        $rule = $this->create(true);
+        isSame('', $rule->test('{"foo":"bar"}'));
+    }
+
+    public function testNegative(): void
+    {
+        $rule = $this->create(true);
+        isSame(
+            'Value "Hello world!" is not a valid JSON',
+            $rule->test('Hello world!'),
+        );
+    }
+}


### PR DESCRIPTION
The commit introduces a `is_json` rule to validate if a given input is a valid JSON. This rule has been added to the json, php, and yml schema examples. Accompanying unit tests have also been added. The rule count in the README.md file is also updated to reflect the new addition.