### PR TITLE
Add `language_code` validation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Stable Version](https://poser.pugx.org/jbzoo/csv-blueprint/version)](https://packagist.org/packages/jbzoo/csv-blueprint/)    [![Total Downloads](https://poser.pugx.org/jbzoo/csv-blueprint/downloads)](https://packagist.org/packages/jbzoo/csv-blueprint/stats)    [![Docker Pulls](https://img.shields.io/docker/pulls/jbzoo/csv-blueprint.svg)](https://hub.docker.com/r/jbzoo/csv-blueprint)    [![Dependents](https://poser.pugx.org/jbzoo/csv-blueprint/dependents)](https://packagist.org/packages/jbzoo/csv-blueprint/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/csv-blueprint)](https://github.com/JBZoo/Csv-Blueprint/blob/master/LICENSE)
 
 <!-- rules-counter -->
-![Static Badge](https://img.shields.io/badge/Rules-79-green?label=Total%20Number%20of%20Rules&labelColor=blue&color=gray)    ![Static Badge](https://img.shields.io/badge/Rules-54-green?label=Cell%20Rules&labelColor=blue&color=gray)    ![Static Badge](https://img.shields.io/badge/Rules-25-green?label=Aggregate%20Rules&labelColor=blue&color=gray)
+![Static Badge](https://img.shields.io/badge/Rules-80-green?label=Total%20Number%20of%20Rules&labelColor=blue&color=gray)    ![Static Badge](https://img.shields.io/badge/Rules-55-green?label=Cell%20Rules&labelColor=blue&color=gray)    ![Static Badge](https://img.shields.io/badge/Rules-25-green?label=Aggregate%20Rules&labelColor=blue&color=gray)
 <!-- /rules-counter -->
 
 ## Introduction
@@ -223,6 +223,11 @@ columns:
       # Available options: "alpha-2" (Ex: "US"), "alpha-3" (Ex: "USA"), "numeric" (Ex: "840").
       # The rule uses data from iso-codes: https://salsa.debian.org/iso-codes-team/iso-codes.
       country_code: alpha-2             # Country code in ISO 3166-1 standard. Examples: "US", "USA", "840".
+
+      # Validates whether the input is language code based on ISO 639.
+      # Available options: "alpha-2" (Ex: "en"), "alpha-3" (Ex: "eng").
+      # See: https://en.wikipedia.org/wiki/ISO_639.
+      language_code: alpha-2            # Examples: "en", "eng".
 
 
     ####################################################################################################################

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -77,7 +77,8 @@
                 "is_cardinal_direction" : true,
                 "is_usa_market_name"    : true,
 
-                "country_code"          : "alpha-2"
+                "country_code"          : "alpha-2",
+                "language_code"         : "alpha-2"
             },
 
             "aggregate_rules" : {

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -93,7 +93,8 @@ return [
                 'is_cardinal_direction' => true,
                 'is_usa_market_name'    => true,
 
-                'country_code' => 'alpha-2',
+                'country_code'  => 'alpha-2',
+                'language_code' => 'alpha-2',
             ],
 
             'aggregate_rules' => [

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -145,6 +145,11 @@ columns:
       # The rule uses data from iso-codes: https://salsa.debian.org/iso-codes-team/iso-codes.
       country_code: alpha-2             # Country code in ISO 3166-1 standard. Examples: "US", "USA", "840".
 
+      # Validates whether the input is language code based on ISO 639.
+      # Available options: "alpha-2" (Ex: "en"), "alpha-3" (Ex: "eng").
+      # See: https://en.wikipedia.org/wiki/ISO_639.
+      language_code: alpha-2            # Examples: "en", "eng".
+
 
     ####################################################################################################################
     # Data validation for the entire(!) column using different data aggregation methods.

--- a/src/Rules/Cell/LanguageCode.php
+++ b/src/Rules/Cell/LanguageCode.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Rules\Cell;
+
+use Respect\Validation\Rules\LanguageCode as RespectLanguageCode;
+use Respect\Validation\Validator;
+
+class LanguageCode extends AbstractCellRule
+{
+    protected const HELP_TOP = [
+        'Validates whether the input is language code based on ISO 639.',
+        'Available options: "alpha-2" (Ex: "en"), "alpha-3" (Ex: "eng").',
+        'See: https://en.wikipedia.org/wiki/ISO_639.',
+    ];
+
+    protected const HELP_OPTIONS = [
+        self::DEFAULT => ['alpha-2', 'Examples: "en", "eng"'],
+    ];
+
+    public function validateRule(string $cellValue): ?string
+    {
+        if ($cellValue === '') {
+            return null;
+        }
+
+        $validSets = [RespectLanguageCode::ALPHA2, RespectLanguageCode::ALPHA3];
+
+        $set = $this->getOptionAsString();
+
+        if (!\in_array($set, $validSets, true)) {
+            return "Unknown language set: \"<c>{$set}</c>\". " .
+                'Available options: [<green>' . \implode(', ', $validSets) . '</green>]';
+        }
+
+        if (!Validator::languageCode($set)->validate($cellValue)) {
+            return "Value \"<c>{$cellValue}</c>\" is not a valid {$set} language code.";
+        }
+
+        return null;
+    }
+}

--- a/tests/Rules/Cell/LanguageCodeTest.php
+++ b/tests/Rules/Cell/LanguageCodeTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Rules\Cell;
+
+use JBZoo\CsvBlueprint\Rules\Cell\LanguageCode;
+use JBZoo\PHPUnit\Rules\AbstractCellRule;
+
+use function JBZoo\PHPUnit\isSame;
+
+final class LanguageCodeTest extends AbstractCellRule
+{
+    protected string $ruleClass = LanguageCode::class;
+
+    public function testPositive(): void
+    {
+        $rule = $this->create('alpha-2');
+        isSame('', $rule->test(''));
+        isSame('', $rule->test('en'));
+        isSame('', $rule->test('it'));
+
+        $rule = $this->create('alpha-3');
+        isSame('', $rule->test('eng'));
+        isSame('', $rule->test('ita'));
+    }
+
+    public function testNegative(): void
+    {
+        $rule = $this->create('alpha-2');
+        isSame(
+            'Value "qq" is not a valid alpha-2 language code.',
+            $rule->test('qq'),
+        );
+    }
+
+    public function testInvalidOption(): void
+    {
+        $rule = $this->create('qwerty');
+        isSame(
+            'Unknown language set: "qwerty". Available options: [alpha-2, alpha-3]',
+            $rule->test('US'),
+        );
+    }
+}


### PR DESCRIPTION
Implemented a new rule for validating 'language_code' based on ISO 639 standard in the schema examples for json, php, and yml files. Added unit tests for this new rule and updated the README along with the total count of rules.