### PR TITLE
Add `standard_deviation` to aggregate rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Stable Version](https://poser.pugx.org/jbzoo/csv-blueprint/version)](https://packagist.org/packages/jbzoo/csv-blueprint/)    [![Total Downloads](https://poser.pugx.org/jbzoo/csv-blueprint/downloads)](https://packagist.org/packages/jbzoo/csv-blueprint/stats)    [![Docker Pulls](https://img.shields.io/docker/pulls/jbzoo/csv-blueprint.svg)](https://hub.docker.com/r/jbzoo/csv-blueprint)    [![Dependents](https://poser.pugx.org/jbzoo/csv-blueprint/dependents)](https://packagist.org/packages/jbzoo/csv-blueprint/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/csv-blueprint)](https://github.com/JBZoo/Csv-Blueprint/blob/master/LICENSE)
 
 <!-- rules-counter -->
-![Static Badge](https://img.shields.io/badge/Rules-88-green?label=Total%20Number%20of%20Rules&labelColor=blue&color=gray)    ![Static Badge](https://img.shields.io/badge/Rules-55-green?label=Cell%20Rules&labelColor=blue&color=gray)    ![Static Badge](https://img.shields.io/badge/Rules-33-green?label=Aggregate%20Rules&labelColor=blue&color=gray)
+![Static Badge](https://img.shields.io/badge/Rules-92-green?label=Total%20Number%20of%20Rules&labelColor=blue&color=gray)    ![Static Badge](https://img.shields.io/badge/Rules-55-green?label=Cell%20Rules&labelColor=blue&color=gray)    ![Static Badge](https://img.shields.io/badge/Rules-37-green?label=Aggregate%20Rules&labelColor=blue&color=gray)
 <!-- /rules-counter -->
 
 ## Introduction
@@ -289,6 +289,15 @@ columns:
       sample_variance_not: 4.123
       sample_variance_min: 1.123
       sample_variance_max: 10.123
+
+      # Standard deviation is a measure that is used to quantify the amount of variation or dispersion of a set of data values.
+      # A low standard deviation indicates that the data points tend to be close to the mean (also called the expected value) of the set.
+      # A high standard deviation indicates that the data points are spread out over a wider range of values.
+      # See: https://en.wikipedia.org/wiki/Standard_deviation.
+      standard_deviation: 5.123
+      standard_deviation_not: 4.123
+      standard_deviation_min: 1.123
+      standard_deviation_max: 10.123
 
   - name: "another_column"
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ columns:
       sample_variance_min: 1.123
       sample_variance_max: 10.123
 
+      # Standard deviation (For a sample; uses sample variance).
       # Standard deviation is a measure that is used to quantify the amount of variation or dispersion of a set of data values.
       # A low standard deviation indicates that the data points tend to be close to the mean (also called the expected value) of the set.
       # A high standard deviation indicates that the data points are spread out over a wider range of values.

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -124,7 +124,6 @@
                 "sample_variance_min"     : 1.123,
                 "sample_variance_max"     : 10.123,
 
-                "sample_variance_max"     : 10.123,
                 "standard_deviation"      : 5.123,
                 "standard_deviation_not"  : 4.123,
                 "standard_deviation_min"  : 1.123,

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -122,7 +122,13 @@
                 "sample_variance"         : 5.123,
                 "sample_variance_not"     : 4.123,
                 "sample_variance_min"     : 1.123,
-                "sample_variance_max"     : 10.123
+                "sample_variance_max"     : 10.123,
+
+                "sample_variance_max"     : 10.123,
+                "standard_deviation"      : 5.123,
+                "standard_deviation_not"  : 4.123,
+                "standard_deviation_min"  : 1.123,
+                "standard_deviation_max"  : 10.123
             }
         },
 

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -139,6 +139,11 @@ return [
                 'sample_variance_not' => 4.123,
                 'sample_variance_min' => 1.123,
                 'sample_variance_max' => 10.123,
+
+                'standard_deviation'     => 5.123,
+                'standard_deviation_not' => 4.123,
+                'standard_deviation_min' => 1.123,
+                'standard_deviation_max' => 10.123,
             ],
         ],
 

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -211,6 +211,15 @@ columns:
       sample_variance_min: 1.123
       sample_variance_max: 10.123
 
+      # Standard deviation is a measure that is used to quantify the amount of variation or dispersion of a set of data values.
+      # A low standard deviation indicates that the data points tend to be close to the mean (also called the expected value) of the set.
+      # A high standard deviation indicates that the data points are spread out over a wider range of values.
+      # See: https://en.wikipedia.org/wiki/Standard_deviation.
+      standard_deviation: 5.123
+      standard_deviation_not: 4.123
+      standard_deviation_min: 1.123
+      standard_deviation_max: 10.123
+
   - name: "another_column"
 
   - name: "third_column"

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -211,6 +211,7 @@ columns:
       sample_variance_min: 1.123
       sample_variance_max: 10.123
 
