### PR TITLE
Add detailed description and metadata to schema examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,18 @@ It's also covered by tests, so it's always up-to-date.
 
 <!-- full-yml -->
 ```yml
-# It's a full example of the CSV schema file in YAML format.
+# It's a complete example of the CSV schema file in YAML format.
+# See copy of the file without comments here ./schema-examples/full_clean.yml
+
+# Just meta
+name: CSV Blueprint Schema Example      # Name of a CSV file. Not used in the validation process.
+description: |                          # Any description of the CSV file. Not used in the validation process.
+  This YAML file provides a detailed description and validation rules for CSV files
+  to be processed by JBZoo/Csv-Blueprint tool. It includes specifications for file name patterns,
+  CSV formatting options, and extensive validation criteria for individual columns and their values,
+  supporting a wide range of data validation rules from basic type checks to complex regex validations.
+  This example serves as a comprehensive guide for creating robust CSV file validations.
+
 
 # Regular expression to match the file name. If not set, then no pattern check
 # This way you can validate the file name before the validation process.
@@ -97,7 +108,10 @@ It's also covered by tests, so it's always up-to-date.
 # See https://www.php.net/manual/en/reference.pcre.pattern.syntax.php
 filename_pattern: /demo(-\d+)?\.csv$/i
 
-csv: # Here are default values. You can skip this section if you don't need to override the default values
+
+# Here are default values to parse CSV file.
+# You can skip this section if you don't need to override the default values.
+csv:
   header: true                          # If the first row is a header. If true, name of each column is required.
   delimiter: ,                          # Delimiter character in CSV file.
   quote_char: \                         # Quote character in CSV file.
@@ -105,6 +119,11 @@ csv: # Here are default values. You can skip this section if you don't need to o
   encoding: utf-8                       # (Experimental) Only utf-8, utf-16, utf-32.
   bom: false                            # (Experimental) If the file has a BOM (Byte Order Mark) at the beginning.
 
+
+# Description of each column in CSV.
+# It is recommended to present each column in the same order as presented in the CSV file.
+# This will not affect the validator, but will make it easier for you to navigate.
+# For convenience, use the first line as a header (if possible).
 columns:
   - name: "Column Name (header)"        # Any custom name of the column in the CSV file (first row). Required if "csv_structure.header" is true.
     description: "Lorem ipsum"          # Description of the column. Not used in the validation process.
@@ -491,44 +510,32 @@ Default report format is `table`:
 
 <!-- output-table -->
 ```
-./csv-blueprint validate:csv --csv='./tests/fixtures/batch/*.csv' --schema='./tests/schemas/demo_invalid.yml'
+./csv-blueprint validate:csv --csv='./tests/fixtures/demo.csv' --schema='./tests/schemas/demo_invalid.yml'
 
 
 Schema: ./tests/schemas/demo_invalid.yml
-Found CSV files: 3
+Found CSV files: 1
 
