### PR TITLE
Implement `nth_*` and fixed line number

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ Check schema syntax: 1
 CSV file validation: 1
 (1/1) Schema: ./tests/schemas/demo_invalid.yml
 (1/1) CSV   : ./tests/fixtures/demo.csv
-(1/1) Issues: 9
+(1/1) Issues: 10
 +------+------------------+--------------+------------------------- demo.csv -------------------------------------------------------------------+
 | Line | id:Column        | Rule         | Message                                                                                              |
 +------+------------------+--------------+------------------------------------------------------------------------------------------------------+
@@ -611,6 +611,7 @@ CSV file validation: 1
 | 11   | 0:Name           | length_min   | The length of the value "Lois" is 4, which is less than the expected "5"                             |
 | 1    | 1:City           | ag:is_unique | Column has non-unique values. Unique: 9, total: 10                                                   |
 | 2    | 2:Float          | num_max      | The number of the value "4825.185", which is greater than the expected "4825.184"                    |
+| 1    | 2:Float          | ag:nth_num   | The N-th value in the column is "74", which is not equal than the expected "0.001"                   |
 | 6    | 3:Birthday       | date_min     | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
 |      |                  |              | expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"                                                   |
 | 8    | 3:Birthday       | date_min     | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
@@ -624,7 +625,7 @@ CSV file validation: 1
 Summary:
   1 pairs (schema to csv) were found based on `filename_pattern`.
   Found 2 issues in 1 schemas.