+      # Standard deviation (For a sample; uses sample variance).
       # Standard deviation is a measure that is used to quantify the amount of variation or dispersion of a set of data values.
       # A low standard deviation indicates that the data points tend to be close to the mean (also called the expected value) of the set.
       # A high standard deviation indicates that the data points are spread out over a wider range of values.

--- a/src/Rules/Aggregate/ComboStandardDeviation.php
+++ b/src/Rules/Aggregate/ComboStandardDeviation.php
@@ -20,9 +20,10 @@ use MathPHP\Statistics\Descriptive;
 
 final class ComboStandardDeviation extends AbstarctAggregateRuleCombo
 {
-    protected const NAME = 'standard deviation';
+    protected const NAME = 'standard deviation (SD)';
 
     protected const HELP_TOP = [
+        'Standard deviation (For a sample; uses sample variance)',
         'Standard deviation is a measure that is used to quantify the amount of variation or dispersion of a set of data values.',
         'A low standard deviation indicates that the data points tend to be close to the mean (also called the expected value) of the set.',
         'A high standard deviation indicates that the data points are spread out over a wider range of values.',

--- a/src/Rules/Aggregate/ComboStandardDeviation.php
+++ b/src/Rules/Aggregate/ComboStandardDeviation.php
@@ -24,8 +24,10 @@ final class ComboStandardDeviation extends AbstarctAggregateRuleCombo
 
     protected const HELP_TOP = [
         'Standard deviation (For a sample; uses sample variance)',
-        'Standard deviation is a measure that is used to quantify the amount of variation or dispersion of a set of data values.',
-        'A low standard deviation indicates that the data points tend to be close to the mean (also called the expected value) of the set.',
+        'Standard deviation is a measure that is used to quantify the amount of variation or ' .
+        'dispersion of a set of data values.',
+        'A low standard deviation indicates that the data points tend to be close to the mean ' .
+        '(also called the expected value) of the set.',
         'A high standard deviation indicates that the data points are spread out over a wider range of values.',
         'See: https://en.wikipedia.org/wiki/Standard_deviation',
     ];

--- a/src/Rules/Aggregate/ComboStandardDeviation.php
+++ b/src/Rules/Aggregate/ComboStandardDeviation.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Rules\Aggregate;
+
+use MathPHP\Statistics\Descriptive;
+
+final class ComboStandardDeviation extends AbstarctAggregateRuleCombo
+{
+    protected const NAME = 'standard deviation';
+
+    protected const HELP_TOP = [
+        'Standard deviation is a measure that is used to quantify the amount of variation or dispersion of a set of data values.',
+        'A low standard deviation indicates that the data points tend to be close to the mean (also called the expected value) of the set.',
+        'A high standard deviation indicates that the data points are spread out over a wider range of values.',
+        'See: https://en.wikipedia.org/wiki/Standard_deviation',
+    ];
+
+    protected function getActualAggregate(array $colValues): ?float
+    {
+        return Descriptive::standardDeviation(self::stringsToFloat($colValues));
+    }
+}

--- a/tests/Rules/Aggregate/ComboStandardDeviationTest.php
+++ b/tests/Rules/Aggregate/ComboStandardDeviationTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Rules\Aggregate;
+
+use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\Aggregate\ComboStandardDeviation;
+use JBZoo\PHPUnit\Rules\AbstractAggregateRuleCombo;
+
+use function JBZoo\PHPUnit\isSame;
+
+class ComboStandardDeviationTest extends AbstractAggregateRuleCombo
+{
+    protected string $ruleClass = ComboStandardDeviation::class;
+
+    public function testEqual(): void
+    {
+        $rule = $this->create(2.5, Combo::EQ);
+        isSame('', $rule->test([1, 5, 1, 1, 1, 2, 8, 1, 1]));
+
+        $rule = $this->create(3, Combo::EQ);
+        isSame(
+            'The standard deviation in the column is "2.5", which is not equal than the expected "3"',
+            $rule->test([1, 5, 1, 1, 1, 2, 8, 1, 1]),
+        );
+    }
+}

--- a/tests/Rules/Aggregate/ComboStandardDeviationTest.php
+++ b/tests/Rules/Aggregate/ComboStandardDeviationTest.php
@@ -33,7 +33,7 @@ class ComboStandardDeviationTest extends AbstractAggregateRuleCombo
 
         $rule = $this->create(3, Combo::EQ);
         isSame(
-            'The standard deviation in the column is "2.5", which is not equal than the expected "3"',
+            'The standard deviation (SD) in the column is "2.5", which is not equal than the expected "3"',
             $rule->test([1, 5, 1, 1, 1, 2, 8, 1, 1]),
         );
     }


### PR DESCRIPTION
Introduced the "Standard Deviation" rule to the aggregate rules in the `full.json`, `full.php`, and `full.yml` files. This involved the creation of a new PHP class and updates to the testing files. The number of aggregate rules in the README has been subsequently updated.