### PR TITLE
Update SchemaValidator to cast example to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,11 +517,12 @@ Schema: ./tests/schemas/demo_invalid.yml
 Found CSV files: 1
 
 Schema is invalid: ./tests/schemas/demo_invalid.yml
-+-------+-----------+----- demo_invalid.yml --------------------------+
-| Line  | id:Column | Rule     | Message                              |
-+-------+-----------+----------+--------------------------------------+
-| undef | 2:Float   | is_float | Value "Qwerty" is not a float number |
-+-------+-----------+----- demo_invalid.yml --------------------------+
++-------+------------------+--------------+----- demo_invalid.yml -----------------------------------------------+
+| Line  | id:Column        | Rule         | Message                                                              |
++-------+------------------+--------------+----------------------------------------------------------------------+
+| undef | 2:Float          | is_float     | Value "Qwerty" is not a float number                                 |
+| undef | 4:Favorite color | allow_values | Value "123" is not allowed. Allowed values: ["red", "green", "Blue"] |
++-------+------------------+--------------+----- demo_invalid.yml -----------------------------------------------+
 
 (1/1) Invalid file: ./tests/fixtures/demo.csv
 +------+------------------+------------------+----------------------- demo.csv ---------------------------------------------------------------------+
@@ -543,7 +544,7 @@ Schema is invalid: ./tests/schemas/demo_invalid.yml
 
 
 Found 9 issues in CSV file.