-  Found 9 issues in 1 out of 1 CSV files.
+  Found 10 issues in 1 out of 1 CSV files.
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Stable Version](https://poser.pugx.org/jbzoo/csv-blueprint/version)](https://packagist.org/packages/jbzoo/csv-blueprint/)    [![Total Downloads](https://poser.pugx.org/jbzoo/csv-blueprint/downloads)](https://packagist.org/packages/jbzoo/csv-blueprint/stats)    [![Docker Pulls](https://img.shields.io/docker/pulls/jbzoo/csv-blueprint.svg)](https://hub.docker.com/r/jbzoo/csv-blueprint/tags)    [![GitHub License](https://img.shields.io/github/license/jbzoo/csv-blueprint)](https://github.com/JBZoo/Csv-Blueprint/blob/master/LICENSE)
 
 <!-- rules-counter -->
-[![Static Badge](https://img.shields.io/badge/Rules-127-green?label=Total%20Number%20of%20Rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)    [![Static Badge](https://img.shields.io/badge/Rules-55-green?label=Cell%20Value&labelColor=blue&color=gray)](src/Rules/Cell)    [![Static Badge](https://img.shields.io/badge/Rules-67-green?label=Aggregate%20Column&labelColor=blue&color=gray)](src/Rules/Aggregate)    [![Static Badge](https://img.shields.io/badge/Rules-5-green?label=Extra%20Checks&labelColor=blue&color=gray)](#extra-checks)    [![Static Badge](https://img.shields.io/badge/Rules-309-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
+[![Static Badge](https://img.shields.io/badge/Rules-131-green?label=Total%20Number%20of%20Rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)    [![Static Badge](https://img.shields.io/badge/Rules-55-green?label=Cell%20Value&labelColor=blue&color=gray)](src/Rules/Cell)    [![Static Badge](https://img.shields.io/badge/Rules-71-green?label=Aggregate%20Column&labelColor=blue&color=gray)](src/Rules/Aggregate)    [![Static Badge](https://img.shields.io/badge/Rules-5-green?label=Extra%20Checks&labelColor=blue&color=gray)](#extra-checks)    [![Static Badge](https://img.shields.io/badge/Rules-309-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
 <!-- /rules-counter -->
 
 ## Introduction
@@ -273,7 +273,12 @@ columns:
       first: Expected                   # First value in the column. Will be compared as strings.
       first_not: 'Not Expected'         # Not allowed as the first value in the column. Will be compared as strings.
 
-      # N-th in the column.
+      # N-th value in the column.
+      # The rule expects exactly two arguments: the first is the line number (without header), the second is the expected value.
+      nth_num: [ 2, 5 ]                 # Example: On the line 2 (disregarding the header), we expect the 5.0. The comparison is always as float.
+      nth_num_not: [ 2, 4.123 ]
+      nth_num_min: [ 2, -1 ]
+      nth_num_max: [ 2, 2e4 ]
       nth: [ 2, Expected ]              # Nth value in the column. Will be compared as strings.
       nth_not: [ 2, 'Not expected' ]    # Not allowed as the N-th value in the column. Will be compared as strings.
 

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -94,6 +94,10 @@
                 "first"                   : "Expected",
                 "first_not"               : "Not Expected",
 
+                "nth_num"                 : [2, 5],
+                "nth_num_not"             : [2, 4.123],
+                "nth_num_min"             : [2, -1],
+                "nth_num_max"             : [2, 20000],
                 "nth"                     : [2, "Expected"],
                 "nth_not"                 : [2, "Not expected"],
 

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -115,8 +115,12 @@ This example serves as a comprehensive guide for creating robust CSV file valida
                 'first'         => 'Expected',
                 'first_not'     => 'Not Expected',
 
-                'nth'     => [2, 'Expected'],
-                'nth_not' => [2, 'Not expected'],
+                'nth_num'     => [2, 5],
+                'nth_num_not' => [2, 4.123],
+                'nth_num_min' => [2, -1],
+                'nth_num_max' => [2, 20000.0],
+                'nth'         => [2, 'Expected'],
+                'nth_not'     => [2, 'Not expected'],
 
                 'last_num'     => 5,
                 'last_num_not' => 4.123,

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -187,7 +187,12 @@ columns:
       first: Expected                   # First value in the column. Will be compared as strings.
       first_not: 'Not Expected'         # Not allowed as the first value in the column. Will be compared as strings.
 
-      # N-th in the column.
+      # N-th value in the column.
+      # The rule expects exactly two arguments: the first is the line number (without header), the second is the expected value.
+      nth_num: [ 2, 5 ]                 # Example: On the line 2 (disregarding the header), we expect the 5.0. The comparison is always as float.
+      nth_num_not: [ 2, 4.123 ]
+      nth_num_min: [ 2, -1 ]
+      nth_num_max: [ 2, 2e4 ]
       nth: [ 2, Expected ]              # Nth value in the column. Will be compared as strings.
       nth_not: [ 2, 'Not expected' ]    # Not allowed as the N-th value in the column. Will be compared as strings.
 

--- a/schema-examples/full_clean.yml
+++ b/schema-examples/full_clean.yml
@@ -102,6 +102,10 @@ columns:
       first: Expected
       first_not: 'Not Expected'
 
+      nth_num: [ 2, 5 ]
+      nth_num_not: [ 2, 4.123 ]
+      nth_num_min: [ 2, -1 ]
+      nth_num_max: [ 2, 2e4 ]
       nth: [ 2, Expected ]
       nth_not: [ 2, 'Not expected' ]
 

--- a/src/Rules/Aggregate/AbstarctAggregateRuleCombo.php
+++ b/src/Rules/Aggregate/AbstarctAggregateRuleCombo.php
@@ -61,15 +61,19 @@ abstract class AbstarctAggregateRuleCombo extends AbstarctRuleCombo
 
         try {
             $actual = $this->getActualAggregate($colValues); // Important to use the original method here!
-        } catch (\Throwable) {
-            $actual = null; // TODO: Expose the error/warning message in the report?
+        } catch (\Throwable $exception) {
+            return $exception->getMessage(); // TODO: Expose the error/warning message in the report?
         }
 
         if ($actual === null) {
             return null; // Looks like it's impossible to calculate the aggregate value in this case. Skip.
         }
 
-        $expected = $this->getExpected();
+        try {
+            $expected = $this->getExpected();
+        } catch (\Throwable $exception) {
+            return $exception->getMessage(); // TODO: Expose the error/warning message in the report?
+        }
 
         if (!self::compare($expected, $actual, $mode)) {
             return "The {$name} in the column is \"<c>{$actual}</c>\", " .

--- a/src/Rules/Aggregate/ComboAverage.php
+++ b/src/Rules/Aggregate/ComboAverage.php
@@ -29,6 +29,10 @@ final class ComboAverage extends AbstarctAggregateRuleCombo
 
     protected function getActualAggregate(array $colValues): ?float
     {
+        if (\count($colValues) === 0) {
+            return null;
+        }
+
         return Average::mean(self::stringsToFloat($colValues));
     }
 }

--- a/src/Rules/Aggregate/ComboCoefOfVar.php
+++ b/src/Rules/Aggregate/ComboCoefOfVar.php
@@ -34,6 +34,10 @@ final class ComboCoefOfVar extends AbstarctAggregateRuleCombo
 
     protected function getActualAggregate(array $colValues): ?float
     {
+        if (\count($colValues) === 0) {
+            return null;
+        }
+
         return Descriptive::coefficientOfVariation(self::stringsToFloat($colValues));
     }
 }

--- a/src/Rules/Aggregate/ComboMeanAbsDev.php
+++ b/src/Rules/Aggregate/ComboMeanAbsDev.php
@@ -33,6 +33,10 @@ final class ComboMeanAbsDev extends AbstarctAggregateRuleCombo
 
     protected function getActualAggregate(array $colValues): ?float
     {
+        if (\count($colValues) === 0) {
+            return null;
+        }
+
         return Descriptive::meanAbsoluteDeviation(self::stringsToFloat($colValues));
     }
 }

--- a/src/Rules/Aggregate/ComboMedian.php
+++ b/src/Rules/Aggregate/ComboMedian.php
@@ -29,6 +29,10 @@ final class ComboMedian extends AbstarctAggregateRuleCombo
 
     protected function getActualAggregate(array $colValues): ?float
     {
+        if (\count($colValues) === 0) {
+            return null;
+        }
+
         return Average::median(self::stringsToFloat($colValues));
     }
 }

--- a/src/Rules/Aggregate/ComboMedianAbsDev.php
+++ b/src/Rules/Aggregate/ComboMedianAbsDev.php
@@ -34,6 +34,10 @@ final class ComboMedianAbsDev extends AbstarctAggregateRuleCombo
 
     protected function getActualAggregate(array $colValues): ?float
     {
+        if (\count($colValues) === 0) {
+            return null;
+        }
+
         return Descriptive::medianAbsoluteDeviation(self::stringsToFloat($colValues));
     }
 }

--- a/src/Rules/Aggregate/ComboNthNum.php
+++ b/src/Rules/Aggregate/ComboNthNum.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Rules\Aggregate;
+
+use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+
+use function JBZoo\Utils\float;
+
+final class ComboNthNum extends AbstarctAggregateRuleCombo
+{
+    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+
+    protected const NAME     = 'N-th value';
+    protected const HELP_TOP = [
+        'N-th value in the column.',
+        'The rule expects exactly two arguments: ' .
+        'the first is the line number (without header), the second is the expected value',
+    ];
+
+    protected const HELP_OPTIONS = [
+        self::EQ => [
+            '[ 2, 5 ]',
+            'Example: On the line 2 (disregarding the header), we expect the 5.0. The comparison is always as float.',
+        ],
+        self::NOT => ['[ 2, 4.123 ]', ''],
+        self::MIN => ['[ 2, -1 ]', ''],
+        self::MAX => ['[ 2, 2e4 ]', ''],
+    ];
+
+    private const ARGS = 2;
+    private const NTH  = 0;
+    private const VAL  = 1;
+
+    protected function getExpected(): float
+    {
+        return float($this->getParams()[self::VAL]);
+    }
+
+    protected function getActualAggregate(array $colValues): ?float
+    {
+        if (\count($colValues) === 0) {
+            return null;
+        }
+
+        $realLine = (int)$this->getParams()[self::NTH];
+        $arrayInd = $realLine - 1;
+        $actual   = $colValues[$arrayInd] ?? null;
+
+        if ($actual === null) {
+            throw new \RuntimeException(
+                "The column does not have a line {$realLine}, so the value cannot be checked.",
+            );
+        }
+
+        return float($actual);
+    }
+
+    private function getParams(): array
+    {
+        $params = $this->getOptionAsArray();
+        if (\count($params) !== self::ARGS) {
+            throw new \RuntimeException(
+                'The rule expects exactly two arguments: ' .
+                'the first is the line number (without header), the second is the expected value',
+            );
+        }
+
+        return $params;
+    }
+}

--- a/src/Rules/Aggregate/ComboPopulationVariance.php
+++ b/src/Rules/Aggregate/ComboPopulationVariance.php
@@ -33,6 +33,10 @@ final class ComboPopulationVariance extends AbstarctAggregateRuleCombo
 
     protected function getActualAggregate(array $colValues): ?float
     {
+        if (\count($colValues) === 0) {
+            return null;
+        }
+
         return Descriptive::populationVariance(self::stringsToFloat($colValues));
     }
 }

