### PR TITLE
Update Docker image tagging and verification in GitHub Workflow

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -42,8 +42,15 @@ jobs:
           push: true
           context: .
           file: ./docker/Dockerfile
-          tags: jbzoo/csv-blueprint:${{ github.event.release.tag_name }}
-          platforms: linux/amd64,linux/arm64/v8,linux/386,
+          tags: |
+            jbzoo/csv-blueprint:latest
+            jbzoo/csv-blueprint:${{ github.event.release.tag_name }}
+          platforms: linux/amd64,linux/arm64/v8,linux/386
+          build-args: |
+            VERSION=${{ github.event.release.tag_name }}
 
-      - name: Verify the Docker image
-        run: docker run --rm jbzoo/csv-blueprint:${{ github.event.release.tag_name }}
+      - name: Verify the Docker image by tag
+        run: docker run --rm jbzoo/csv-blueprint:${{ github.event.release.tag_name }} --ansi -vvv
+
+      - name: Verify the Docker image by latest
+        run: docker run --rm jbzoo/csv-blueprint:latest --ansi -vvv


### PR DESCRIPTION
This commit modifies the Docker image tagging process in the GitHub workflow to include the 'latest' tag along with the version-specific tag. Additionally, the workflow now involves steps to verify the Docker images tagged with both 'latest' and the specific version. The version-specific build arguments have been incorporated in the Docker build stage.