### PR TITLE
Add test cases and handle exceptions for undefined rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ It's random ideas and plans. No orderings and deadlines. <u>But batch processing
   * [More aggregate rules](https://github.com/markrogoyski/math-php#statistics---descriptive).
   * [More cell rules](https://github.com/Respect/Validation).
   * `required` flag for the column.
+  * Multi values in one cell.
   * Custom cell rule as a callback. It's useful when you have a complex rule that can't be described in the schema file.
   * Custom agregate rule as a callback. It's useful when you have a complex rule that can't be described in the schema file.
   * Configurable keyword for null/empty values. By default, it's an empty string. But you will use `null`, `nil`, `none`, `empty`, etc. Overridable on the column level.
@@ -594,6 +595,7 @@ It's random ideas and plans. No orderings and deadlines. <u>But batch processing
 * **Mock data generation**
   * Create CSV files based on the schema (like "create 1000 rows with random data based on schema and rules").
   * Use [Faker](https://github.com/FakerPHP/Faker) for random data generation.
+  * [ReverseRegex](https://github.com/enso-media/ReverseRegex) to generate text from regex.
 
 * **Reporting**
   * More report formats (like JSON, XML, etc). Any ideas?

--- a/tests/Commands/ValidateCsvTest.php
+++ b/tests/Commands/ValidateCsvTest.php
@@ -485,4 +485,13 @@ final class ValidateCsvTest extends TestCase
         isSame(1, $exitCode, $actual);
         isSame($expected, $actual);
     }
+
+    public function testSchemaNotFound(): void
+    {
+        $this->expectExceptionMessage('Schema file not found: invalid_schema_path.yml');
+        Tools::virtualExecution('validate:csv', [
+            'csv'    => './tests/fixtures/no-found-file.csv',
+            'schema' => 'invalid_schema_path.yml',
+        ]);
+    }
 }

--- a/tests/Rules/Cell/AllowValuesTest.php
+++ b/tests/Rules/Cell/AllowValuesTest.php
@@ -42,9 +42,14 @@ final class AllowValuesTest extends AbstractCellRule
     public function testNegative(): void
     {
         $rule = $this->create(['1', '2', '3']);
-
         isSame(
             'Value "invalid" is not allowed. Allowed values: ["1", "2", "3"]',
+            $rule->test('invalid'),
+        );
+
+        $rule = $this->create([]);
+        isSame(
+            'Allowed values are not defined',
             $rule->test('invalid'),
         );
     }

--- a/tests/Rules/Cell/DateFormatTest.php
+++ b/tests/Rules/Cell/DateFormatTest.php
@@ -43,5 +43,11 @@ final class DateFormatTest extends AbstractCellRule
             'Date format of value "2000-01-02 12:34:56" is not valid. Expected format: "Y-m-d"',
             $rule->test('2000-01-02 12:34:56'),
         );
+
+        $rule = $this->create('');
+        isSame(
+            'Date format is not defined',
+            $rule->test('12'),
+        );
     }
 }

--- a/tests/Rules/Cell/IsTrimmedTest.php
+++ b/tests/Rules/Cell/IsTrimmedTest.php
@@ -16,34 +16,28 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Cell;
 
-use JBZoo\CsvBlueprint\Rules\Cell\StartsWith;
+use JBZoo\CsvBlueprint\Rules\Cell\IsJson;
+use JBZoo\CsvBlueprint\Rules\Cell\IsTrimmed;
 use JBZoo\PHPUnit\Rules\AbstractCellRule;
 
 use function JBZoo\PHPUnit\isSame;
 