--- a/src/Rules/Aggregate/ComboSampleVariance.php
+++ b/src/Rules/Aggregate/ComboSampleVariance.php
@@ -32,6 +32,10 @@ final class ComboSampleVariance extends AbstarctAggregateRuleCombo
 
     protected function getActualAggregate(array $colValues): ?float
     {
+        if (\count($colValues) === 0) {
+            return null;
+        }
+
         return Descriptive::sampleVariance(self::stringsToFloat($colValues));
     }
 }

--- a/src/Rules/Aggregate/ComboStddev.php
+++ b/src/Rules/Aggregate/ComboStddev.php
@@ -36,6 +36,10 @@ final class ComboStddev extends AbstarctAggregateRuleCombo
 
     protected function getActualAggregate(array $colValues): ?float
     {
+        if (\count($colValues) === 0) {
+            return null;
+        }
+
         return Descriptive::standardDeviation(self::stringsToFloat($colValues));
     }
 }

--- a/src/Rules/Aggregate/ComboStddevPop.php
+++ b/src/Rules/Aggregate/ComboStddevPop.php
@@ -31,6 +31,10 @@ final class ComboStddevPop extends AbstarctAggregateRuleCombo
 
     protected function getActualAggregate(array $colValues): ?float
     {
+        if (\count($colValues) === 0) {
+            return null;
+        }
+
         return Descriptive::standardDeviation(self::stringsToFloat($colValues), Descriptive::POPULATION);
     }
 }

--- a/src/Rules/Aggregate/Nth.php
+++ b/src/Rules/Aggregate/Nth.php
@@ -39,19 +39,20 @@ final class Nth extends AbstarctAggregateRule
         $params = $this->getOptionAsArray();
         if (\count($params) !== self::ARGS) {
             return 'The rule expects exactly two arguments: ' .
-                'the first is the line number, the second is the expected value';
+                'the first is the line number (without header), the second is the expected value';
         }
 
-        $nth      = (int)$params[self::NTH];
+        $realLine = (int)$params[self::NTH];
+        $arrayInd = $realLine - 1;
         $expValue = (string)$params[self::VAL];
 
-        $actual = $columnValues[$nth] ?? null;
+        $actual = $columnValues[$arrayInd] ?? null;
         if ($actual === null) {
-            return "The column does not have a line {$nth}, so the value cannot be checked.";
+            return "The column does not have a line {$realLine}, so the value cannot be checked.";
         }
 
         if ($actual !== $expValue) {
-            return "The {$nth} value in the column is \"<c>{$actual}</c>\", " .
+            return "The value on line {$realLine} in the column is \"<c>{$actual}</c>\", " .
                 "which is not equal than the expected \"<green>{$expValue}</green>\"";
         }
 

--- a/src/Rules/Aggregate/NthNot.php
+++ b/src/Rules/Aggregate/NthNot.php
@@ -42,19 +42,20 @@ final class NthNot extends AbstarctAggregateRule
         $params = $this->getOptionAsArray();
         if (\count($params) !== self::ARGS) {
             return 'The rule expects exactly two arguments: ' .
-                'the first is the line number, the second is the not expected value';
+                'the first is the line number (without header), the second is the not expected value';
         }
 
-        $nth      = (int)$params[self::NTH];
+        $realLine = (int)$params[self::NTH];
+        $arrayInd = $realLine - 1;
         $expValue = (string)$params[self::VAL];
 
-        $actual = $columnValues[$nth] ?? null;
+        $actual = $columnValues[$arrayInd] ?? null;
         if ($actual === null) {
-            return "The column does not have a line {$nth}, so the value cannot be checked.";
+            return "The column does not have a line {$realLine}, so the value cannot be checked.";
         }
 
         if ($actual === $expValue) {
-            return "The {$nth} value in the column is \"<c>{$actual}</c>\", " .
+            return "The value on line {$realLine} in the column is \"<c>{$actual}</c>\", " .
                 "which is equal than the not expected \"<green>{$expValue}</green>\"";
         }
 

--- a/tests/Commands/ValidateCsvBasicTest.php
+++ b/tests/Commands/ValidateCsvBasicTest.php
@@ -123,7 +123,7 @@ final class ValidateCsvBasicTest extends TestCase
             CSV file validation: 1
             (1/1) Schema: ./tests/schemas/demo_invalid.yml
             (1/1) CSV   : ./tests/fixtures/demo.csv
-            (1/1) Issues: 9
+            (1/1) Issues: 10
             +------+------------------+--------------+------------------------- demo.csv -------------------------------------------------------------------+
             | Line | id:Column        | Rule         | Message                                                                                              |
             +------+------------------+--------------+------------------------------------------------------------------------------------------------------+
@@ -132,6 +132,7 @@ final class ValidateCsvBasicTest extends TestCase
             | 11   | 0:Name           | length_min   | The length of the value "Lois" is 4, which is less than the expected "5"                             |
             | 1    | 1:City           | ag:is_unique | Column has non-unique values. Unique: 9, total: 10                                                   |
             | 2    | 2:Float          | num_max      | The number of the value "4825.185", which is greater than the expected "4825.184"                    |
