### PR TITLE
Add Mean Absolute Deviation rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Stable Version](https://poser.pugx.org/jbzoo/csv-blueprint/version)](https://packagist.org/packages/jbzoo/csv-blueprint/)    [![Total Downloads](https://poser.pugx.org/jbzoo/csv-blueprint/downloads)](https://packagist.org/packages/jbzoo/csv-blueprint/stats)    [![Docker Pulls](https://img.shields.io/docker/pulls/jbzoo/csv-blueprint.svg)](https://hub.docker.com/r/jbzoo/csv-blueprint/tags)    [![GitHub License](https://img.shields.io/github/license/jbzoo/csv-blueprint)](https://github.com/JBZoo/Csv-Blueprint/blob/master/LICENSE)
 
 <!-- rules-counter -->
-[![Static Badge](https://img.shields.io/badge/Rules-119-green?label=Total%20Number%20of%20Rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)    [![Static Badge](https://img.shields.io/badge/Rules-55-green?label=Cell%20Value&labelColor=blue&color=gray)](src/Rules/Cell)    [![Static Badge](https://img.shields.io/badge/Rules-59-green?label=Aggregate%20Column&labelColor=blue&color=gray)](src/Rules/Aggregate)    [![Static Badge](https://img.shields.io/badge/Rules-5-green?label=Extra%20Checks&labelColor=blue&color=gray)](#extra-checks)    [![Static Badge](https://img.shields.io/badge/Rules-317-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
+[![Static Badge](https://img.shields.io/badge/Rules-123-green?label=Total%20Number%20of%20Rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)    [![Static Badge](https://img.shields.io/badge/Rules-55-green?label=Cell%20Value&labelColor=blue&color=gray)](src/Rules/Cell)    [![Static Badge](https://img.shields.io/badge/Rules-63-green?label=Aggregate%20Column&labelColor=blue&color=gray)](src/Rules/Aggregate)    [![Static Badge](https://img.shields.io/badge/Rules-5-green?label=Extra%20Checks&labelColor=blue&color=gray)](#extra-checks)    [![Static Badge](https://img.shields.io/badge/Rules-313-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
 <!-- /rules-counter -->
 
 ## Introduction
@@ -321,6 +321,14 @@ columns:
       median_not: 4.123
       median_min: 1.123
       median_max: 10.123
+
+      # MAD - mean absolute deviation. The average of the absolute deviations from a central point.
+      # It is a summary statistic of statistical dispersion or variability.
+      # See: https://en.wikipedia.org/wiki/Average_absolute_deviation.
+      mean_abs_dev: 5.123
+      mean_abs_dev_not: 4.123
+      mean_abs_dev_min: 1.123
+      mean_abs_dev_max: 10.123
 
       # Population variance - Use when all possible observations of the system are present.
       # If used with a subset of data (sample variance), it will be a biased variance.

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -134,6 +134,11 @@
                 "median_min"              : 1.123,
                 "median_max"              : 10.123,
 
+                "mean_abs_dev"            : 5.123,
+                "mean_abs_dev_not"        : 4.123,
+                "mean_abs_dev_min"        : 1.123,
+                "mean_abs_dev_max"        : 10.123,
+
                 "population_variance"     : 5.123,
                 "population_variance_not" : 4.123,
                 "population_variance_min" : 1.123,

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -155,6 +155,11 @@ This example serves as a comprehensive guide for creating robust CSV file valida
                 'median_min' => 1.123,
                 'median_max' => 10.123,
 
+                'mean_abs_dev'     => 5.123,
+                'mean_abs_dev_not' => 4.123,
+                'mean_abs_dev_min' => 1.123,
+                'mean_abs_dev_max' => 10.123,
+
                 'population_variance'     => 5.123,
                 'population_variance_not' => 4.123,
                 'population_variance_min' => 1.123,

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -236,6 +236,14 @@ columns:
       median_min: 1.123
       median_max: 10.123
 
+      # MAD - mean absolute deviation. The average of the absolute deviations from a central point.
+      # It is a summary statistic of statistical dispersion or variability.
+      # See: https://en.wikipedia.org/wiki/Average_absolute_deviation.
+      mean_abs_dev: 5.123
+      mean_abs_dev_not: 4.123
+      mean_abs_dev_min: 1.123
+      mean_abs_dev_max: 10.123
+
       # Population variance - Use when all possible observations of the system are present.
       # If used with a subset of data (sample variance), it will be a biased variance.
       # n degrees of freedom, where n is the number of observations.

--- a/schema-examples/full_clean.yml
+++ b/schema-examples/full_clean.yml
@@ -142,6 +142,11 @@ columns:
       median_min: 1.123
       median_max: 10.123
 
+      mean_abs_dev: 5.123
+      mean_abs_dev_not: 4.123
+      mean_abs_dev_min: 1.123
+      mean_abs_dev_max: 10.123
+
       population_variance: 5.123
       population_variance_not: 4.123
       population_variance_min: 1.123

--- a/src/Rules/Aggregate/AbstarctAggregateRuleCombo.php
+++ b/src/Rules/Aggregate/AbstarctAggregateRuleCombo.php
@@ -81,6 +81,6 @@ abstract class AbstarctAggregateRuleCombo extends AbstarctRuleCombo
 
     protected static function stringsToFloat(array $colValues): array
     {
-        return \array_map('floatval', $colValues);
+        return \array_map('\JBZoo\Utils\float', $colValues);
     }
 }

--- a/src/Rules/Aggregate/ComboMeanAbsDev.php
+++ b/src/Rules/Aggregate/ComboMeanAbsDev.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Rules\Aggregate;
+
+use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use MathPHP\Statistics\Descriptive;
+
+final class ComboMeanAbsDev extends AbstarctAggregateRuleCombo
+{
+    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+
+    protected const NAME = 'MAD';
+
+    protected const HELP_TOP = [
+        'MAD - mean absolute deviation. The average of the absolute deviations from a central point.',
+        'It is a summary statistic of statistical dispersion or variability.',
+        'See: https://en.wikipedia.org/wiki/Average_absolute_deviation',
+    ];
+
+    protected function getActualAggregate(array $colValues): ?float
+    {
+        return Descriptive::meanAbsoluteDeviation(self::stringsToFloat($colValues));
+    }
+}

--- a/tests/Rules/Aggregate/ComboStdDev1Test.php
+++ b/tests/Rules/Aggregate/ComboStdDev1Test.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Rules\Aggregate;
+
+use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\Aggregate\ComboMeanAbsDev;
+use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
+
+use function JBZoo\PHPUnit\isSame;
+
+class ComboStdDev1Test extends TestAbstractAggregateRuleCombo
+{
+    protected string $ruleClass = ComboMeanAbsDev::class;
+
+    public function testEqual(): void
+    {
+        $rule = $this->create(3.5, Combo::EQ);
+        isSame('', $rule->test(['_1', '   8.00   ']));
+
+        $rule = $this->create(3, Combo::EQ);
+        isSame(
+            'The MAD in the column is "3.5", which is not equal than the expected "3"',
+            $rule->test([1, 8]),
+        );
+    }
+}

--- a/tests/schemas/todo.yml
+++ b/tests/schemas/todo.yml
@@ -257,7 +257,6 @@ columns:
       count_false: 1
 
       # https://github.com/markrogoyski/math-php#statistics---descriptive
-      mean_abs_dev: 1
       median_abs_dev: 1
       quartiles: [ 1, mode ]         # 0%, Q1, Q2, Q3, 100%, IQR
       quartiles_exclusive: 1


### PR DESCRIPTION
The commit incorporates Mean Absolute Deviation (MAD) rules and updates relevant files including JSON, PHP, and YML schema examples as well as unit tests. It also reflects these changes in the README and the rules counter badge. The process of handling floats has been changed to use the 'JBZoo\Utils\float' utility function.