-final class StratsWithTest extends AbstractCellRule
+final class IsTrimmedTest extends AbstractCellRule
 {
-    protected string $ruleClass = StartsWith::class;
+    protected string $ruleClass = IsTrimmed::class;
 
     public function testPositive(): void
     {
-        $rule = $this->create('a');
-        isSame(null, $rule->validate(''));
-        isSame('', $rule->test('a'));
-        isSame('', $rule->test('abc'));
-        isSame(null, $rule->validate(''));
-
-        $rule = $this->create('a');
+        $rule = $this->create(true);
         isSame('', $rule->test(''));
+        isSame('', $rule->test('Hello world!'));
     }
 
     public function testNegative(): void
     {
-        $rule = $this->create('a');
-
-        isSame('Value " a" must start with "a"',$rule->test(' a'));
-
-        $rule = $this->create('');
-        isSame('Rule must contain a prefix value in schema file.', $rule->test('a '));
+        $rule = $this->create(true);
+        isSame('Value "Hello world! " is not trimmed', $rule->test('Hello world! '));
+        isSame('Value " Hello world!" is not trimmed', $rule->test(' Hello world!'));
+        isSame('Value " Hello world! " is not trimmed', $rule->test(' Hello world! '));
     }
 }

--- a/tests/Rules/Cell/IsTrimmedTest.php
+++ b/tests/Rules/Cell/IsTrimmedTest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Cell;
 
-use JBZoo\CsvBlueprint\Rules\Cell\IsJson;
 use JBZoo\CsvBlueprint\Rules\Cell\IsTrimmed;
 use JBZoo\PHPUnit\Rules\AbstractCellRule;
 

--- a/tests/Rules/Cell/NotAllowValuesTest.php
+++ b/tests/Rules/Cell/NotAllowValuesTest.php
@@ -40,16 +40,11 @@ final class NotAllowValuesTest extends AbstractCellRule
     public function testNegative(): void
     {
         $rule = $this->create(['invalid', ' ']);
+        isSame('Value "invalid" is not allowed', $rule->test('invalid'));
+        isSame('Value " " is not allowed', $rule->test(' '));
 
-        isSame(
-            'Value "invalid" is not allowed',
-            $rule->test('invalid'),
-        );
-
-        isSame(
-            'Value " " is not allowed',
-            $rule->test(' '),
-        );
+        $rule = $this->create([]);
+        isSame('Not allowed values are not defined', $rule->test('invalid'));
     }
 
     public function testInvalidOption(): void

--- a/tests/Rules/Cell/RegexTest.php
+++ b/tests/Rules/Cell/RegexTest.php
@@ -43,15 +43,12 @@ final class RegexTest extends AbstractCellRule
     public function testNegative(): void
     {
         $rule = $this->create('/^a/');
-        isSame(
-            'Value "1bc" does not match the pattern "/^a/"',
-            $rule->test('1bc'),
-        );
+        isSame('Value "1bc" does not match the pattern "/^a/"', $rule->test('1bc'));
 
         $rule = $this->create('^a');
-        isSame(
-            'Value "1bc" does not match the pattern "/^a/"',
-            $rule->test('1bc'),
-        );
+        isSame('Value "1bc" does not match the pattern "/^a/"', $rule->test('1bc'));
+
+        $rule = $this->create('');
+        isSame('Regex pattern is not defined', $rule->test('1bc'));
     }
 }

--- a/tests/Rules/Cell/StratsWithTest.php
+++ b/tests/Rules/Cell/StratsWithTest.php
@@ -41,7 +41,7 @@ final class StratsWithTest extends AbstractCellRule
     {
         $rule = $this->create('a');
 
-        isSame('Value " a" must start with "a"',$rule->test(' a'));
+        isSame('Value " a" must start with "a"', $rule->test(' a'));
 
         $rule = $this->create('');
         isSame('Rule must contain a prefix value in schema file.', $rule->test('a '));

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -51,6 +51,7 @@ final class UtilsTest extends TestCase
         ])));
 
         isSame([], $this->getFileName(Utils::findFiles([])));
+        isSame([], $this->getFileName(Utils::findFiles([''])));
 
         $this->getFileName(Utils::findFiles(['*.qwerty']));
 


### PR DESCRIPTION
Added additional tests for when schema file not found and when certain rules are left undefined. These tests cover cases for allowed values, date formats, disallowed values, and regex pattern. Furthermore, a new rule for checking whether a cell data is trimmed was introduced. Also fixed some formatting errors and updated the README file.