+            | 1    | 2:Float          | ag:nth_num   | The N-th value in the column is "74", which is not equal than the expected "0.001"                   |
             | 6    | 3:Birthday       | date_min     | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
             |      |                  |              | expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"                                                   |
             | 8    | 3:Birthday       | date_min     | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
@@ -145,7 +146,7 @@ final class ValidateCsvBasicTest extends TestCase
             Summary:
               1 pairs (schema to csv) were found based on `filename_pattern`.
               Found 2 issues in 1 schemas.
-              Found 9 issues in 1 out of 1 CSV files.
+              Found 10 issues in 1 out of 1 CSV files.
             
             
             TXT;

--- a/tests/Commands/ValidateCsvBatchCsvTest.php
+++ b/tests/Commands/ValidateCsvBatchCsvTest.php
@@ -101,12 +101,13 @@ final class ValidateCsvBatchCsvTest extends TestCase
             CSV file validation: 3
             (1/3) Schema: ./tests/schemas/demo_invalid.yml
             (1/3) CSV   : ./tests/fixtures/batch/demo-1.csv
-            (1/3) Issues: 4
+            (1/3) Issues: 5
             +------+------------------+--------------+------------------------ demo-1.csv ------------------------------------------------------------------+
             | Line | id:Column        | Rule         | Message                                                                                              |
             +------+------------------+--------------+------------------------------------------------------------------------------------------------------+
             | 1    |                  | csv.header   | Columns not found in CSV: "wrong_column_name"                                                        |
             | 1    | 1:City           | ag:is_unique | Column has non-unique values. Unique: 1, total: 2                                                    |
+            | 1    | 2:Float          | ag:nth_num   | The column does not have a line 4, so the value cannot be checked.                                   |
             | 1    | 3:Birthday       | ag:nth       | The value on line 2 in the column is "1998-02-28", which is not equal than the expected "2000-12-01" |
             | 3    | 4:Favorite color | allow_values | Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"]                                |
             +------+------------------+--------------+------------------------ demo-1.csv ------------------------------------------------------------------+
@@ -142,7 +143,7 @@ final class ValidateCsvBatchCsvTest extends TestCase
             Summary:
               3 pairs (schema to csv) were found based on `filename_pattern`.
               Found 2 issues in 1 schemas.
-              Found 12 issues in 3 out of 3 CSV files.
+              Found 13 issues in 3 out of 3 CSV files.
             
             
             TXT;

--- a/tests/Commands/ValidateCsvBatchCsvTest.php
+++ b/tests/Commands/ValidateCsvBatchCsvTest.php
@@ -101,18 +101,19 @@ final class ValidateCsvBatchCsvTest extends TestCase
             CSV file validation: 3
             (1/3) Schema: ./tests/schemas/demo_invalid.yml
             (1/3) CSV   : ./tests/fixtures/batch/demo-1.csv
-            (1/3) Issues: 3
-            +------+------------------+--------------+--------- demo-1.csv --------------------------------------------------+
-            | Line | id:Column        | Rule         | Message                                                               |
-            +------+------------------+--------------+-----------------------------------------------------------------------+
-            | 1    |                  | csv.header   | Columns not found in CSV: "wrong_column_name"                         |
-            | 1    | 1:City           | ag:is_unique | Column has non-unique values. Unique: 1, total: 2                     |
-            | 3    | 4:Favorite color | allow_values | Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"] |
-            +------+------------------+--------------+--------- demo-1.csv --------------------------------------------------+
+            (1/3) Issues: 4
+            +------+------------------+--------------+------------------------ demo-1.csv ------------------------------------------------------------------+
+            | Line | id:Column        | Rule         | Message                                                                                              |
+            +------+------------------+--------------+------------------------------------------------------------------------------------------------------+
+            | 1    |                  | csv.header   | Columns not found in CSV: "wrong_column_name"                                                        |
+            | 1    | 1:City           | ag:is_unique | Column has non-unique values. Unique: 1, total: 2                                                    |
+            | 1    | 3:Birthday       | ag:nth       | The value on line 2 in the column is "1998-02-28", which is not equal than the expected "2000-12-01" |
+            | 3    | 4:Favorite color | allow_values | Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"]                                |
+            +------+------------------+--------------+------------------------ demo-1.csv ------------------------------------------------------------------+
             
             (2/3) Schema: ./tests/schemas/demo_invalid.yml
             (2/3) CSV   : ./tests/fixtures/batch/demo-2.csv
-            (2/3) Issues: 6
+            (2/3) Issues: 7
             +------+------------+------------+---------------------------- demo-2.csv --------------------------------------------------------------+
             | Line | id:Column  | Rule       | Message                                                                                              |
             +------+------------+------------+------------------------------------------------------------------------------------------------------+
@@ -125,6 +126,7 @@ final class ValidateCsvBatchCsvTest extends TestCase
             |      |            |            | expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"                                                   |
             | 5    | 3:Birthday | date_max   | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", which is greater than  |
             |      |            |            | the expected "2009-01-01 00:00:00 +00:00 (2009-01-01)"                                               |
+            | 1    | 3:Birthday | ag:nth     | The value on line 2 in the column is "1989-05-15", which is not equal than the expected "2000-12-01" |
             +------+------------+------------+---------------------------- demo-2.csv --------------------------------------------------------------+
             
             (3/3) Schema: ./tests/schemas/demo_invalid.yml
@@ -140,7 +142,7 @@ final class ValidateCsvBatchCsvTest extends TestCase
             Summary:
               3 pairs (schema to csv) were found based on `filename_pattern`.
               Found 2 issues in 1 schemas.
-              Found 10 issues in 3 out of 3 CSV files.
+              Found 12 issues in 3 out of 3 CSV files.
             
             
             TXT;

--- a/tests/Commands/ValidateCsvBatchSchemaTest.php
+++ b/tests/Commands/ValidateCsvBatchSchemaTest.php
@@ -71,7 +71,7 @@ final class ValidateCsvBatchSchemaTest extends TestCase
             CSV file validation: 2
             (1/2) Schema: ./tests/schemas/demo_invalid.yml
             (1/2) CSV   : ./tests/fixtures/demo.csv
