### PR TITLE
Implemented `sample_variance` to aggregate rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Stable Version](https://poser.pugx.org/jbzoo/csv-blueprint/version)](https://packagist.org/packages/jbzoo/csv-blueprint/)    [![Total Downloads](https://poser.pugx.org/jbzoo/csv-blueprint/downloads)](https://packagist.org/packages/jbzoo/csv-blueprint/stats)    [![Docker Pulls](https://img.shields.io/docker/pulls/jbzoo/csv-blueprint.svg)](https://hub.docker.com/r/jbzoo/csv-blueprint)    [![Dependents](https://poser.pugx.org/jbzoo/csv-blueprint/dependents)](https://packagist.org/packages/jbzoo/csv-blueprint/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/csv-blueprint)](https://github.com/JBZoo/Csv-Blueprint/blob/master/LICENSE)
 
 <!-- rules-counter -->
-![Static Badge](https://img.shields.io/badge/Rules-84-green?label=Total%20Number%20of%20Rules&labelColor=blue&color=gray)    ![Static Badge](https://img.shields.io/badge/Rules-55-green?label=Cell%20Rules&labelColor=blue&color=gray)    ![Static Badge](https://img.shields.io/badge/Rules-29-green?label=Aggregate%20Rules&labelColor=blue&color=gray)
+![Static Badge](https://img.shields.io/badge/Rules-88-green?label=Total%20Number%20of%20Rules&labelColor=blue&color=gray)    ![Static Badge](https://img.shields.io/badge/Rules-55-green?label=Cell%20Rules&labelColor=blue&color=gray)    ![Static Badge](https://img.shields.io/badge/Rules-33-green?label=Aggregate%20Rules&labelColor=blue&color=gray)
 <!-- /rules-counter -->
 
 ## Introduction
@@ -277,11 +277,18 @@ columns:
 
       # Population variance - Use when all possible observations of the system are present.
       # If used with a subset of data (sample variance), it will be a biased variance.
-      # It's n degrees of freedom.
+      # n degrees of freedom, where n is the number of observations.
       population_variance: 5.123
       population_variance_not: 4.123
       population_variance_min: 1.123
       population_variance_max: 10.123
+
+      # Unbiased sample variance Use when only a subset of all possible observations of the system are present.
+      # n - 1 degrees of freedom, where n is the number of observations.
+      sample_variance: 5.123
+      sample_variance_not: 4.123
+      sample_variance_min: 1.123
+      sample_variance_max: 10.123
 
   - name: "another_column"
 

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -117,7 +117,12 @@
                 "population_variance"     : 5.123,
                 "population_variance_not" : 4.123,
                 "population_variance_min" : 1.123,
-                "population_variance_max" : 10.123
+                "population_variance_max" : 10.123,
+
+                "sample_variance"         : 5.123,
+                "sample_variance_not"     : 4.123,
+                "sample_variance_min"     : 1.123,
+                "sample_variance_max"     : 10.123
             }
         },
 

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -134,6 +134,11 @@ return [
                 'population_variance_not' => 4.123,
                 'population_variance_min' => 1.123,
                 'population_variance_max' => 10.123,
+
+                'sample_variance'     => 5.123,
+                'sample_variance_not' => 4.123,
+                'sample_variance_min' => 1.123,
+                'sample_variance_max' => 10.123,
             ],
         ],
 

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -198,11 +198,18 @@ columns:
 
       # Population variance - Use when all possible observations of the system are present.
       # If used with a subset of data (sample variance), it will be a biased variance.
-      # It's n degrees of freedom.
+      # n degrees of freedom, where n is the number of observations.
       population_variance: 5.123
       population_variance_not: 4.123
       population_variance_min: 1.123
       population_variance_max: 10.123
+
+      # Unbiased sample variance Use when only a subset of all possible observations of the system are present.
+      # n - 1 degrees of freedom, where n is the number of observations.
+      sample_variance: 5.123
+      sample_variance_not: 4.123
+      sample_variance_min: 1.123
+      sample_variance_max: 10.123
 
   - name: "another_column"
 