-(1/3) Invalid file: ./tests/fixtures/batch/demo-1.csv
-+------+------------------+--------------+--------- demo-1.csv --------------------------------------------------+
-| Line | id:Column        | Rule         | Message                                                               |
-+------+------------------+--------------+-----------------------------------------------------------------------+
-| 1    | 1:City           | ag:is_unique | Column has non-unique values. Unique: 1, total: 2                     |
-| 3    | 4:Favorite color | allow_values | Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"] |
-+------+------------------+--------------+--------- demo-1.csv --------------------------------------------------+
-
-(2/3) Invalid file: ./tests/fixtures/batch/demo-2.csv
-+------+------------+------------+----------------- demo-2.csv --------------------------------------------------+
-| Line | id:Column  | Rule       | Message                                                                       |
-+------+------------+------------+-------------------------------------------------------------------------------+
-| 2    | 0:Name     | length_min | The length of the value "Carl" is 4, which is less than the expected "5"      |
-| 7    | 0:Name     | length_min | The length of the value "Lois" is 4, which is less than the expected "5"      |
-| 2    | 3:Birthday | date_min   | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", |
-|      |            |            | which is less than the expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"     |
-| 4    | 3:Birthday | date_min   | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", |
-|      |            |            | which is less than the expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"     |
-| 5    | 3:Birthday | date_max   | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", |
-|      |            |            | which is greater than the expected "2009-01-01 00:00:00 +00:00 (2009-01-01)"  |
-+------+------------+------------+----------------- demo-2.csv --------------------------------------------------+
-
-(3/3) Invalid file: ./tests/fixtures/batch/sub/demo-3.csv
-+------+-----------+------------------+------------ demo-3.csv --------------------------------------------------+
-| Line | id:Column | Rule             | Message                                                                  |
-+------+-----------+------------------+--------------------------------------------------------------------------+
-| 1    |           | filename_pattern | Filename "./tests/fixtures/batch/sub/demo-3.csv" does not match pattern: |
-|      |           |                  | "/demo-[12].csv$/i"                                                      |
-+------+-----------+------------------+------------ demo-3.csv --------------------------------------------------+
+(1/1) Invalid file: ./tests/fixtures/demo.csv
++------+------------------+------------------+----------------------- demo.csv ---------------------------------------------------------------------+
+| Line | id:Column        | Rule             | Message                                                                                              |
++------+------------------+------------------+------------------------------------------------------------------------------------------------------+
+| 1    |                  | filename_pattern | Filename "./tests/fixtures/demo.csv" does not match pattern: "/demo-[12].csv$/i"                     |
+| 6    | 0:Name           | length_min       | The length of the value "Carl" is 4, which is less than the expected "5"                             |
+| 11   | 0:Name           | length_min       | The length of the value "Lois" is 4, which is less than the expected "5"                             |
+| 1    | 1:City           | ag:is_unique     | Column has non-unique values. Unique: 9, total: 10                                                   |
+| 2    | 2:Float          | num_max          | The number of the value "4825.185", which is greater than the expected "4825.184"                    |
+| 6    | 3:Birthday       | date_min         | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
+|      |                  |                  | expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"                                                   |
+| 8    | 3:Birthday       | date_min         | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
+|      |                  |                  | expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"                                                   |
+| 9    | 3:Birthday       | date_max         | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", which is greater than  |
+|      |                  |                  | the expected "2009-01-01 00:00:00 +00:00 (2009-01-01)"                                               |
+| 5    | 4:Favorite color | allow_values     | Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"]                                |
++------+------------------+------------------+----------------------- demo.csv ---------------------------------------------------------------------+
 
 
-Found 8 issues in 3 out of 3 CSV files.
+Found 9 issues in CSV file.
 
 ```
 <!-- /output-table -->

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -1,4 +1,6 @@
 {
+    "name"             : "CSV Blueprint Schema Example",
+    "description"      : "This YAML file provides a detailed description and validation rules for CSV files\nto be processed by JBZoo\/Csv-Blueprint tool. It includes specifications for file name patterns,\nCSV formatting options, and extensive validation criteria for individual columns and their values,\nsupporting a wide range of data validation rules from basic type checks to complex regex validations.\nThis example serves as a comprehensive guide for creating robust CSV file validations.\n",
     "filename_pattern" : "\/demo(-\\d+)?\\.csv$\/i",
     "csv"              : {
         "header"     : true,

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -15,6 +15,13 @@
 declare(strict_types=1);
 
 return [
+    'name'        => 'CSV Blueprint Schema Example',
+    'description' => 'This YAML file provides a detailed description and validation rules for CSV files
+to be processed by JBZoo/Csv-Blueprint tool. It includes specifications for file name patterns,
+CSV formatting options, and extensive validation criteria for individual columns and their values,
+supporting a wide range of data validation rules from basic type checks to complex regex validations.
+This example serves as a comprehensive guide for creating robust CSV file validations.
+',
     'filename_pattern' => '/demo(-\\d+)?\\.csv$/i',
     'csv'              => [
         'header'     => true,

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -10,7 +10,18 @@
 # @see        https://github.com/JBZoo/Csv-Blueprint
 #
 
-# It's a full example of the CSV schema file in YAML format.
+# It's a complete example of the CSV schema file in YAML format.
+# See copy of the file without comments here ./schema-examples/full_clean.yml
+
+# Just meta
+name: CSV Blueprint Schema Example      # Name of a CSV file. Not used in the validation process.
+description: |                          # Any description of the CSV file. Not used in the validation process.
+  This YAML file provides a detailed description and validation rules for CSV files
+  to be processed by JBZoo/Csv-Blueprint tool. It includes specifications for file name patterns,
+  CSV formatting options, and extensive validation criteria for individual columns and their values,
+  supporting a wide range of data validation rules from basic type checks to complex regex validations.
+  This example serves as a comprehensive guide for creating robust CSV file validations.
+
 
 # Regular expression to match the file name. If not set, then no pattern check
 # This way you can validate the file name before the validation process.
@@ -18,7 +29,10 @@
 # See https://www.php.net/manual/en/reference.pcre.pattern.syntax.php
 filename_pattern: /demo(-\d+)?\.csv$/i
 
-csv: # Here are default values. You can skip this section if you don't need to override the default values
+
+# Here are default values to parse CSV file.
+# You can skip this section if you don't need to override the default values.
+csv:
   header: true                          # If the first row is a header. If true, name of each column is required.
   delimiter: ,                          # Delimiter character in CSV file.
   quote_char: \                         # Quote character in CSV file.
@@ -26,6 +40,11 @@ csv: # Here are default values. You can skip this section if you don't need to o
   encoding: utf-8                       # (Experimental) Only utf-8, utf-16, utf-32.
   bom: false                            # (Experimental) If the file has a BOM (Byte Order Mark) at the beginning.
 
+
+# Description of each column in CSV.
+# It is recommended to present each column in the same order as presented in the CSV file.
+# This will not affect the validator, but will make it easier for you to navigate.
+# For convenience, use the first line as a header (if possible).
 columns:
   - name: "Column Name (header)"        # Any custom name of the column in the CSV file (first row). Required if "csv_structure.header" is true.
     description: "Lorem ipsum"          # Description of the column. Not used in the validation process.

--- a/schema-examples/full_clean.yml
+++ b/schema-examples/full_clean.yml
@@ -1,0 +1,148 @@
+#
+# JBZoo Toolbox - Csv-Blueprint.
+#
+# This file is part of the JBZoo Toolbox project.
+# For the full copyright and license information, please view the LICENSE
+# file that was distributed with this source code.
+#
+# @license    MIT
+# @copyright  Copyright (C) JBZoo.com, All rights reserved.
+# @see        https://github.com/JBZoo/Csv-Blueprint
+#
+
+# It's a complete example of the CSV schema file in YAML format.
+# It's just a copy of ./schema-examples/full.yml without comments.
+
+name: CSV Blueprint Schema Example
+description: |
+  This YAML file provides a detailed description and validation rules for CSV files
+  to be processed by JBZoo/Csv-Blueprint tool. It includes specifications for file name patterns,
+  CSV formatting options, and extensive validation criteria for individual columns and their values,
+  supporting a wide range of data validation rules from basic type checks to complex regex validations.
+  This example serves as a comprehensive guide for creating robust CSV file validations.
+
+filename_pattern: /demo(-\d+)?\.csv$/i
+
+csv:
+  header: true
+  delimiter: ","
+  quote_char: "\\"
+  enclosure: "\""
+  encoding: utf-8
+  bom: false
+
+columns:
+  - name: "Column Name (header)"
+    description: "Lorem ipsum"
+    example: "Some example"
+    rules:
+      not_empty: true
+      exact_value: Some string
+      allow_values: [ y, n, "" ]
+      not_allow_values: [ invalid ]
+      regex: /^[\d]{2}$/
+      length: 5
+      length_not: 4
+      length_min: 1
+      length_max: 10
+      is_trimmed: true
+      is_lowercase: true
+      is_uppercase: true
+      is_capitalize: true
+      word_count: 5
+      word_count_not: 4
+      word_count_min: 1
+      word_count_max: 10
+      contains: Hello
+      contains_one: [ a, b ]
+      contains_all: [ a, b, c ]
+      starts_with: "prefix "
+      ends_with: " suffix"
+      num: 5
+      num_not: 4.123
+      num_min: 1.2e3
+      num_max: -10.123
+      is_int: true
+      is_float: true
+      precision: 5
+      precision_not: 4
+      precision_min: 1
+      precision_max: 10
+      date: 01 Jan 2000
+      date_not: 2006-01-02 15:04:05 -0700 Europe/Rome
+      date_min: +1 day
+      date_max: now
+      date_format: Y-m-d
+      is_date: true
+      is_bool: true
+      is_ip4: true
+      is_url: true
+      is_email: true
+      is_domain: true
+      is_uuid: true
+      is_alias: true
+      is_currency_code: true
+      is_base64: true
+      is_json: true
+      is_latitude: true
+      is_longitude: true
+      is_geohash: true
+      is_cardinal_direction: true
+      is_usa_market_name: true
+      country_code: alpha-2
+      language_code: alpha-2
+
+    aggregate_rules:
+      is_unique: true
+      sum: 5.123
+      sum_not: 4.123
+      sum_min: 1.123
+      sum_max: 10.123
+      average: 5.123
+      average_not: 4.123
+      average_min: 1.123
+      average_max: 10.123
+      count: 5
+      count_not: 4
+      count_min: 1
+      count_max: 10
+      count_empty: 5
+      count_empty_not: 4
+      count_empty_min: 1
+      count_empty_max: 10
+      count_not_empty: 5
+      count_not_empty_not: 4
+      count_not_empty_min: 1
+      count_not_empty_max: 10
+      median: 5.123
+      median_not: 4.123
+      median_min: 1.123
+      median_max: 10.123
+      population_variance: 5.123
+      population_variance_not: 4.123
+      population_variance_min: 1.123
+      population_variance_max: 10.123
+      sample_variance: 5.123
+      sample_variance_not: 4.123
+      sample_variance_min: 1.123
+      sample_variance_max: 10.123
+      sd_sample: 5.123
+      sd_sample_not: 4.123
+      sd_sample_min: 1.123
+      sd_sample_max: 10.123
+      sd_population: 5.123
+      sd_population_not: 4.123
+      sd_population_min: 1.123
+      sd_population_max: 10.123
+      coef_of_var: 5.123
+      coef_of_var_not: 4.123
+      coef_of_var_min: 1.123
+      coef_of_var_max: 10.123
+
+  - name: "another_column"
+    rules:
+      not_empty: true
+
+  - name: "third_column"
+    rules:
+      not_empty: true

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -150,7 +150,7 @@ final class Schema
 
         $errors = new ErrorSuite($this->filename);
 
-        $metaErrors = Utils::compareArray($expectedMeta, $actualMeta->getArrayCopy(), 'meta',  '.');
+        $metaErrors = Utils::compareArray($expectedMeta, $actualMeta->getArrayCopy(), 'meta', '.');
 
         // Validate meta info
         foreach ($metaErrors as $metaError) {

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -150,7 +150,7 @@ final class Schema
 
         $errors = new ErrorSuite($this->filename);
 
-        $metaErrors = Utils::compareArray($expectedMeta, $actualMeta->getArrayCopy(), 'meta');
+        $metaErrors = Utils::compareArray($expectedMeta, $actualMeta->getArrayCopy(), 'meta',  '.');
 
         // Validate meta info
         foreach ($metaErrors as $metaError) {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -148,7 +148,13 @@ final class Utils
             $curPath = $path === '' ? (string)$key : "{$path}.{$key}";
 
             if (!\array_key_exists($key, $expectedSchema)) {
-                $differences[$columnId . '/' . $curPath] = [$columnId, "Unknown key: {$keyPrefix}.{$curPath}"];
+                if (\strlen($keyPrefix) <= 1) {
+                    $message = "Unknown key: .{$curPath}";
+                } else {
+                    $message = "Unknown key: .{$keyPrefix}.{$curPath}";
+                }
+
+                $differences[$columnId . '/' . $curPath] = [$columnId, $message];
                 continue;
             }
 
@@ -159,7 +165,7 @@ final class Utils
                 $differences[$columnId . '/' . $curPath] = [
                     $columnId,
                     "Expected type \"<c>{$expectedType}</c>\", actual \"<green>{$actualType}</green>\" in " .
-                    "{$keyPrefix}.{$curPath}",
+                    ".{$keyPrefix}.{$curPath}",
                 ];
             } elseif (\is_array($value)) {
                 $differences += \array_merge(

--- a/src/Validators/ErrorSuite.php
+++ b/src/Validators/ErrorSuite.php
@@ -203,7 +203,7 @@ final class ErrorSuite
             'column'  => 30,
             'rule'    => 30,
             'min'     => 120,
-            'max'     => 150,
+            'max'     => 170,
             'reserve' => 3, // So that the table does not rest on the very edge of the terminal. Just in case.
         ];
 

--- a/tests/Commands/ValidateCsvTest.php
+++ b/tests/Commands/ValidateCsvTest.php
@@ -63,23 +63,22 @@ final class ValidateCsvTest extends TestCase
             Found CSV files: 1
             
             (1/1) Invalid file: ./tests/fixtures/demo.csv
-            +------+------------------+------------------+------------- demo.csv -----------------------------------------------------------+
-            | Line | id:Column        | Rule             | Message                                                                          |
-            +------+------------------+------------------+----------------------------------------------------------------------------------+
-            | 1    |                  | filename_pattern | Filename "./tests/fixtures/demo.csv" does not match pattern: "/demo-[12].csv$/i" |
-            | 6    | 0:Name           | length_min       | The length of the value "Carl" is 4, which is less than the expected "5"         |
-            | 11   | 0:Name           | length_min       | The length of the value "Lois" is 4, which is less than the expected "5"         |
-            | 1    | 1:City           | ag:is_unique     | Column has non-unique values. Unique: 9, total: 10                               |
-            | 2    | 2:Float          | num_max          | The number of the value "4825.185", which is greater than the expected           |
-            |      |                  |                  | "4825.184"                                                                       |
-            | 6    | 3:Birthday       | date_min         | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00",    |
-            |      |                  |                  | which is less than the expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"        |
-            | 8    | 3:Birthday       | date_min         | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00",    |
-            |      |                  |                  | which is less than the expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"        |
-            | 9    | 3:Birthday       | date_max         | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00",    |
-            |      |                  |                  | which is greater than the expected "2009-01-01 00:00:00 +00:00 (2009-01-01)"     |
-            | 5    | 4:Favorite color | allow_values     | Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"]            |
-            +------+------------------+------------------+------------- demo.csv -----------------------------------------------------------+
+            +------+------------------+------------------+----------------------- demo.csv ---------------------------------------------------------------------+
+            | Line | id:Column        | Rule             | Message                                                                                              |
+            +------+------------------+------------------+------------------------------------------------------------------------------------------------------+
+            | 1    |                  | filename_pattern | Filename "./tests/fixtures/demo.csv" does not match pattern: "/demo-[12].csv$/i"                     |
+            | 6    | 0:Name           | length_min       | The length of the value "Carl" is 4, which is less than the expected "5"                             |
+            | 11   | 0:Name           | length_min       | The length of the value "Lois" is 4, which is less than the expected "5"                             |
+            | 1    | 1:City           | ag:is_unique     | Column has non-unique values. Unique: 9, total: 10                                                   |
+            | 2    | 2:Float          | num_max          | The number of the value "4825.185", which is greater than the expected "4825.184"                    |
+            | 6    | 3:Birthday       | date_min         | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
+            |      |                  |                  | expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"                                                   |
+            | 8    | 3:Birthday       | date_min         | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
+            |      |                  |                  | expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"                                                   |
+            | 9    | 3:Birthday       | date_max         | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", which is greater than  |
+            |      |                  |                  | the expected "2009-01-01 00:00:00 +00:00 (2009-01-01)"                                               |
+            | 5    | 4:Favorite color | allow_values     | Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"]                                |
+            +------+------------------+------------------+----------------------- demo.csv ---------------------------------------------------------------------+
             
             
             Found 9 issues in CSV file.
@@ -112,26 +111,25 @@ final class ValidateCsvTest extends TestCase
             +------+------------------+--------------+--------- demo-1.csv --------------------------------------------------+
             
             (2/3) Invalid file: ./tests/fixtures/batch/demo-2.csv
-            +------+------------+------------+----------------- demo-2.csv --------------------------------------------------+
-            | Line | id:Column  | Rule       | Message                                                                       |
-            +------+------------+------------+-------------------------------------------------------------------------------+
-            | 2    | 0:Name     | length_min | The length of the value "Carl" is 4, which is less than the expected "5"      |
-            | 7    | 0:Name     | length_min | The length of the value "Lois" is 4, which is less than the expected "5"      |
-            | 2    | 3:Birthday | date_min   | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", |
-            |      |            |            | which is less than the expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"     |
-            | 4    | 3:Birthday | date_min   | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", |
-            |      |            |            | which is less than the expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"     |
-            | 5    | 3:Birthday | date_max   | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", |
-            |      |            |            | which is greater than the expected "2009-01-01 00:00:00 +00:00 (2009-01-01)"  |
-            +------+------------+------------+----------------- demo-2.csv --------------------------------------------------+
+            +------+------------+------------+---------------------------- demo-2.csv --------------------------------------------------------------+
+            | Line | id:Column  | Rule       | Message                                                                                              |
+            +------+------------+------------+------------------------------------------------------------------------------------------------------+
+            | 2    | 0:Name     | length_min | The length of the value "Carl" is 4, which is less than the expected "5"                             |
+            | 7    | 0:Name     | length_min | The length of the value "Lois" is 4, which is less than the expected "5"                             |
+            | 2    | 3:Birthday | date_min   | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
+            |      |            |            | expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"                                                   |
+            | 4    | 3:Birthday | date_min   | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
+            |      |            |            | expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"                                                   |
+            | 5    | 3:Birthday | date_max   | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", which is greater than  |
+            |      |            |            | the expected "2009-01-01 00:00:00 +00:00 (2009-01-01)"                                               |
+            +------+------------+------------+---------------------------- demo-2.csv --------------------------------------------------------------+
             
             (3/3) Invalid file: ./tests/fixtures/batch/sub/demo-3.csv
-            +------+-----------+------------------+------------ demo-3.csv --------------------------------------------------+
-            | Line | id:Column | Rule             | Message                                                                  |
-            +------+-----------+------------------+--------------------------------------------------------------------------+
-            | 1    |           | filename_pattern | Filename "./tests/fixtures/batch/sub/demo-3.csv" does not match pattern: |
-            |      |           |                  | "/demo-[12].csv$/i"                                                      |
-            +------+-----------+------------------+------------ demo-3.csv --------------------------------------------------+
+            +------+-----------+------------------+---------------------- demo-3.csv ------------------------------------------------------------+
+            | Line | id:Column | Rule             | Message                                                                                      |
+            +------+-----------+------------------+----------------------------------------------------------------------------------------------+
+            | 1    |           | filename_pattern | Filename "./tests/fixtures/batch/sub/demo-3.csv" does not match pattern: "/demo-[12].csv$/i" |
+            +------+-----------+------------------+---------------------- demo-3.csv ------------------------------------------------------------+
             
             
             Found 8 issues in 3 out of 3 CSV files.
@@ -390,63 +388,61 @@ final class ValidateCsvTest extends TestCase
             +-------+------------+--------+----------- invalid_schema.yml ------------------------------------------+
             | Line  | id:Column  | Rule   | Message                                                                 |
             +-------+------------+--------+-------------------------------------------------------------------------+
-            | undef | meta       | schema | Unknown key: .undefined-param_1                                         |
-            | undef | meta       | schema | Unknown key: .csv.undefined-param_2                                     |
-            | undef | 0:Name     | schema | Unknown key: columns.0.rules.undefined-param_3                          |
-            | undef | 1:City     | schema | Unknown key: columns.1.undefined-param_4                                |
-            | undef | 1:City     | schema | Unknown key: columns.1.aggregate_rules.undefined-param_5                |
-            | undef | 3:Birthday | schema | Expected type "string", actual "boolean" in columns.3.rules.date_max    |
+            | undef | meta       | schema | Unknown key: .unknow_root_option                                        |
+            | undef | meta       | schema | Unknown key: .csv.unknow_csv_param                                      |
+            | undef | 0:Name     | schema | Unknown key: .columns.0.rules.unknow_rule                               |
+            | undef | 1:City     | schema | Unknown key: .columns.1.unknow_colum_option                             |
+            | undef | 3:Birthday | schema | Expected type "string", actual "boolean" in .columns.3.rules.date_max   |
             | undef | 4:         | schema | The key "name" must be non-empty because the option "csv.header" = true |
-            | undef | 4:         | schema | Expected type "boolean", actual "string" in columns.4.rules.not_empty   |
-            | undef | 4:         | schema | Expected type "array", actual "string" in columns.4.rules.allow_values  |
+            | undef | 4:         | schema | Expected type "boolean", actual "string" in .columns.4.rules.not_empty  |
+            | undef | 4:         | schema | Expected type "array", actual "string" in .columns.4.rules.allow_values |
             +-------+------------+--------+----------- invalid_schema.yml ------------------------------------------+
             
             (1/1) Invalid file: ./tests/fixtures/demo.csv
-            +------+------------+------------------+---------------- demo.csv --------------------------------------------------------+
-            | Line | id:Column  | Rule             | Message                                                                          |
-            +------+------------+------------------+----------------------------------------------------------------------------------+
-            | 1    |            | filename_pattern | Filename "./tests/fixtures/demo.csv" does not match pattern: "/demo-[12].csv$/i" |
-            | 1    | 4:         | csv.header       | Property "name" is not defined in schema: "./tests/schemas/invalid_schema.yml"   |
-            | 6    | 0:Name     | length_min       | The length of the value "Carl" is 4, which is less than the expected "5"         |
-            | 11   | 0:Name     | length_min       | The length of the value "Lois" is 4, which is less than the expected "5"         |
-            | 1    | 1:City     | ag:is_unique     | Column has non-unique values. Unique: 9, total: 10                               |
-            | 2    | 2:Float    | num_max          | The number of the value "4825.185", which is greater than the expected           |
-            |      |            |                  | "4825.184"                                                                       |
-            | 2    | 3:Birthday | date_max         | The date of the value "2000-01-01" is parsed as "2000-01-01 00:00:00 +00:00",    |
-            |      |            |                  | which is greater than the expected "Can't parse date: 1"                         |
-            | 2    | 3:Birthday | allow_values     | Value "2000-01-01" is not allowed. Allowed values: ["red", "green", "Blue"]      |
-            | 3    | 3:Birthday | date_max         | The date of the value "2000-12-01" is parsed as "2000-12-01 00:00:00 +00:00",    |
-            |      |            |                  | which is greater than the expected "Can't parse date: 1"                         |
-            | 3    | 3:Birthday | allow_values     | Value "2000-12-01" is not allowed. Allowed values: ["red", "green", "Blue"]      |
-            | 4    | 3:Birthday | date_max         | The date of the value "2000-01-31" is parsed as "2000-01-31 00:00:00 +00:00",    |
-            |      |            |                  | which is greater than the expected "Can't parse date: 1"                         |
-            | 4    | 3:Birthday | allow_values     | Value "2000-01-31" is not allowed. Allowed values: ["red", "green", "Blue"]      |
-            | 5    | 3:Birthday | date_max         | The date of the value "1998-02-28" is parsed as "1998-02-28 00:00:00 +00:00",    |
-            |      |            |                  | which is greater than the expected "Can't parse date: 1"                         |
-            | 5    | 3:Birthday | allow_values     | Value "1998-02-28" is not allowed. Allowed values: ["red", "green", "Blue"]      |
-            | 6    | 3:Birthday | date_min         | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00",    |
-            |      |            |                  | which is less than the expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"        |
-            | 6    | 3:Birthday | allow_values     | Value "1955-05-14" is not allowed. Allowed values: ["red", "green", "Blue"]      |
-            | 7    | 3:Birthday | date_max         | The date of the value "1989-05-15" is parsed as "1989-05-15 00:00:00 +00:00",    |
-            |      |            |                  | which is greater than the expected "Can't parse date: 1"                         |
-            | 7    | 3:Birthday | allow_values     | Value "1989-05-15" is not allowed. Allowed values: ["red", "green", "Blue"]      |
-            | 8    | 3:Birthday | date_min         | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00",    |
-            |      |            |                  | which is less than the expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"        |
-            | 8    | 3:Birthday | allow_values     | Value "1955-05-14" is not allowed. Allowed values: ["red", "green", "Blue"]      |
-            | 9    | 3:Birthday | date_max         | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00",    |
-            |      |            |                  | which is greater than the expected "Can't parse date: 1"                         |
-            | 9    | 3:Birthday | allow_values     | Value "2010-07-20" is not allowed. Allowed values: ["red", "green", "Blue"]      |
-            | 10   | 3:Birthday | date_max         | The date of the value "1990-09-10" is parsed as "1990-09-10 00:00:00 +00:00",    |
-            |      |            |                  | which is greater than the expected "Can't parse date: 1"                         |
-            | 10   | 3:Birthday | allow_values     | Value "1990-09-10" is not allowed. Allowed values: ["red", "green", "Blue"]      |
-            | 11   | 3:Birthday | date_max         | The date of the value "1988-08-24" is parsed as "1988-08-24 00:00:00 +00:00",    |
-            |      |            |                  | which is greater than the expected "Can't parse date: 1"                         |
-            | 11   | 3:Birthday | allow_values     | Value "1988-08-24" is not allowed. Allowed values: ["red", "green", "Blue"]      |
-            +------+------------+------------------+---------------- demo.csv --------------------------------------------------------+
+            +------+------------+------------------+-------------------------- demo.csv ------------------------------------------------------------------+
+            | Line | id:Column  | Rule             | Message                                                                                              |
+            +------+------------+------------------+------------------------------------------------------------------------------------------------------+
+            | 1    |            | filename_pattern | Filename "./tests/fixtures/demo.csv" does not match pattern: "/demo-[12].csv$/i"                     |
+            | 1    | 4:         | csv.header       | Property "name" is not defined in schema: "./tests/schemas/invalid_schema.yml"                       |
+            | 6    | 0:Name     | length_min       | The length of the value "Carl" is 4, which is less than the expected "5"                             |
+            | 11   | 0:Name     | length_min       | The length of the value "Lois" is 4, which is less than the expected "5"                             |
+            | 1    | 1:City     | ag:is_unique     | Column has non-unique values. Unique: 9, total: 10                                                   |
+            | 2    | 2:Float    | num_max          | The number of the value "4825.185", which is greater than the expected "4825.184"                    |
+            | 2    | 3:Birthday | date_max         | The date of the value "2000-01-01" is parsed as "2000-01-01 00:00:00 +00:00", which is greater than  |
+            |      |            |                  | the expected "Can't parse date: 1"                                                                   |
+            | 2    | 3:Birthday | allow_values     | Value "2000-01-01" is not allowed. Allowed values: ["red", "green", "Blue"]                          |
+            | 3    | 3:Birthday | date_max         | The date of the value "2000-12-01" is parsed as "2000-12-01 00:00:00 +00:00", which is greater than  |
+            |      |            |                  | the expected "Can't parse date: 1"                                                                   |
+            | 3    | 3:Birthday | allow_values     | Value "2000-12-01" is not allowed. Allowed values: ["red", "green", "Blue"]                          |
+            | 4    | 3:Birthday | date_max         | The date of the value "2000-01-31" is parsed as "2000-01-31 00:00:00 +00:00", which is greater than  |
+            |      |            |                  | the expected "Can't parse date: 1"                                                                   |
+            | 4    | 3:Birthday | allow_values     | Value "2000-01-31" is not allowed. Allowed values: ["red", "green", "Blue"]                          |
+            | 5    | 3:Birthday | date_max         | The date of the value "1998-02-28" is parsed as "1998-02-28 00:00:00 +00:00", which is greater than  |
+            |      |            |                  | the expected "Can't parse date: 1"                                                                   |
+            | 5    | 3:Birthday | allow_values     | Value "1998-02-28" is not allowed. Allowed values: ["red", "green", "Blue"]                          |
+            | 6    | 3:Birthday | date_min         | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
+            |      |            |                  | expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"                                                   |
+            | 6    | 3:Birthday | allow_values     | Value "1955-05-14" is not allowed. Allowed values: ["red", "green", "Blue"]                          |
+            | 7    | 3:Birthday | date_max         | The date of the value "1989-05-15" is parsed as "1989-05-15 00:00:00 +00:00", which is greater than  |
+            |      |            |                  | the expected "Can't parse date: 1"                                                                   |
+            | 7    | 3:Birthday | allow_values     | Value "1989-05-15" is not allowed. Allowed values: ["red", "green", "Blue"]                          |
+            | 8    | 3:Birthday | date_min         | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
+            |      |            |                  | expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"                                                   |
+            | 8    | 3:Birthday | allow_values     | Value "1955-05-14" is not allowed. Allowed values: ["red", "green", "Blue"]                          |
+            | 9    | 3:Birthday | date_max         | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", which is greater than  |
+            |      |            |                  | the expected "Can't parse date: 1"                                                                   |
+            | 9    | 3:Birthday | allow_values     | Value "2010-07-20" is not allowed. Allowed values: ["red", "green", "Blue"]                          |
+            | 10   | 3:Birthday | date_max         | The date of the value "1990-09-10" is parsed as "1990-09-10 00:00:00 +00:00", which is greater than  |
+            |      |            |                  | the expected "Can't parse date: 1"                                                                   |
+            | 10   | 3:Birthday | allow_values     | Value "1990-09-10" is not allowed. Allowed values: ["red", "green", "Blue"]                          |
+            | 11   | 3:Birthday | date_max         | The date of the value "1988-08-24" is parsed as "1988-08-24 00:00:00 +00:00", which is greater than  |
+            |      |            |                  | the expected "Can't parse date: 1"                                                                   |
+            | 11   | 3:Birthday | allow_values     | Value "1988-08-24" is not allowed. Allowed values: ["red", "green", "Blue"]                          |
+            +------+------------+------------------+-------------------------- demo.csv ------------------------------------------------------------------+
             
-
+            
             Found 26 issues in CSV file.
-            Found 9 issues in schema.
+            Found 8 issues in schema.
             
             TXT;
 
@@ -471,19 +467,18 @@ final class ValidateCsvTest extends TestCase
             +-------+------------+--------+----------- invalid_schema.yml ------------------------------------------+
             | Line  | id:Column  | Rule   | Message                                                                 |
             +-------+------------+--------+-------------------------------------------------------------------------+
-            | undef | meta       | schema | Unknown key: .undefined-param_1                                         |
-            | undef | meta       | schema | Unknown key: .csv.undefined-param_2                                     |
-            | undef | 0:Name     | schema | Unknown key: columns.0.rules.undefined-param_3                          |
-            | undef | 1:City     | schema | Unknown key: columns.1.undefined-param_4                                |
-            | undef | 1:City     | schema | Unknown key: columns.1.aggregate_rules.undefined-param_5                |
-            | undef | 3:Birthday | schema | Expected type "string", actual "boolean" in columns.3.rules.date_max    |
+            | undef | meta       | schema | Unknown key: .unknow_root_option                                        |
+            | undef | meta       | schema | Unknown key: .csv.unknow_csv_param                                      |
+            | undef | 0:Name     | schema | Unknown key: .columns.0.rules.unknow_rule                               |
+            | undef | 1:City     | schema | Unknown key: .columns.1.unknow_colum_option                             |
+            | undef | 3:Birthday | schema | Expected type "string", actual "boolean" in .columns.3.rules.date_max   |
             | undef | 4:         | schema | The key "name" must be non-empty because the option "csv.header" = true |
-            | undef | 4:         | schema | Expected type "boolean", actual "string" in columns.4.rules.not_empty   |
-            | undef | 4:         | schema | Expected type "array", actual "string" in columns.4.rules.allow_values  |
+            | undef | 4:         | schema | Expected type "boolean", actual "string" in .columns.4.rules.not_empty  |
+            | undef | 4:         | schema | Expected type "array", actual "string" in .columns.4.rules.allow_values |
             +-------+------------+--------+----------- invalid_schema.yml ------------------------------------------+
             
             
-            Found 9 issues in schema.
+            Found 8 issues in schema.
             
             TXT;
 

--- a/tests/ExampleSchemasTest.php
+++ b/tests/ExampleSchemasTest.php
@@ -28,7 +28,7 @@ final class ExampleSchemasTest extends TestCase
 {
     public function testFullListOfRules(): void
     {
-        $rulesInConfig = yml(Tools::SCHEMA_FULL)->findArray('columns.0.rules');
+        $rulesInConfig = yml(Tools::SCHEMA_FULL_YML)->findArray('columns.0.rules');
         $rulesInConfig = \array_keys($rulesInConfig);
         \sort($rulesInConfig, \SORT_NATURAL);
 
@@ -82,7 +82,7 @@ final class ExampleSchemasTest extends TestCase
 
     public function testCsvStrutureDefaultValues(): void
     {
-        $defaultsInDoc = yml(Tools::SCHEMA_FULL)->findArray('csv');
+        $defaultsInDoc = yml(Tools::SCHEMA_FULL_YML)->findArray('csv');
 
         $schema = new Schema([]);
         $schema->getCsvStructure()->getArrayCopy();
@@ -93,22 +93,30 @@ final class ExampleSchemasTest extends TestCase
     public function testCheckPhpExample(): void
     {
         $basepath = PROJECT_ROOT . '/schema-examples/full';
-        $origYml  = yml(Tools::SCHEMA_FULL)->getArrayCopy();
+        $origYml  = yml(Tools::SCHEMA_FULL_YML)->getArrayCopy();
 
-        isSame((string)phpArray(Tools::SCHEMA_FULL_PHP), (string)phpArray($origYml), 'PHP config is invalid');
+        isSame((string)phpArray(Tools::SCHEMA_FULL_PHP), (string)phpArray($origYml), 'PHP config');
+    }
+
+    public function testCheckYmlCleanExample(): void
+    {
+        $basepath = PROJECT_ROOT . '/schema-examples/full';
+        $origYml  = yml(Tools::SCHEMA_FULL_YML)->getArrayCopy();
+
+        isSame((string)yml(Tools::SCHEMA_FULL_YML_CLEAN), (string)yml($origYml), 'Yml (clean) config');
     }
 
     public function testCheckJsonExample(): void
     {
         $basepath = PROJECT_ROOT . '/schema-examples/full';
-        $origYml  = yml(Tools::SCHEMA_FULL)->getArrayCopy();
+        $origYml  = yml(Tools::SCHEMA_FULL_YML)->getArrayCopy();
 
-        isSame((string)json(Tools::SCHEMA_FULL_JSON), (string)json($origYml), 'JSON config is invalid');
+        isSame((string)json(Tools::SCHEMA_FULL_JSON), (string)json($origYml), 'JSON config');
     }
 
     public function testUniqueNameOfRules(): void
     {
-        $yml = yml(Tools::SCHEMA_FULL);
+        $yml = yml(Tools::SCHEMA_FULL_YML);
 
         $rules     = \array_keys($yml->findArray('columns.0.rules'));
         $agRules   = \array_keys($yml->findArray('columns.0.aggregate_rules'));
@@ -119,7 +127,7 @@ final class ExampleSchemasTest extends TestCase
 
     public function testRuleNaming(): void
     {
-        $yml = yml(Tools::SCHEMA_FULL);
+        $yml = yml(Tools::SCHEMA_FULL_YML);
 
         $rules = $yml->findArray('columns.0.rules');
 

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -40,7 +40,7 @@ final class ReadmeTest extends TestCase
     public function testTableOutputExample(): void
     {
         $options = [
-            'csv'    => './tests/fixtures/batch/*.csv',
+            'csv'    => './tests/fixtures/demo.csv',
             'schema' => './tests/schemas/demo_invalid.yml',
         ];
         $optionsAsString     = new StringInput(Cli::build('', $options));
@@ -62,8 +62,8 @@ final class ReadmeTest extends TestCase
 
     public function testBadgeOfRules(): void
     {
-        $cellRules  = \count(yml(Tools::SCHEMA_FULL)->findArray('columns.0.rules'));
-        $aggRules   = \count(yml(Tools::SCHEMA_FULL)->findArray('columns.0.aggregate_rules'));
+        $cellRules  = \count(yml(Tools::SCHEMA_FULL_YML)->findArray('columns.0.rules'));
+        $aggRules   = \count(yml(Tools::SCHEMA_FULL_YML)->findArray('columns.0.aggregate_rules'));
         $totalRules = $cellRules + $aggRules;
 
         $badge = static function (string $label, int $count): string {
@@ -86,7 +86,7 @@ final class ReadmeTest extends TestCase
     {
         $ymlContent = \implode(
             "\n",
-            \array_slice(\explode("\n", \file_get_contents(Tools::SCHEMA_FULL)), 12),
+            \array_slice(\explode("\n", \file_get_contents(Tools::SCHEMA_FULL_YML)), 12),
         );
 
         $text = \implode("\n", ['```yml', $ymlContent, '```']);

--- a/tests/Rules/AbstractAggregateRule.php
+++ b/tests/Rules/AbstractAggregateRule.php
@@ -39,7 +39,7 @@ abstract class AbstractAggregateRule extends TestCase
 
     public function testHelpMessageInExample(): void
     {
-        isFileContains($this->create(6)->getHelp(), Tools::SCHEMA_FULL);
+        isFileContains($this->create(6)->getHelp(), Tools::SCHEMA_FULL_YML);
     }
 
     public function testBoolenOptionFlag(): void

--- a/tests/Rules/AbstractAggregateRuleCombo.php
+++ b/tests/Rules/AbstractAggregateRuleCombo.php
@@ -41,7 +41,7 @@ abstract class AbstractAggregateRuleCombo extends TestCase
 
     public function testHelpMessageInExample(): void
     {
-        isFileContains($this->create(6, Combo::MAX)->getHelp(), Tools::SCHEMA_FULL);
+        isFileContains($this->create(6, Combo::MAX)->getHelp(), Tools::SCHEMA_FULL_YML);
     }
 
     public function testBoolenOptionFlag(): void

--- a/tests/Rules/AbstractCellRule.php
+++ b/tests/Rules/AbstractCellRule.php
@@ -39,7 +39,7 @@ abstract class AbstractCellRule extends TestCase
 
     public function testHelpMessageInExample(): void
     {
-        isFileContains($this->create(6)->getHelp(), Tools::SCHEMA_FULL);
+        isFileContains($this->create(6)->getHelp(), Tools::SCHEMA_FULL_YML);
     }
 
     public function testBoolenOptionFlag(): void

--- a/tests/Rules/AbstractCellRuleCombo.php
+++ b/tests/Rules/AbstractCellRuleCombo.php
@@ -40,7 +40,7 @@ abstract class AbstractCellRuleCombo extends TestCase
 
     public function testHelpMessageInExample(): void
     {
-        isFileContains($this->create(6, Combo::MAX)->getHelp(), Tools::SCHEMA_FULL);
+        isFileContains($this->create(6, Combo::MAX)->getHelp(), Tools::SCHEMA_FULL_YML);
     }
 
     protected function create(array|float|int|string $value, string $mode): Combo

--- a/tests/Tools.php
+++ b/tests/Tools.php
@@ -35,10 +35,11 @@ final class Tools
     public const SCHEMA_SIMPLE_HEADER_JSON = './tests/schemas/simple_header.json';
     public const SCHEMA_EXAMPLE_EMPTY      = './tests/schemas/example_empty.yml';
 
-    public const SCHEMA_FULL      = './schema-examples/full.yml';
-    public const SCHEMA_FULL_JSON = './schema-examples/full.json';
-    public const SCHEMA_FULL_PHP  = './schema-examples/full.php';
-    public const SCHEMA_INVALID   = './tests/schemas/invalid_schema.yml';
+    public const SCHEMA_FULL_YML       = './schema-examples/full.yml';
+    public const SCHEMA_FULL_YML_CLEAN = './schema-examples/full_clean.yml';
+    public const SCHEMA_FULL_JSON      = './schema-examples/full.json';
+    public const SCHEMA_FULL_PHP       = './schema-examples/full.php';
+    public const SCHEMA_INVALID        = './tests/schemas/invalid_schema.yml';
 
     public const DEMO_YML_VALID   = './tests/schemas/demo_valid.yml';
     public const DEMO_YML_INVALID = './tests/schemas/demo_invalid.yml';

--- a/tests/schemas/invalid_schema.yml
+++ b/tests/schemas/invalid_schema.yml
@@ -14,10 +14,10 @@
 
 filename_pattern: /demo-[12].csv$/i
 
-undefined-param_1: true
+unknow_root_option: true
 
 csv:
-  undefined-param_2: true
+  unknow_csv_param: true
 
 columns:
   - name: Name
@@ -25,16 +25,15 @@ columns:
       not_empty: true
       length_min: 5
       length_max: 7
-      undefined-param_3: true
+      unknow_rule: true
 
   - name: City
-    undefined-param_4: true
+    unknow_colum_option: true
     rules:
       not_empty: true
       is_capitalize: true
     aggregate_rules:
       is_unique: true
-      undefined-param_5: true
 
   - name: Float
     rules:


### PR DESCRIPTION
Updated JSON, PHP, and YAML schema examples to include a detailed description and name metadata. Also added a `full_clean.yml` file with the comment lines removed. Updated the `ErrorSuite.php`, `Schema.php`, `Utils.php`, `ValidateCsvTest.php` classes to reflect these changes.