-            (1/2) Issues: 9
+            (1/2) Issues: 10
             +------+------------------+--------------+------------------------- demo.csv -------------------------------------------------------------------+
             | Line | id:Column        | Rule         | Message                                                                                              |
             +------+------------------+--------------+------------------------------------------------------------------------------------------------------+
@@ -80,6 +80,7 @@ final class ValidateCsvBatchSchemaTest extends TestCase
             | 11   | 0:Name           | length_min   | The length of the value "Lois" is 4, which is less than the expected "5"                             |
             | 1    | 1:City           | ag:is_unique | Column has non-unique values. Unique: 9, total: 10                                                   |
             | 2    | 2:Float          | num_max      | The number of the value "4825.185", which is greater than the expected "4825.184"                    |
+            | 1    | 2:Float          | ag:nth_num   | The N-th value in the column is "74", which is not equal than the expected "0.001"                   |
             | 6    | 3:Birthday       | date_min     | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
             |      |                  |              | expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"                                                   |
             | 8    | 3:Birthday       | date_min     | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
@@ -96,7 +97,7 @@ final class ValidateCsvBatchSchemaTest extends TestCase
             Summary:
               2 pairs (schema to csv) were found based on `filename_pattern`.
               Found 10 issues in 3 schemas.
-              Found 9 issues in 1 out of 1 CSV files.
+              Found 10 issues in 1 out of 1 CSV files.
               Not used schemas:
                 - ./tests/schemas/invalid_schema.yml
             

--- a/tests/Commands/ValidateCsvQuickTest.php
+++ b/tests/Commands/ValidateCsvQuickTest.php
@@ -81,9 +81,10 @@ final class ValidateCsvQuickTest extends TestCase
             CSV file validation: 3
             (1/3) Schema: ./tests/schemas/demo_invalid.yml
             (1/3) CSV   : ./tests/fixtures/batch/demo-1.csv
-            (1/3) Issues: 4
+            (1/3) Issues: 5
             "csv.header" at line 1. Columns not found in CSV: "wrong_column_name".
             "ag:is_unique" at line 1, column "1:City". Column has non-unique values. Unique: 1, total: 2.
+            "ag:nth_num" at line 1, column "2:Float". The column does not have a line 4, so the value cannot be checked.
             "ag:nth" at line 1, column "3:Birthday". The value on line 2 in the column is "1998-02-28", which is not equal than the expected "2000-12-01".
             "allow_values" at line 3, column "4:Favorite color". Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"].
             
@@ -107,7 +108,7 @@ final class ValidateCsvQuickTest extends TestCase
             Summary:
               3 pairs (schema to csv) were found based on `filename_pattern`.
               Found 2 issues in 1 schemas.
-              Found 12 issues in 3 out of 3 CSV files.
+              Found 13 issues in 3 out of 3 CSV files.
             
             
             TXT;

--- a/tests/Commands/ValidateCsvQuickTest.php
+++ b/tests/Commands/ValidateCsvQuickTest.php
@@ -81,20 +81,22 @@ final class ValidateCsvQuickTest extends TestCase
             CSV file validation: 3
             (1/3) Schema: ./tests/schemas/demo_invalid.yml
             (1/3) CSV   : ./tests/fixtures/batch/demo-1.csv
-            (1/3) Issues: 3
+            (1/3) Issues: 4
             "csv.header" at line 1. Columns not found in CSV: "wrong_column_name".
             "ag:is_unique" at line 1, column "1:City". Column has non-unique values. Unique: 1, total: 2.
+            "ag:nth" at line 1, column "3:Birthday". The value on line 2 in the column is "1998-02-28", which is not equal than the expected "2000-12-01".
             "allow_values" at line 3, column "4:Favorite color". Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"].
             
             (2/3) Schema: ./tests/schemas/demo_invalid.yml
             (2/3) CSV   : ./tests/fixtures/batch/demo-2.csv
-            (2/3) Issues: 6
+            (2/3) Issues: 7
             "csv.header" at line 1. Columns not found in CSV: "wrong_column_name".
             "length_min" at line 2, column "0:Name". The length of the value "Carl" is 4, which is less than the expected "5".
             "length_min" at line 7, column "0:Name". The length of the value "Lois" is 4, which is less than the expected "5".
             "date_min" at line 2, column "3:Birthday". The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the expected "1955-05-15 00:00:00 +00:00 (1955-05-15)".
             "date_min" at line 4, column "3:Birthday". The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the expected "1955-05-15 00:00:00 +00:00 (1955-05-15)".
             "date_max" at line 5, column "3:Birthday". The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", which is greater than the expected "2009-01-01 00:00:00 +00:00 (2009-01-01)".
+            "ag:nth" at line 1, column "3:Birthday". The value on line 2 in the column is "1989-05-15", which is not equal than the expected "2000-12-01".
             
             (3/3) Schema: ./tests/schemas/demo_invalid.yml
             (3/3) CSV   : ./tests/fixtures/batch/sub/demo-3.csv
@@ -105,7 +107,7 @@ final class ValidateCsvQuickTest extends TestCase
             Summary:
               3 pairs (schema to csv) were found based on `filename_pattern`.
               Found 2 issues in 1 schemas.
-              Found 10 issues in 3 out of 3 CSV files.
+              Found 12 issues in 3 out of 3 CSV files.
             
             
             TXT;

--- a/tests/Commands/ValidateCsvReportsTest.php
+++ b/tests/Commands/ValidateCsvReportsTest.php
@@ -45,7 +45,7 @@ final class ValidateCsvReportsTest extends TestCase
             CSV file validation: 1
             (1/1) Schema: ./tests/schemas/demo_invalid.yml
             (1/1) CSV   : ./tests/fixtures/demo.csv
-            (1/1) Issues: 9
+            (1/1) Issues: 10
             +------+------------------+--------------+------------------------- demo.csv -------------------------------------------------------------------+
             | Line | id:Column        | Rule         | Message                                                                                              |
             +------+------------------+--------------+------------------------------------------------------------------------------------------------------+