-Found 1 issues in schema.
+Found 2 issues in schema.
 
 ```
 <!-- /output-table -->

--- a/src/Validators/SchemaValidator.php
+++ b/src/Validators/SchemaValidator.php
@@ -107,7 +107,7 @@ final class SchemaValidator
         ];
 
         if (isset($actualColumn['example']) && !\in_array($actualColumn['example'], $exclude, true)) {
-            return (new Column($columnKey, $actualColumn))->validateCell($actualColumn['example']);
+            return (new Column($columnKey, $actualColumn))->validateCell((string)$actualColumn['example']);
         }
 
         return null;

--- a/tests/Commands/ValidateCsvTest.php
+++ b/tests/Commands/ValidateCsvTest.php
@@ -63,11 +63,12 @@ final class ValidateCsvTest extends TestCase
             Found CSV files: 1
             
             Schema is invalid: ./tests/schemas/demo_invalid.yml
-            +-------+-----------+----- demo_invalid.yml --------------------------+
-            | Line  | id:Column | Rule     | Message                              |
-            +-------+-----------+----------+--------------------------------------+
-            | undef | 2:Float   | is_float | Value "Qwerty" is not a float number |
-            +-------+-----------+----- demo_invalid.yml --------------------------+
+            +-------+------------------+--------------+----- demo_invalid.yml -----------------------------------------------+
+            | Line  | id:Column        | Rule         | Message                                                              |
+            +-------+------------------+--------------+----------------------------------------------------------------------+
+            | undef | 2:Float          | is_float     | Value "Qwerty" is not a float number                                 |
+            | undef | 4:Favorite color | allow_values | Value "123" is not allowed. Allowed values: ["red", "green", "Blue"] |
+            +-------+------------------+--------------+----- demo_invalid.yml -----------------------------------------------+
             
             (1/1) Invalid file: ./tests/fixtures/demo.csv
             +------+------------------+------------------+----------------------- demo.csv ---------------------------------------------------------------------+
@@ -89,7 +90,7 @@ final class ValidateCsvTest extends TestCase
             
             
             Found 9 issues in CSV file.
-            Found 1 issues in schema.
+            Found 2 issues in schema.
             
             TXT;
 
@@ -111,11 +112,12 @@ final class ValidateCsvTest extends TestCase
             Found CSV files: 3
             
             Schema is invalid: ./tests/schemas/demo_invalid.yml
-            +-------+-----------+----- demo_invalid.yml --------------------------+
-            | Line  | id:Column | Rule     | Message                              |
-            +-------+-----------+----------+--------------------------------------+
-            | undef | 2:Float   | is_float | Value "Qwerty" is not a float number |
-            +-------+-----------+----- demo_invalid.yml --------------------------+
+            +-------+------------------+--------------+----- demo_invalid.yml -----------------------------------------------+
+            | Line  | id:Column        | Rule         | Message                                                              |
+            +-------+------------------+--------------+----------------------------------------------------------------------+
+            | undef | 2:Float          | is_float     | Value "Qwerty" is not a float number                                 |
+            | undef | 4:Favorite color | allow_values | Value "123" is not allowed. Allowed values: ["red", "green", "Blue"] |
+            +-------+------------------+--------------+----- demo_invalid.yml -----------------------------------------------+
             
             (1/3) Invalid file: ./tests/fixtures/batch/demo-1.csv
             +------+------------------+--------------+--------- demo-1.csv --------------------------------------------------+
@@ -148,7 +150,7 @@ final class ValidateCsvTest extends TestCase
             
             
             Found 8 issues in 3 out of 3 CSV files.
-            Found 1 issues in schema.
+            Found 2 issues in schema.
             
             TXT;
 
@@ -170,6 +172,7 @@ final class ValidateCsvTest extends TestCase
             
             Schema is invalid: ./tests/schemas/demo_invalid.yml
             "is_float", column "2:Float". Value "Qwerty" is not a float number.
+            "allow_values", column "4:Favorite color". Value "123" is not allowed. Allowed values: ["red", "green", "Blue"].
             
             (1/1) Invalid file: ./tests/fixtures/demo.csv
             "filename_pattern" at line 1, column "". Filename "./tests/fixtures/demo.csv" does not match pattern: "/demo-[12].csv$/i".
@@ -184,7 +187,7 @@ final class ValidateCsvTest extends TestCase
             
             
             Found 9 issues in CSV file.
-            Found 1 issues in schema.
+            Found 2 issues in schema.
             
             TXT;
 
@@ -200,6 +203,7 @@ final class ValidateCsvTest extends TestCase
             
             Schema is invalid: ./tests/schemas/demo_invalid.yml
             "is_float", column "2:Float". Value "Qwerty" is not a float number.
+            "allow_values", column "4:Favorite color". Value "123" is not allowed. Allowed values: ["red", "green", "Blue"].
             
             (1/3) Invalid file: ./tests/fixtures/batch/demo-1.csv
             "ag:is_unique" at line 1, column "1:City". Column has non-unique values. Unique: 1, total: 2.
@@ -208,7 +212,7 @@ final class ValidateCsvTest extends TestCase
             (3/3) Skipped: ./tests/fixtures/batch/sub/demo-3.csv
             
             Found 1 issues in 1 out of 3 CSV files.
-            Found 1 issues in schema.
+            Found 2 issues in schema.
             
             TXT;
 
@@ -267,6 +271,7 @@ final class ValidateCsvTest extends TestCase
             
             Schema is invalid: ./tests/schemas/demo_invalid.yml
             "is_float", column "2:Float". Value "Qwerty" is not a float number.
+            "allow_values", column "4:Favorite color". Value "123" is not allowed. Allowed values: ["red", "green", "Blue"].
             
             (1/3) Invalid file: ./tests/fixtures/batch/demo-1.csv
             "ag:is_unique" at line 1, column "1:City". Column has non-unique values. Unique: 1, total: 2.
@@ -284,7 +289,7 @@ final class ValidateCsvTest extends TestCase
             
             
             Found 8 issues in 3 out of 3 CSV files.
-            Found 1 issues in schema.
+            Found 2 issues in schema.
             
             TXT;
 
@@ -308,13 +313,17 @@ final class ValidateCsvTest extends TestCase
             
             Schema is invalid: ./tests/schemas/demo_invalid.yml
             
-            ##teamcity[testCount count='1' flowId='42']
+            ##teamcity[testCount count='2' flowId='42']
             
             ##teamcity[testSuiteStarted name='demo_invalid.yml' flowId='42']
             
             ##teamcity[testStarted name='is_float at column 2:Float' locationHint='php_qn://./tests/schemas/demo_invalid.yml' flowId='42']
             "is_float", column "2:Float". Value "Qwerty" is not a float number.
             ##teamcity[testFinished name='is_float at column 2:Float' flowId='42']
+            
+            ##teamcity[testStarted name='allow_values at column 4:Favorite color' locationHint='php_qn://./tests/schemas/demo_invalid.yml' flowId='42']
+            "allow_values", column "4:Favorite color". Value "123" is not allowed. Allowed values: ["red", "green", "Blue"].
+            ##teamcity[testFinished name='allow_values at column 4:Favorite color' flowId='42']
             
             ##teamcity[testSuiteFinished name='demo_invalid.yml' flowId='42']
             
@@ -376,7 +385,7 @@ final class ValidateCsvTest extends TestCase
             
             
             Found 8 issues in 3 out of 3 CSV files.
-            Found 1 issues in schema.
+            Found 2 issues in schema.
             
             TXT;
 

--- a/tests/schemas/demo_invalid.yml
+++ b/tests/schemas/demo_invalid.yml
@@ -44,6 +44,7 @@ columns:
       date_max: "2009-01-01"
 
   - name: Favorite color
+    example: 123
     rules:
       not_empty: true
       allow_values: [ red, green, Blue ]


### PR DESCRIPTION
This commit modifies the SchemaValidator code, ensuring that values used for examples are cast as strings before validation. This change addresses potential issues with non-string values, improving the robustness and accuracy of the schema validation process. Updates have also been made to the associated tests and documentation.