### PR TITLE
Add "contains_none" rule to cell validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Stable Version](https://poser.pugx.org/jbzoo/csv-blueprint/version)](https://packagist.org/packages/jbzoo/csv-blueprint/)    [![Total Downloads](https://poser.pugx.org/jbzoo/csv-blueprint/downloads)](https://packagist.org/packages/jbzoo/csv-blueprint/stats)    [![Docker Pulls](https://img.shields.io/docker/pulls/jbzoo/csv-blueprint.svg)](https://hub.docker.com/r/jbzoo/csv-blueprint/tags)    [![GitHub License](https://img.shields.io/github/license/jbzoo/csv-blueprint)](https://github.com/JBZoo/Csv-Blueprint/blob/master/LICENSE)
 
 <!-- rules-counter -->
-[![Static Badge](https://img.shields.io/badge/Rules-179-green?label=Total%20Number%20of%20Rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)    [![Static Badge](https://img.shields.io/badge/Rules-65-green?label=Cell%20Value&labelColor=blue&color=gray)](src/Rules/Cell)    [![Static Badge](https://img.shields.io/badge/Rules-109-green?label=Aggregate%20Column&labelColor=blue&color=gray)](src/Rules/Aggregate)    [![Static Badge](https://img.shields.io/badge/Rules-5-green?label=Extra%20Checks&labelColor=blue&color=gray)](#extra-checks)    [![Static Badge](https://img.shields.io/badge/Rules-301-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
+[![Static Badge](https://img.shields.io/badge/Rules-180-green?label=Total%20Number%20of%20Rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)    [![Static Badge](https://img.shields.io/badge/Rules-66-green?label=Cell%20Value&labelColor=blue&color=gray)](src/Rules/Cell)    [![Static Badge](https://img.shields.io/badge/Rules-109-green?label=Aggregate%20Column&labelColor=blue&color=gray)](src/Rules/Aggregate)    [![Static Badge](https://img.shields.io/badge/Rules-5-green?label=Extra%20Checks&labelColor=blue&color=gray)](#extra-checks)    [![Static Badge](https://img.shields.io/badge/Rules-293-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
 <!-- /rules-counter -->
 
 ## Introduction
@@ -194,8 +194,9 @@ columns:
 
       # Contains rules
       contains: Hello                   # Example: "Hello World".
-      contains_one: [ a, b ]            # At least one of the string must be in the CSV value.
+      contains_one: [ a, b ]            # At least one of the string must be part of the CSV value.
       contains_all: [ a, b, c ]         # All the strings must be part of a CSV value.
+      contains_none: [ a, b ]           # All the strings must NOT be part of a CSV value.
       starts_with: "prefix "            # Example: "prefix Hello World".
       ends_with: " suffix"              # Example: "Hello World suffix".
 

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -49,6 +49,7 @@
                 "contains"              : "Hello",
                 "contains_one"          : ["a", "b"],
                 "contains_all"          : ["a", "b", "c"],
+                "contains_none"         : ["a", "b"],
                 "starts_with"           : "prefix ",
                 "ends_with"             : " suffix",
 

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -67,11 +67,12 @@ This example serves as a comprehensive guide for creating robust CSV file valida
                 'word_count_less'    => 8,
                 'word_count_max'     => 9,
 
-                'contains'     => 'Hello',
-                'contains_one' => ['a', 'b'],
-                'contains_all' => ['a', 'b', 'c'],
-                'starts_with'  => 'prefix ',
-                'ends_with'    => ' suffix',
+                'contains'      => 'Hello',
+                'contains_one'  => ['a', 'b'],
+                'contains_all'  => ['a', 'b', 'c'],
+                'contains_none' => ['a', 'b'],
+                'starts_with'   => 'prefix ',
+                'ends_with'     => ' suffix',
 
                 'num_min'     => 1.0,
                 'num_greater' => 2.0,

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -108,8 +108,9 @@ columns:
 
       # Contains rules
       contains: Hello                   # Example: "Hello World".
-      contains_one: [ a, b ]            # At least one of the string must be in the CSV value.
+      contains_one: [ a, b ]            # At least one of the string must be part of the CSV value.
       contains_all: [ a, b, c ]         # All the strings must be part of a CSV value.
+      contains_none: [ a, b ]           # All the strings must NOT be part of a CSV value.
       starts_with: "prefix "            # Example: "prefix Hello World".
       ends_with: " suffix"              # Example: "Hello World suffix".
 

--- a/schema-examples/full_clean.yml
+++ b/schema-examples/full_clean.yml
@@ -75,6 +75,9 @@ columns:
         - a
         - b
         - c
+      contains_none:
+        - a
+        - b
       starts_with: 'prefix '
       ends_with: ' suffix'
 

--- a/src/Rules/Cell/ContainsNone.php
+++ b/src/Rules/Cell/ContainsNone.php
@@ -16,13 +16,13 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Cell;
 
-final class ContainsOne extends AbstractCellRule
+final class ContainsNone extends AbstractCellRule
 {
     public function getHelpMeta(): array
     {
         return [
             [],
-            [self::DEFAULT => ['[ a, b ]', 'At least one of the string must be part of the CSV value.']],
+            [self::DEFAULT => ['[ a, b ]', 'All the strings must NOT be part of a CSV value.']],
         ];
     }
 
@@ -32,18 +32,18 @@ final class ContainsOne extends AbstractCellRule
             return null;
         }
 
-        $inclusions = $this->getOptionAsArray();
-        if (\count($inclusions) === 0) {
-            return 'Rule must contain at least one inclusion value in schema file.';
+        $exclusions = $this->getOptionAsArray();
+        if (\count($exclusions) === 0) {
+            return 'Rule must contain at least one exclusion value in schema file.';
         }
 
-        foreach ($inclusions as $inclusion) {
-            if (\strpos($cellValue, $inclusion) !== false) {
-                return null;
+        foreach ($exclusions as $exclusion) {
+            if (\strpos($cellValue, $exclusion) !== false) {
+                return "Value \"<c>{$cellValue}</c>\" must not contain any of the following:" .
+                    ' "<green>["' . \implode('", "', $exclusions) . '"]</green>"';
             }
         }
 
-        return "Value \"<c>{$cellValue}</c>\" must contain at least one of the following:" .
-            ' "<green>["' . \implode('", "', $inclusions) . '"]</green>"';
+        return null;
     }
 }

--- a/tests/Rules/Cell/ContainsNoneTest.php
+++ b/tests/Rules/Cell/ContainsNoneTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Rules\Cell;
+
+use JBZoo\CsvBlueprint\Rules\Cell\ContainsNone;
+use JBZoo\PHPUnit\Rules\TestAbstractCellRule;
+
+use function JBZoo\PHPUnit\isSame;
+
+final class ContainsNoneTest extends TestAbstractCellRule
+{
+    protected string $ruleClass = ContainsNone::class;
+
+    public function testPositive(): void
+    {
+        $rule = $this->create([]);
+        isSame('', $rule->test(''));
+
+        $rule = $this->create(['a', 'b', 'c']);
+        isSame('', $rule->test(''));
+        isSame('', $rule->test('q'));
+    }
+
+    public function testNegative(): void
+    {
+        $rule = $this->create([]);
+        isSame(
+            'Rule must contain at least one exclusion value in schema file.',
+            $rule->test('ac'),
+        );
+
+        $rule = $this->create(['a', 'b', 'c']);
+        isSame(
+            'Value "a" must not contain any of the following: "["a", "b", "c"]"',
+            $rule->test('a'),
+        );
+
+        $rule = $this->create(['a', 'b', 'c']);
+        isSame(
+            'Value "ddddb" must not contain any of the following: "["a", "b", "c"]"',
+            $rule->test('ddddb'),
+        );
+    }
+}

--- a/tests/schemas/todo.yml
+++ b/tests/schemas/todo.yml
@@ -44,18 +44,8 @@ columns:
       is_iban: true
       is_bool_value: true             # https://github.com/Respect/Validation/blob/main/docs/rules/BoolVal.md
 
-      # Comparisons
-      between: 1
-      between_exclusive: [ min, max ]  # https://github.com/Respect/Validation/blob/main/docs/rules/BetweenExclusive.md
-      equals: 1
-      equivalent: 1
-      identical: 1
-      in: 1
-
       # Composite (deprecated current rule names)
-      all_of: [ ]
       any_of: [ ]
-      consecutive: [ ]
       none_of: [ ]
       one_of: [ ]
       


### PR DESCRIPTION
This update introduces a new rule named "contains_none" to the cell validation process. This rule takes an array of strings and validates that none of these strings appear in the cell value. Changes have been incorporated in the relevant schema example files and the associated PHP and Test files for the new validation rule have been created.