@@ -54,6 +54,7 @@ final class ValidateCsvReportsTest extends TestCase
             | 11   | 0:Name           | length_min   | The length of the value "Lois" is 4, which is less than the expected "5"                             |
             | 1    | 1:City           | ag:is_unique | Column has non-unique values. Unique: 9, total: 10                                                   |
             | 2    | 2:Float          | num_max      | The number of the value "4825.185", which is greater than the expected "4825.184"                    |
+            | 1    | 2:Float          | ag:nth_num   | The N-th value in the column is "74", which is not equal than the expected "0.001"                   |
             | 6    | 3:Birthday       | date_min     | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
             |      |                  |              | expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"                                                   |
             | 8    | 3:Birthday       | date_min     | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
@@ -67,7 +68,7 @@ final class ValidateCsvReportsTest extends TestCase
             Summary:
               1 pairs (schema to csv) were found based on `filename_pattern`.
               Found 2 issues in 1 schemas.
-              Found 9 issues in 1 out of 1 CSV files.
+              Found 10 issues in 1 out of 1 CSV files.
             
             
             TXT;
@@ -92,12 +93,13 @@ final class ValidateCsvReportsTest extends TestCase
             CSV file validation: 1
             (1/1) Schema: ./tests/schemas/demo_invalid.yml
             (1/1) CSV   : ./tests/fixtures/demo.csv
-            (1/1) Issues: 9
+            (1/1) Issues: 10
             "csv.header" at line 1. Columns not found in CSV: "wrong_column_name".
             "length_min" at line 6, column "0:Name". The length of the value "Carl" is 4, which is less than the expected "5".
             "length_min" at line 11, column "0:Name". The length of the value "Lois" is 4, which is less than the expected "5".
             "ag:is_unique" at line 1, column "1:City". Column has non-unique values. Unique: 9, total: 10.
             "num_max" at line 2, column "2:Float". The number of the value "4825.185", which is greater than the expected "4825.184".
+            "ag:nth_num" at line 1, column "2:Float". The N-th value in the column is "74", which is not equal than the expected "0.001".
             "date_min" at line 6, column "3:Birthday". The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the expected "1955-05-15 00:00:00 +00:00 (1955-05-15)".
             "date_min" at line 8, column "3:Birthday". The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the expected "1955-05-15 00:00:00 +00:00 (1955-05-15)".
             "date_max" at line 9, column "3:Birthday". The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", which is greater than the expected "2009-01-01 00:00:00 +00:00 (2009-01-01)".
@@ -107,7 +109,7 @@ final class ValidateCsvReportsTest extends TestCase
             Summary:
               1 pairs (schema to csv) were found based on `filename_pattern`.
               Found 2 issues in 1 schemas.
-              Found 9 issues in 1 out of 1 CSV files.
+              Found 10 issues in 1 out of 1 CSV files.
             
             
             TXT;
@@ -133,7 +135,7 @@ final class ValidateCsvReportsTest extends TestCase
             CSV file validation: 1
             (1/1) Schema: ./tests/schemas/demo_invalid.yml
             (1/1) CSV   : ./tests/fixtures/demo.csv
-            (1/1) Issues: 9
+            (1/1) Issues: 10
             ::error file=<root>/tests/fixtures/demo.csv,line=1::csv.header at column%0A"csv.header" at line 1. Columns not found in CSV: "wrong_column_name".
             
             ::error file=<root>/tests/fixtures/demo.csv,line=6::length_min at column 0:Name%0A"length_min" at line 6, column "0:Name". The length of the value "Carl" is 4, which is less than the expected "5".
@@ -143,6 +145,8 @@ final class ValidateCsvReportsTest extends TestCase
             ::error file=<root>/tests/fixtures/demo.csv,line=1::ag:is_unique at column 1:City%0A"ag:is_unique" at line 1, column "1:City". Column has non-unique values. Unique: 9, total: 10.
             
             ::error file=<root>/tests/fixtures/demo.csv,line=2::num_max at column 2:Float%0A"num_max" at line 2, column "2:Float". The number of the value "4825.185", which is greater than the expected "4825.184".
+            
+            ::error file=<root>/tests/fixtures/demo.csv,line=1::ag:nth_num at column 2:Float%0A"ag:nth_num" at line 1, column "2:Float". The N-th value in the column is "74", which is not equal than the expected "0.001".
             
             ::error file=<root>/tests/fixtures/demo.csv,line=6::date_min at column 3:Birthday%0A"date_min" at line 6, column "3:Birthday". The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the expected "1955-05-15 00:00:00 +00:00 (1955-05-15)".
             
@@ -156,7 +160,7 @@ final class ValidateCsvReportsTest extends TestCase
             Summary:
               1 pairs (schema to csv) were found based on `filename_pattern`.
               Found 2 issues in 1 schemas.
-              Found 9 issues in 1 out of 1 CSV files.
+              Found 10 issues in 1 out of 1 CSV files.
             
             
             TXT;
@@ -183,7 +187,7 @@ final class ValidateCsvReportsTest extends TestCase
             ##teamcity[testSuiteFinished name='demo_invalid.yml' flowId='42']
             
             
-            ##teamcity[testCount count='9' flowId='42']
+            ##teamcity[testCount count='10' flowId='42']
             
             ##teamcity[testSuiteStarted name='demo.csv' flowId='42']
             
@@ -206,6 +210,10 @@ final class ValidateCsvReportsTest extends TestCase
             ##teamcity[testStarted name='num_max at column 2:Float' locationHint='php_qn://<root>/tests/fixtures/demo.csv' flowId='42']
             "num_max" at line 2, column "2:Float". The number of the value "4825.185", which is greater than the expected "4825.184".
             ##teamcity[testFinished name='num_max at column 2:Float' flowId='42']
