### PR TITLE
Refactor standard deviation terms in schemas and rename related methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,21 +317,21 @@ columns:
       sample_variance_min: 1.123
       sample_variance_max: 10.123
 
-      # Standard deviation (For a sample; uses sample variance).
-      # Standard deviation is a measure that is used to quantify the amount of variation or dispersion of a set of data values.
-      # A low standard deviation indicates that the data points tend to be close to the mean (also called the expected value) of the set.
-      # A high standard deviation indicates that the data points are spread out over a wider range of values.
+      # Standard deviation (For a sample; uses sample variance). It also known as SD or StdDev.
+      # StdDev is a measure that is used to quantify the amount of variation or dispersion of a set of data values.
+      #  - Low standard deviation indicates that the data points tend to be close to the mean (also called the expected value) of the set.
+      #  - High standard deviation indicates that the data points are spread out over a wider range of values.
       # See: https://en.wikipedia.org/wiki/Standard_deviation.
-      sd_sample: 5.123
-      sd_sample_not: 4.123
-      sd_sample_min: 1.123
-      sd_sample_max: 10.123
+      stddev: 5.123
+      stddev_not: 4.123
+      stddev_min: 1.123
+      stddev_max: 10.123
 
       # SD+ (Standard deviation for a population; uses population variance).
-      sd_population: 5.123
-      sd_population_not: 4.123
-      sd_population_min: 1.123
-      sd_population_max: 10.123
+      stddev_pop: 5.123
+      stddev_pop_not: 4.123
+      stddev_pop_min: 1.123
+      stddev_pop_max: 10.123
 
       # Coefficient of variation (cᵥ) Also known as relative standard deviation (RSD).
       # A standardized measure of dispersion of a probability distribution or frequency distribution.

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -127,15 +127,15 @@
                 "sample_variance_min"     : 1.123,
                 "sample_variance_max"     : 10.123,
 
-                "sd_sample"               : 5.123,
-                "sd_sample_not"           : 4.123,
-                "sd_sample_min"           : 1.123,
-                "sd_sample_max"           : 10.123,
+                "stddev"                  : 5.123,
+                "stddev_not"              : 4.123,
+                "stddev_min"              : 1.123,
+                "stddev_max"              : 10.123,
 
-                "sd_population"           : 5.123,
-                "sd_population_not"       : 4.123,
-                "sd_population_min"       : 1.123,
-                "sd_population_max"       : 10.123,
+                "stddev_pop"              : 5.123,
+                "stddev_pop_not"          : 4.123,
+                "stddev_pop_min"          : 1.123,
+                "stddev_pop_max"          : 10.123,
 
                 "coef_of_var"             : 5.123,
                 "coef_of_var_not"         : 4.123,

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -148,15 +148,15 @@ This example serves as a comprehensive guide for creating robust CSV file valida
                 'sample_variance_min' => 1.123,
                 'sample_variance_max' => 10.123,
 
-                'sd_sample'     => 5.123,
-                'sd_sample_not' => 4.123,
-                'sd_sample_min' => 1.123,
-                'sd_sample_max' => 10.123,
+                'stddev'     => 5.123,
+                'stddev_not' => 4.123,
+                'stddev_min' => 1.123,
+                'stddev_max' => 10.123,
 
-                'sd_population'     => 5.123,
-                'sd_population_not' => 4.123,
-                'sd_population_min' => 1.123,
-                'sd_population_max' => 10.123,
+                'stddev_pop'     => 5.123,
+                'stddev_pop_not' => 4.123,
+                'stddev_pop_min' => 1.123,
+                'stddev_pop_max' => 10.123,
 
                 'coef_of_var'     => 5.123,
                 'coef_of_var_not' => 4.123,

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -231,21 +231,21 @@ columns:
       sample_variance_min: 1.123
       sample_variance_max: 10.123
 
