### PR TITLE
Add 'is_sorted' rule to aggregate rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Stable Version](https://poser.pugx.org/jbzoo/csv-blueprint/version)](https://packagist.org/packages/jbzoo/csv-blueprint/)    [![Total Downloads](https://poser.pugx.org/jbzoo/csv-blueprint/downloads)](https://packagist.org/packages/jbzoo/csv-blueprint/stats)    [![Docker Pulls](https://img.shields.io/docker/pulls/jbzoo/csv-blueprint.svg)](https://hub.docker.com/r/jbzoo/csv-blueprint/tags)    [![GitHub License](https://img.shields.io/github/license/jbzoo/csv-blueprint)](https://github.com/JBZoo/Csv-Blueprint/blob/master/LICENSE)
 
 <!-- rules-counter -->
-[![Static Badge](https://img.shields.io/badge/Rules-276-green?label=Total%20Number%20of%20Rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)    [![Static Badge](https://img.shields.io/badge/Rules-66-green?label=Cell%20Value&labelColor=blue&color=gray)](src/Rules/Cell)    [![Static Badge](https://img.shields.io/badge/Rules-205-green?label=Aggregate%20Column&labelColor=blue&color=gray)](src/Rules/Aggregate)    [![Static Badge](https://img.shields.io/badge/Rules-5-green?label=Extra%20Checks&labelColor=blue&color=gray)](#extra-checks)    [![Static Badge](https://img.shields.io/badge/Rules-233-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
+[![Static Badge](https://img.shields.io/badge/Rules-277-green?label=Total%20Number%20of%20Rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)    [![Static Badge](https://img.shields.io/badge/Rules-66-green?label=Cell%20Value&labelColor=blue&color=gray)](src/Rules/Cell)    [![Static Badge](https://img.shields.io/badge/Rules-206-green?label=Aggregate%20Column&labelColor=blue&color=gray)](src/Rules/Aggregate)    [![Static Badge](https://img.shields.io/badge/Rules-5-green?label=Extra%20Checks&labelColor=blue&color=gray)](#extra-checks)    [![Static Badge](https://img.shields.io/badge/Rules-227-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
 <!-- /rules-counter -->
 
 ## Introduction
@@ -275,6 +275,12 @@ columns:
     # TODO: There are several ways to optimize this process, but the author needs time to test it carefully.
     aggregate_rules:
       is_unique: true                   # All values in the column are unique.
+
+      # Check if the column is sorted in a specific order.
+      #  - Direction: "asc", "desc".
+      #  - Method: "natural", "regular", "numeric", "string".
+      # See: https://www.php.net/manual/en/function.sort.php
+      is_sorted: [ asc, natural ]       # Expected ascending order, natural sorting.
 
       # First number in the column. Expected value is float or integer.
       first_num_min: 1.0                # x >= 1.0

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -99,6 +99,7 @@
             },
             "aggregate_rules" : {
                 "is_unique"                   : true,
+                "is_sorted"                   : ["asc", "natural"],
 
                 "first_num_min"               : 1,
                 "first_num_greater"           : 2,

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -121,6 +121,7 @@ This example serves as a comprehensive guide for creating robust CSV file valida
 
             'aggregate_rules' => [
                 'is_unique' => true,
+                'is_sorted' => ['asc', 'natural'],
 
                 'first_num_min'     => 1.0,
                 'first_num_greater' => 2.0,

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -190,6 +190,12 @@ columns:
     aggregate_rules:
       is_unique: true                   # All values in the column are unique.
 
+      # Check if the column is sorted in a specific order.
+      #  - Direction: "asc", "desc".
+      #  - Method: "natural", "regular", "numeric", "string".
+      # See: https://www.php.net/manual/en/function.sort.php
+      is_sorted: [ asc, natural ]       # Expected ascending order, natural sorting.
+
       # First number in the column. Expected value is float or integer.
       first_num_min: 1.0                # x >= 1.0
       first_num_greater: 2.0            # x >  2.0

--- a/schema-examples/full_clean.yml
+++ b/schema-examples/full_clean.yml
@@ -126,6 +126,9 @@ columns:
 
     aggregate_rules:
       is_unique: true
+      is_sorted:
+        - asc
+        - natural
 
       first_num_min: 1.0
       first_num_greater: 2.0

--- a/src/Rules/Aggregate/IsSorted.php
+++ b/src/Rules/Aggregate/IsSorted.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Rules\Aggregate;
+
+use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+
+final class IsSorted extends AbstarctAggregateRule
+{
+    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_STRINGS;
+
+    private const ARGS   = 2;
+    private const DIR    = 0;
+    private const METHOD = 1;
+
+    private const DIRS    = ['asc', 'desc'];
+    private const METHODS = [
+        'natural' => \SORT_NATURAL,
+        'regular' => \SORT_REGULAR,
+        'numeric' => \SORT_NUMERIC,
+        'string'  => \SORT_STRING,
+    ];
+
+    public function getHelpMeta(): array
+    {
+        return [
+            [
+                'Check if the column is sorted in a specific order.',
+                ' - Direction: "' . \implode('", "', self::DIRS) . '".',
+                ' - Method: "' . \implode('", "', \array_keys(self::METHODS)) . '".',
+                'See: https://www.php.net/manual/en/function.sort.php',
+            ],
+            [
+                self::DEFAULT => ['[ asc, natural ]', 'Expected ascending order, natural sorting.'],
+            ],
+        ];
+    }
+
+    public function validateRule(array &$columnValues): ?string
+    {
+        if (\count($columnValues) === 0) {
+            return null;
+        }
+
+        try {
+            $dir    = $this->getDir();
+            $method = $this->getMethod();
+        } catch (\RuntimeException $e) {
+            return $e->getMessage();
+        }
+
+        $methodHuman = $this->getParams()[self::METHOD];
+
+        $sorted = $columnValues; // copy
+        if ($dir === self::DIRS[0]) {
+            \sort($sorted, $method);
+        } else {
+            \rsort($sorted, $method);
+        }
+
+        if ($sorted !== $columnValues) {
+            return "The column is not sorted \"{$dir}\" using method \"{$methodHuman}\"";
+        }
+
+        return null;
+    }
+
+    private function getDir(): string
+    {
+        $dir = $this->getParams()[self::DIR];
+
+        if (!\in_array($dir, self::DIRS, true)) {
+            throw new \RuntimeException(
+                "Unknown sort direction: \"{$dir}\". Allowed: \"" . \implode('", "', self::DIRS) . '"',
+            );
+        }
+
+        return $dir;
+    }
+
+    private function getMethod(): int
+    {
+        $method = $this->getParams()[self::METHOD];
+
+        if (!\in_array($method, \array_keys(self::METHODS), true)) {
+            throw new \RuntimeException(
+                "Unknown sort method: \"{$method}\". Allowed: \"" . \implode('", "', \array_keys(self::METHODS)) . '"',
+            );
+        }
+
+        return self::METHODS[$method];
+    }
+
+    private function getParams(): array
+    {
+        $params = $this->getOptionAsArray();
+        if (\count($params) !== self::ARGS) {
+            throw new \RuntimeException(
+                'The rule expects exactly three params: ' .
+                'method (exclusive, inclusive), type (0%, Q1, Q2, Q3, 100%, IQR), expected value (float)',
+            );
+        }
+
+        return $params;
+    }
+}

--- a/tests/Rules/Aggregate/IsSortedTest.php
+++ b/tests/Rules/Aggregate/IsSortedTest.php
@@ -21,7 +21,7 @@ use JBZoo\PHPUnit\Rules\TestAbstractAggregateRule;
 
 use function JBZoo\PHPUnit\isSame;
 
-class SortedTest extends TestAbstractAggregateRule
+class IsSortedTest extends TestAbstractAggregateRule
 {
     protected string $ruleClass = IsSorted::class;
 

--- a/tests/Rules/Aggregate/SortedTest.php
+++ b/tests/Rules/Aggregate/SortedTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Rules\Aggregate;
+
+use JBZoo\CsvBlueprint\Rules\Aggregate\IsSorted;
+use JBZoo\PHPUnit\Rules\TestAbstractAggregateRule;
+
+use function JBZoo\PHPUnit\isSame;
+
+class SortedTest extends TestAbstractAggregateRule
+{
+    protected string $ruleClass = IsSorted::class;
+
+    public function testPositive(): void
+    {
+        // natural
+        $rule = $this->create(['asc', 'natural']);
+        isSame('', $rule->test([]));
+        isSame('', $rule->test(['item2', 'item10', 'item12']));
+
+        $rule = $this->create(['desc', 'natural']);
+        isSame('', $rule->test(['item12', 'item10', 'item2']));
+
+        // regular
+        $rule = $this->create(['asc', 'regular']);
+        isSame('', $rule->test(['item10', 'item12', 'item2']));
+
+        $rule = $this->create(['desc', 'regular']);
+        isSame('', $rule->test(['item2', 'item12', 'item10']));
+
+        // numeric
+        $rule = $this->create(['asc', 'numeric']);
+        isSame('', $rule->test(['Orange1', 'Orange3', 'orange2', 'orange20', '1', '2', '11', '20', '21']));
+
+        $rule = $this->create(['desc', 'numeric']);
+        isSame('', $rule->test(['21', '20', '11', '2', '1', 'orange20', 'orange2', 'Orange3', 'Orange1']));
+
+        // string
+        $rule = $this->create(['asc', 'string']);
+        isSame('', $rule->test(['1', '11', '2', '20', '21', 'Orange1', 'Orange3', 'orange2', 'orange20']));
+
+        $rule = $this->create(['desc', 'string']);
+        isSame('', $rule->test(['orange20', 'orange2', 'Orange3', 'Orange1', '21', '20', '2', '11', '1']));
+    }
+
+    public function testNegative(): void
+    {
+        $rule = $this->create(['asc', 'natural']);
+        isSame(
+            'The column is not sorted "asc" using method "natural"',
+            $rule->test(['1', '11', '2', '20', '21']),
+        );
+
+        $rule = $this->create(['QQQ', 'natural']);
+        isSame(
+            'Unknown sort direction: "QQQ". Allowed: "asc", "desc"',
+            $rule->test(['1', '11', '2', '20', '21']),
+        );
+
+        $rule = $this->create(['asc', 'QQQQQQQ']);
+        isSame(
+            'Unknown sort method: "QQQQQQQ". Allowed: "natural", "regular", "numeric", "string"',
+            $rule->test(['1', '11', '2', '20', '21']),
+        );
+    }
+}

--- a/tests/schemas/todo.yml
+++ b/tests/schemas/todo.yml
@@ -223,9 +223,6 @@ columns:
 
 
     aggregate_rules:
-      # ?? https://github.com/Respect/Validation/blob/main/docs/rules/Sorted.md
-      sorted: [ asc, SORT_NATURAL ]   # SORT_NATURAL, SORT_FLAG_CASE, SORT_FLAG_CASE|SORT_NATURAL
-
       count_true: 1
       count_false: 1
 


### PR DESCRIPTION
The `is_sorted` rule has been added to the aggregate rules section of the schema examples in various formats (json, php, yml, etc.). This rule checks if the column is sorted in a specific order. An implementation of the rule has also been added to the 'Rules/Aggregate' section of the application's source code and tests for this rule have been written under `tests/Rules/Aggregate/SortedTest.php`.