+            
+            ##teamcity[testStarted name='ag:nth_num at column 2:Float' locationHint='php_qn://<root>/tests/fixtures/demo.csv' flowId='42']
+            "ag:nth_num" at line 1, column "2:Float". The N-th value in the column is "74", which is not equal than the expected "0.001".
+            ##teamcity[testFinished name='ag:nth_num at column 2:Float' flowId='42']
             
             ##teamcity[testStarted name='date_min at column 3:Birthday' locationHint='php_qn://<root>/tests/fixtures/demo.csv' flowId='42']
             "date_min" at line 6, column "3:Birthday". The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the expected "1955-05-15 00:00:00 +00:00 (1955-05-15)".
@@ -249,7 +257,7 @@ final class ValidateCsvReportsTest extends TestCase
             
             <?xml version="1.0" encoding="UTF-8"?>
             <testsuites>
-              <testsuite name="demo.csv" tests="9">
+              <testsuite name="demo.csv" tests="10">
                 <testcase name="csv.header at column" file="<root>/tests/fixtures/demo.csv" line="1">
                   <system-out>"csv.header" at line 1. Columns not found in CSV: "wrong_column_name".</system-out>
                 </testcase>
@@ -264,6 +272,9 @@ final class ValidateCsvReportsTest extends TestCase
                 </testcase>
                 <testcase name="num_max at column 2:Float" file="<root>/tests/fixtures/demo.csv" line="2">
                   <system-out>"num_max" at line 2, column "2:Float". The number of the value "4825.185", which is greater than the expected "4825.184".</system-out>
+                </testcase>
+                <testcase name="ag:nth_num at column 2:Float" file="<root>/tests/fixtures/demo.csv" line="1">
+                  <system-out>"ag:nth_num" at line 1, column "2:Float". The N-th value in the column is "74", which is not equal than the expected "0.001".</system-out>
                 </testcase>
                 <testcase name="date_min at column 3:Birthday" file="<root>/tests/fixtures/demo.csv" line="6">
                   <system-out>"date_min" at line 6, column "3:Birthday". The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the expected "1955-05-15 00:00:00 +00:00 (1955-05-15)".</system-out>
@@ -368,6 +379,17 @@ final class ValidateCsvReportsTest extends TestCase
                         "path": "<root>\/tests\/fixtures\/demo.csv",
                         "lines": {
                             "begin": 2
+                        }
+                    }
+                },
+                {
+                    "description": "ag:nth_num at column 2:Float\n\"ag:nth_num\" at line 1, column \"2:Float\". The N-th value in the column is \"74\", which is not equal than the expected \"0.001\".",
+                    "fingerprint": "_replaced_",
+                    "severity": "major",
+                    "location": {
+                        "path": "<root>\/tests\/fixtures\/demo.csv",
+                        "lines": {
+                            "begin": 1
                         }
                     }
                 },

--- a/tests/Rules/Aggregate/ComboAverageTest.php
+++ b/tests/Rules/Aggregate/ComboAverageTest.php
@@ -76,11 +76,13 @@ class ComboAverageTest extends TestAbstractAggregateRuleCombo
 
     public function testInvalidOption(): void
     {
-        $this->expectExceptionMessage(
-            'Invalid option "[1, 2]" for the "ag:average_max" rule. It should be integer/float.',
-        );
         $rule = $this->create([1, 2], Combo::MAX);
-        $rule->validate(['1', '2', '3']);
+        isSame(
+            '"ag:average_max" at line <red>1</red>, column "prop". ' .
+            'Invalid option "[1, 2]" for the "ag:average_max" rule. ' .
+            'It should be integer/float.',
+            (string)$rule->validate(['1', '2', '3']),
+        );
     }
 
     public function testInvalidParsing(): void

--- a/tests/Rules/Aggregate/ComboCountEmptyTest.php
+++ b/tests/Rules/Aggregate/ComboCountEmptyTest.php
@@ -81,11 +81,13 @@ class ComboCountEmptyTest extends TestAbstractAggregateRuleCombo
 
     public function testInvalidOption(): void
     {
-        $this->expectExceptionMessage(
-            'Invalid option "[1, 2]" for the "ag:count_empty_max" rule. It should be integer/float.',
-        );
         $rule = $this->create([1, 2], Combo::MAX);
-        $rule->validate(['1', '2', '3']);
+        isSame(
+            '"ag:count_empty_max" at line <red>1</red>, column "prop". ' .
+            'Invalid option "[1, 2]" for the "ag:count_empty_max" rule. ' .
+            'It should be integer/float.',
+            (string)$rule->validate(['1', '2', '3']),
+        );
     }
 
     public function testInvalidParsing(): void

--- a/tests/Rules/Aggregate/ComboCountNotEmptyTest.php
+++ b/tests/Rules/Aggregate/ComboCountNotEmptyTest.php
@@ -77,15 +77,6 @@ class ComboCountNotEmptyTest extends TestAbstractAggregateRuleCombo
         );
     }
 
-    public function testInvalidOption(): void
-    {
-        $this->expectExceptionMessage(
-            'Invalid option "[1, 2]" for the "ag:count_not_empty_max" rule. It should be integer/float.',
-        );
-        $rule = $this->create([1, 2], Combo::MAX);
-        $rule->validate(['1', '2', '3']);
-    }
-
     public function testInvalidParsing(): void
     {
         $rule = $this->create(0, Combo::EQ);

--- a/tests/Rules/Aggregate/ComboCountTest.php
+++ b/tests/Rules/Aggregate/ComboCountTest.php
@@ -74,15 +74,6 @@ class ComboCountTest extends TestAbstractAggregateRuleCombo
         );
     }
 