--- a/src/Rules/Aggregate/ComboSampleVariance.php
+++ b/src/Rules/Aggregate/ComboSampleVariance.php
@@ -18,18 +18,17 @@ namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
 use MathPHP\Statistics\Descriptive;
 
-final class ComboPopulationVariance extends AbstarctAggregateRuleCombo
+final class ComboSampleVariance extends AbstarctAggregateRuleCombo
 {
     protected const NAME = 'population variance';
 
     protected const HELP_TOP = [
-        'Population variance - Use when all possible observations of the system are present.',
-        'If used with a subset of data (sample variance), it will be a biased variance.',
-        'n degrees of freedom, where n is the number of observations.',
+        'Unbiased sample variance Use when only a subset of all possible observations of the system are present.',
+        'n - 1 degrees of freedom, where n is the number of observations.',
     ];
 
     protected function getActualAggregate(array $colValues): ?float
     {
-        return Descriptive::populationVariance(self::stringsToFloat($colValues));
+        return Descriptive::sampleVariance(self::stringsToFloat($colValues));
     }
 }

--- a/tests/Rules/Aggregate/ComboPopulationVarianceTest.php
+++ b/tests/Rules/Aggregate/ComboPopulationVarianceTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Rules\Aggregate;
+
+use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\Aggregate\ComboPopulationVariance;
+use JBZoo\PHPUnit\Rules\AbstractAggregateRuleCombo;
+
+use function JBZoo\PHPUnit\isSame;
+
+class ComboPopulationVarianceTest extends AbstractAggregateRuleCombo
+{
+    protected string $ruleClass = ComboPopulationVariance::class;
+
+    public function testEqual(): void
+    {
+        $rule = $this->create(0.1875, Combo::EQ);
+        isSame('', $rule->test(['1', '2', '1', '1']));
+
+        $rule = $this->create(10, Combo::EQ);
+        isSame(
+            'The population variance in the column is "0.1875", which is not equal than the expected "10"',
+            $rule->test(['1', '2', '1', '1']),
+        );
+    }
+}

--- a/tests/Rules/Aggregate/ComboSampleVarianceTest.php
+++ b/tests/Rules/Aggregate/ComboSampleVarianceTest.php
@@ -17,27 +17,24 @@ declare(strict_types=1);
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
 use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
-use JBZoo\CsvBlueprint\Rules\Aggregate\ComboPopulationVariance;
+use JBZoo\CsvBlueprint\Rules\Aggregate\ComboSampleVariance;
 use JBZoo\PHPUnit\Rules\AbstractAggregateRuleCombo;
 
 use function JBZoo\PHPUnit\isSame;
 
-class ComboVarianceTest extends AbstractAggregateRuleCombo
+class ComboSampleVarianceTest extends AbstractAggregateRuleCombo
 {
-    protected string $ruleClass = ComboPopulationVariance::class;
+    protected string $ruleClass = ComboSampleVariance::class;
 
     public function testEqual(): void
     {
+        $rule = $this->create(10.5, Combo::EQ);
+        isSame('', $rule->test([13, 18, 13, 14, 13, 16, 14, 21, 10]));
+
         $rule = $this->create(10, Combo::EQ);
-
         isSame(
-            'The population variance in the column is "9.3333333333333", which is not equal than the expected "10"',
+            'The population variance in the column is "10.5", which is not equal than the expected "10"',
             $rule->test([13, 18, 13, 14, 13, 16, 14, 21, 10]),
-        );
-
-        isSame(
-            'The population variance in the column is "0.1875", which is not equal than the expected "10"',
-            $rule->test(['1', '2', '1', '1']),
         );
     }
 }


### PR DESCRIPTION
Added the "Sample Variance" rule to the set of aggregate rules. Changes reflect in the schema files (JSON, PHP, YAML), with a new PHP class for the rule and updates to existing tests. The README's rules count has been updated as well.