### PR TITLE
Update error message output in ValidateCsv. StdErr to StdOut

### DIFF
--- a/src/Commands/ValidateCsv.php
+++ b/src/Commands/ValidateCsv.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace JBZoo\CsvBlueprint\Commands;
 
 use JBZoo\Cli\CliCommand;
-use JBZoo\Cli\OutLvl;
 use JBZoo\CsvBlueprint\Csv\CsvFile;
 use JBZoo\CsvBlueprint\Exception;
 use JBZoo\CsvBlueprint\Schema;
@@ -199,15 +198,12 @@ final class ValidateCsv extends CliCommand
                 $errorCounter += $errorSuite->count();
 
                 if ($this->isHumanReadableMode()) {
-                    $this->_(
-                        "{$prefix} <red>Invalid file:</red> " . Utils::cutPath($csvFilename->getPathname()),
-                        OutLvl::E,
-                    );
+                    $this->_("{$prefix} <red>Invalid file:</red> " . Utils::cutPath($csvFilename->getPathname()));
                 }
 
                 $output = $errorSuite->render($this->getOptString('report'));
                 if ($output !== null) {
-                    $this->_($output, $this->isHumanReadableMode() ? OutLvl::E : OutLvl::DEFAULT);
+                    $this->_($output);
                 }
             } elseif ($this->isHumanReadableMode()) {
                 $this->_("{$prefix} <green>OK:</green> " . Utils::cutPath($csvFilename->getPathname()));

--- a/src/Commands/ValidateCsv.php
+++ b/src/Commands/ValidateCsv.php
@@ -168,7 +168,7 @@ final class ValidateCsv extends CliCommand
             $schemaErrors = (new Schema($schemaFilename))->validate();
             if ($schemaErrors->count() > 0) {
                 $this->_("<red>Schema is invalid:</red> {$schemaFilename}");
-                $this->_($schemaErrors->render($this->getReportType()), OutLvl::E);
+                $this->_($schemaErrors->render($this->getReportType()));
             }
         }
 
@@ -241,7 +241,7 @@ final class ValidateCsv extends CliCommand
                 $errMessage = "<c>Found {$errorCounter} issues in {$invalidFiles} out of {$totalFiles} CSV files.</c>";
             }
 
-            $this->_($errMessage, OutLvl::E);
+            $this->_($errMessage);
 
             $exitCode = self::FAILURE;
         }


### PR DESCRIPTION
Error message outputs have been updated in ValidateCsv class for better readability and debugging. The method `OutLvl::E` has been removed from `this->_()` function to streamline the message output, improving the error message display.