-      # Standard deviation (For a sample; uses sample variance).
-      # Standard deviation is a measure that is used to quantify the amount of variation or dispersion of a set of data values.
-      # A low standard deviation indicates that the data points tend to be close to the mean (also called the expected value) of the set.
-      # A high standard deviation indicates that the data points are spread out over a wider range of values.
+      # Standard deviation (For a sample; uses sample variance). It also known as SD or StdDev.
+      # StdDev is a measure that is used to quantify the amount of variation or dispersion of a set of data values.
+      #  - Low standard deviation indicates that the data points tend to be close to the mean (also called the expected value) of the set.
+      #  - High standard deviation indicates that the data points are spread out over a wider range of values.
       # See: https://en.wikipedia.org/wiki/Standard_deviation.
-      sd_sample: 5.123
-      sd_sample_not: 4.123
-      sd_sample_min: 1.123
-      sd_sample_max: 10.123
+      stddev: 5.123
+      stddev_not: 4.123
+      stddev_min: 1.123
+      stddev_max: 10.123
 
       # SD+ (Standard deviation for a population; uses population variance).
-      sd_population: 5.123
-      sd_population_not: 4.123
-      sd_population_min: 1.123
-      sd_population_max: 10.123
+      stddev_pop: 5.123
+      stddev_pop_not: 4.123
+      stddev_pop_min: 1.123
+      stddev_pop_max: 10.123
 
       # Coefficient of variation (cᵥ) Also known as relative standard deviation (RSD).
       # A standardized measure of dispersion of a probability distribution or frequency distribution.

--- a/schema-examples/full_clean.yml
+++ b/schema-examples/full_clean.yml
@@ -126,14 +126,14 @@ columns:
       sample_variance_not: 4.123
       sample_variance_min: 1.123
       sample_variance_max: 10.123
-      sd_sample: 5.123
-      sd_sample_not: 4.123
-      sd_sample_min: 1.123
-      sd_sample_max: 10.123
-      sd_population: 5.123
-      sd_population_not: 4.123
-      sd_population_min: 1.123
-      sd_population_max: 10.123
+      stddev: 5.123
+      stddev_not: 4.123
+      stddev_min: 1.123
+      stddev_max: 10.123
+      stddev_pop: 5.123
+      stddev_pop_not: 4.123
+      stddev_pop_min: 1.123
+      stddev_pop_max: 10.123
       coef_of_var: 5.123
       coef_of_var_not: 4.123
       coef_of_var_min: 1.123

--- a/src/Rules/Aggregate/ComboStddev.php
+++ b/src/Rules/Aggregate/ComboStddev.php
@@ -19,19 +19,18 @@ namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use MathPHP\Statistics\Descriptive;
 