-    public function testInvalidOption(): void
-    {
-        $this->expectExceptionMessage(
-            'Invalid option "[1, 2]" for the "ag:count_max" rule. It should be integer/float.',
-        );
-        $rule = $this->create([1, 2], Combo::MAX);
-        $rule->validate(['1', '2', '3']);
-    }
-
     public function testInvalidParsing(): void
     {
         $rule = $this->create(0, Combo::EQ);

--- a/tests/Rules/Aggregate/ComboNthNumTest.php
+++ b/tests/Rules/Aggregate/ComboNthNumTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Rules\Aggregate;
+
+use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\Aggregate\ComboNthNum;
+use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
+
+use function JBZoo\PHPUnit\isSame;
+
+class ComboNthNumTest extends TestAbstractAggregateRuleCombo
+{
+    protected string $ruleClass = ComboNthNum::class;
+
+    public function testEqual(): void
+    {
+        $rule = $this->create([2, 30], Combo::EQ);
+
+        isSame('', $rule->test(['1', '30', '3']));
+
+        isSame(
+            'The N-th value in the column is "3", which is not equal than the expected "30"',
+            $rule->test(['2.00', '3', '4.5']),
+        );
+    }
+}

--- a/tests/Rules/Aggregate/ComboNthNumTest.php
+++ b/tests/Rules/Aggregate/ComboNthNumTest.php
@@ -29,12 +29,24 @@ class ComboNthNumTest extends TestAbstractAggregateRuleCombo
     public function testEqual(): void
     {
         $rule = $this->create([2, 30], Combo::EQ);
-
         isSame('', $rule->test(['1', '30', '3']));
-
         isSame(
             'The N-th value in the column is "3", which is not equal than the expected "30"',
             $rule->test(['2.00', '3', '4.5']),
+        );
+
+        $rule = $this->create([100, 30], Combo::EQ);
+        isSame(
+            '"ag:nth_num" at line <red>1</red>, column "prop". ' .
+            'The column does not have a line 100, so the value cannot be checked.',
+            (string)$rule->validate(['2.00', '3', '4.5']),
+        );
+        $rule = $this->create([], Combo::EQ);
+        isSame(
+            '"ag:nth_num" at line <red>1</red>, column "prop". ' .
+            'The rule expects exactly two arguments: ' .
+            'the first is the line number (without header), the second is the expected value.',
+            (string)$rule->validate(['2.00', '3', '4.5']),
         );
     }
 }

--- a/tests/Rules/Aggregate/ComboSumTest.php
+++ b/tests/Rules/Aggregate/ComboSumTest.php
@@ -74,13 +74,6 @@ class ComboSumTest extends TestAbstractAggregateRuleCombo
         );
     }
 
-    public function testInvalidOption(): void
-    {
-        $this->expectExceptionMessage('Invalid option "[1, 2]" for the "ag:sum_max" rule. It should be integer/float.');
-        $rule = $this->create([1, 2], Combo::MAX);
-        $rule->validate(['1', '2', '3']);
-    }
-
     public function testInvalidParsing(): void
     {
         $this->expectExceptionMessage('The value should be an array of numbers/strings');

--- a/tests/Rules/Aggregate/NthNotTest.php
+++ b/tests/Rules/Aggregate/NthNotTest.php
@@ -27,9 +27,9 @@ final class NthNotTest extends TestAbstractAggregateRule
 
     public function testPositive(): void
     {
-        $rule = $this->create([2, 'Value']);
+        $rule = $this->create([1, 'Value']);
         isSame(null, $rule->validate([]));
-        isSame(null, $rule->validate(['', 'Value', '']));
+        isSame(null, $rule->validate(['Asasasa', 'Value', 'Qwerty']));
     }
 
     public function testNegative(): void
@@ -44,13 +44,13 @@ final class NthNotTest extends TestAbstractAggregateRule
         $rule = $this->create([]);
         isSame(
             'The rule expects exactly two arguments: ' .
-            'the first is the line number, the second is the not expected value',
+            'the first is the line number (without header), the second is the not expected value',
             $rule->test(['1', 'Value', '2', '3']),
         );
 
-        $rule = $this->create([2, 'Value']);
+        $rule = $this->create([3, 'Value']);
         isSame(
-            'The 2 value in the column is "Value", which is equal than the not expected "Value"',
+            'The value on line 3 in the column is "Value", which is equal than the not expected "Value"',
             $rule->test(['1', '2', 'Value', '3']),
         );
     }

--- a/tests/Rules/Aggregate/NthTest.php
+++ b/tests/Rules/Aggregate/NthTest.php
@@ -27,7 +27,7 @@ final class NthTest extends TestAbstractAggregateRule
 
     public function testPositive(): void
     {
-        $rule = $this->create([2, 'Value']);
+        $rule = $this->create([3, 'Value']);
         isSame(null, $rule->validate([]));
         isSame(null, $rule->validate(['', '2', 'Value']));
         isSame(null, $rule->validate(['', '2', 'Value', '']));
@@ -45,14 +45,14 @@ final class NthTest extends TestAbstractAggregateRule
         $rule = $this->create([]);
         isSame(
             'The rule expects exactly two arguments: ' .
-            'the first is the line number, the second is the expected value',
+            'the first is the line number (without header), the second is the expected value',
             $rule->test(['1', 'Value', '2', '3']),
         );
 
         $rule = $this->create([2, 'Value']);
         isSame(
-            'The 2 value in the column is "2", which is not equal than the expected "Value"',
-            $rule->test(['1', 'Value', '2', '3']),
+            'The value on line 2 in the column is "2", which is not equal than the expected "Value"',
+            $rule->test(['1', '2', 'Value', '3']),
         );
     }
 }

--- a/tests/schemas/demo_invalid.yml
+++ b/tests/schemas/demo_invalid.yml
@@ -35,6 +35,8 @@ columns:
       is_float: true
       num_min: -19366059128
       num_max: 4825.184
+    aggregate_rules:
+      nth_num: [ 4, 0.001 ]
 
   - name: Birthday
     rules:

--- a/tests/schemas/demo_invalid.yml
+++ b/tests/schemas/demo_invalid.yml
@@ -42,6 +42,8 @@ columns:
       date_format: Y-m-d
       date_min: "1955-05-15"
       date_max: "2009-01-01"
+    aggregate_rules:
+      nth: [ 2, '2000-12-01' ]
 
   - name: Favorite color
     example: 123


### PR DESCRIPTION
This update introduces a new error handling mechanism for the nth value rule, providing enhanced precision when validating CSV data. The nth_num rule has been added to manage acceptance of line numbers without headers, and the expected value handling has been enhanced. This update also revises related test cases to ensure these newly introduced systems work as intended.