### PR TITLE
GitHub actions. New default value: table

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ You can find launch examples in the [workflow demo](https://github.com/JBZoo/Csv
 ```
 <!-- /github-actions-yml -->
 
-**Note**. GitHub Actions report format is `github` by default. See [GitHub Actions friendly](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-warning-message) and [PR as a live demo](https://github.com/JBZoo/Csv-Blueprint-Demo/pull/1/files). 
+**Note**. GitHub Actions report format is `table` by default. See [GitHub Actions friendly](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-warning-message) and [PR as a live demo](https://github.com/JBZoo/Csv-Blueprint-Demo/pull/1/files). 
 
 This allows you to see bugs in the GitHub interface at the PR level.
 That is, the error will be shown in a specific place in the CSV file right in diff of your Pull Requests! [See example](https://github.com/JBZoo/Csv-Blueprint-Demo/pull/1/files).
@@ -586,7 +586,7 @@ Optional format `text` with highlited keywords:
 
 
 **Notes**
-* Report format for GitHub Actions is `github` by default.
+* Report format for GitHub Actions is `table` by default.
 * Tools uses [JBZoo/CI-Report-Converter](https://github.com/JBZoo/CI-Report-Converter) as SDK to convert reports to different formats. So you can easily integrate it with any CI system.
 
 

--- a/README.md
+++ b/README.md
@@ -387,10 +387,10 @@ You can find launch examples in the [workflow demo](https://github.com/JBZoo/Csv
     # Required: true
     schema: ./tests/schema.yml
 
-    # Report format. Available options: text, table, github, gitlab, teamcity, junit
-    # Default value: github
+    # Report format. Available options: text, table, github, gitlab, teamcity, junit.
+    # Default value: table
     # You can skip it
-    report: github
+    report: table
 
     # Quick mode. It will not validate all rows. It will stop after the first error.
     # Default value: no

--- a/action.yml
+++ b/action.yml
@@ -29,8 +29,8 @@ inputs:
     description: 'Schema filepath. It can be a YAML, JSON or PHP. See examples on GitHub.'
     required: true
   report:
-    description: 'Report format. Available options: text, table, github, gitlab, teamcity, junit'
-    default: github
+    description: 'Report format. Available options: text, table, github, gitlab, teamcity, junit.'
+    default: table
     required: true
   quick:
     description: 'Quick mode. It will not validate all rows. It will stop after the first error.'

--- a/src/Commands/ValidateCsv.php
+++ b/src/Commands/ValidateCsv.php
@@ -68,7 +68,7 @@ final class ValidateCsv extends CliCommand
                 InputOption::VALUE_REQUIRED,
                 "Report output format. Available options:\n" .
                 '<info>' . \implode(', ', ErrorSuite::getAvaiableRenderFormats()) . '</info>',
-                ErrorSuite::RENDER_TABLE,
+                ErrorSuite::REPORT_DEFAULT,
             )
             ->addOption(
                 'quick',

--- a/src/Validators/ErrorSuite.php
+++ b/src/Validators/ErrorSuite.php
@@ -34,6 +34,7 @@ final class ErrorSuite
     public const REPORT_GITLAB   = 'gitlab';
     public const REPORT_GITHUB   = 'github';
     public const REPORT_JUNIT    = 'junit';
+    public const REPORT_DEFAULT  = self::RENDER_TABLE;
 
     /** @var Error[] */
     private array $errors = [];

--- a/tests/GithubActionsTest.php
+++ b/tests/GithubActionsTest.php
@@ -42,7 +42,7 @@ final class GithubActionsTest extends TestCase
 
         isSame(
             $action->findString('inputs.report.description'),
-            'Report format. Available options: ' . \implode(', ', ErrorSuite::getAvaiableRenderFormats()),
+            'Report format. Available options: ' . \implode(', ', ErrorSuite::getAvaiableRenderFormats()) . '.',
         );
     }
 
@@ -52,7 +52,7 @@ final class GithubActionsTest extends TestCase
         $examples = [
             'csv'         => './tests/**/*.csv',
             'schema'      => './tests/schema.yml',
-            'report'      => 'github',
+            'report'      => ErrorSuite::REPORT_DEFAULT,
             'quick'       => 'no',
             'skip-schema' => 'no',
         ];


### PR DESCRIPTION
The README.md file has been updated to reflect that the default report format for GitHub Actions is now 'table' instead of 'github'. This change has been applied consistently across the documentation, ensuring clearer understanding and more consistency for the users.