-final class ComboSdSample extends AbstarctAggregateRuleCombo
+final class ComboStddev extends AbstarctAggregateRuleCombo
 {
     public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
 
-    protected const NAME = 'standard deviation (SD)';
+    protected const NAME = 'StdDev';
 
     protected const HELP_TOP = [
-        'Standard deviation (For a sample; uses sample variance)',
-        'Standard deviation is a measure that is used to quantify the amount of variation or ' .
-        'dispersion of a set of data values.',
-        'A low standard deviation indicates that the data points tend to be close to the mean ' .
+        'Standard deviation (For a sample; uses sample variance). It also known as SD or StdDev.',
+        'StdDev is a measure that is used to quantify the amount of variation or dispersion of a set of data values.',
+        ' - Low standard deviation indicates that the data points tend to be close to the mean ' .
         '(also called the expected value) of the set.',
-        'A high standard deviation indicates that the data points are spread out over a wider range of values.',
+        ' - High standard deviation indicates that the data points are spread out over a wider range of values.',
         'See: https://en.wikipedia.org/wiki/Standard_deviation',
     ];
 

--- a/src/Rules/Aggregate/ComboStddevPop.php
+++ b/src/Rules/Aggregate/ComboStddevPop.php
@@ -19,7 +19,7 @@ namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use MathPHP\Statistics\Descriptive;
 
-final class ComboSdPopulation extends AbstarctAggregateRuleCombo
+final class ComboStddevPop extends AbstarctAggregateRuleCombo
 {
     public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
 

--- a/tests/Rules/Aggregate/ComboStdDevTest.php
+++ b/tests/Rules/Aggregate/ComboStdDevTest.php
@@ -17,23 +17,23 @@ declare(strict_types=1);
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
 use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
-use JBZoo\CsvBlueprint\Rules\Aggregate\ComboSdPopulation;
+use JBZoo\CsvBlueprint\Rules\Aggregate\ComboStddev;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 
 use function JBZoo\PHPUnit\isSame;
 
-class ComboSdPopulationTest extends TestAbstractAggregateRuleCombo
+class ComboStdDevTest extends TestAbstractAggregateRuleCombo
 {
-    protected string $ruleClass = ComboSdPopulation::class;
+    protected string $ruleClass = ComboStddev::class;
 
     public function testEqual(): void
     {
-        $rule = $this->create(2.3570226039552, Combo::EQ);
+        $rule = $this->create(2.5, Combo::EQ);
         isSame('', $rule->test([1, 5, 1, 1, 1, 2, 8, 1, 1]));
 
         $rule = $this->create(3, Combo::EQ);
         isSame(
-            'The standard deviation (SD+) in the column is "2.3570226039552", which is not equal than the expected "3"',
+            'The StdDev in the column is "2.5", which is not equal than the expected "3"',
             $rule->test([1, 5, 1, 1, 1, 2, 8, 1, 1]),
         );
     }

--- a/tests/Rules/Aggregate/ComboStddevPopTest.php
+++ b/tests/Rules/Aggregate/ComboStddevPopTest.php
@@ -17,23 +17,23 @@ declare(strict_types=1);
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
 use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
-use JBZoo\CsvBlueprint\Rules\Aggregate\ComboSdSample;
+use JBZoo\CsvBlueprint\Rules\Aggregate\ComboStddevPop;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 
 use function JBZoo\PHPUnit\isSame;
 
-class ComboSdSampleTest extends TestAbstractAggregateRuleCombo
+class ComboStddevPopTest extends TestAbstractAggregateRuleCombo
 {
-    protected string $ruleClass = ComboSdSample::class;
+    protected string $ruleClass = ComboStddevPop::class;
 
     public function testEqual(): void
     {
-        $rule = $this->create(2.5, Combo::EQ);
+        $rule = $this->create(2.3570226039552, Combo::EQ);
         isSame('', $rule->test([1, 5, 1, 1, 1, 2, 8, 1, 1]));
 
         $rule = $this->create(3, Combo::EQ);
         isSame(
-            'The standard deviation (SD) in the column is "2.5", which is not equal than the expected "3"',
+            'The standard deviation (SD+) in the column is "2.3570226039552", which is not equal than the expected "3"',
             $rule->test([1, 5, 1, 1, 1, 2, 8, 1, 1]),
         );
     }

--- a/tests/schemas/todo.yml
+++ b/tests/schemas/todo.yml
@@ -36,6 +36,7 @@ columns:
     # Multi prop
     multiple: true
     multiple_separator: "|"           # Separator for multiple values
+    faker: [faker_method arg1 arg2]   # Faker method with arguments
 
     rules:
       # https://github.com/Respect/Validation/blob/main/docs/08-list-of-rules-by-category.md


### PR DESCRIPTION
This commit modifies all standard deviation related terms in JSON, PHP, YML files from `sd_sample` and `sd_population` to `stddev` and `stddev_pop` respectively. The related methods are also renamed to align with these changes. This replaces the abbreviated form `sd` with the more commonly used term `stddev`, improving clarity and understanding for users. Corresponding comments and tests are updated to reflect these changes.
