### PR TITLE
Add delay to wait for Docker image and extend release workflows

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -28,6 +28,15 @@ jobs:
     name: All Report Types
     runs-on: ubuntu-latest
     steps:
+      # Sleep for 15 minutes to wait for the Docker image to be built and pushed to the Docker Hub.
+      # This is a workaround for the Docker image not being available immediately after the release is created.
+      # I don't want to use a GA trigger to wait for the Docker image to be built and pushed to the Docker Hub,
+      # because in this case the name of the pipeline in the log will be "Demo", not the name of the tag.
+      # Usually it takes less than 12 minutes to build and push the Docker image.
+      # So 15 min - just in case.
+      - name: Wait for Docker image
+        run: sleep 900
+
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -268,6 +268,14 @@ jobs:
         run: |
           ! $BLUEPRINT_DOCKER $CMD_VALIDATE $INVALID_TEST
 
+      - name: Push Docker Image (master)
+        uses: docker/build-push-action@v5
+        if: github.ref == 'refs/heads/master'
+        with:
+          context: .
+          puth: true
+          tags: jbzoo/csv-blueprint:master
+
 
   verify-ga:
     name: Verify GitHub Actions

--- a/.github/workflows/release-phar.yml
+++ b/.github/workflows/release-phar.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Build project in production mode
         run: make build-prod build-phar-file --no-print-directory
 
+      - name: 🎨 Test PHAR file
+        run: ./build/csv-blueprint.phar --ansi -vvv
+
       - name: Upload PHAR to the release
         uses: softprops/action-gh-release@v2
         with:

--- a/src/CliApplication.php
+++ b/src/CliApplication.php
@@ -23,13 +23,13 @@ class CliApplication extends \JBZoo\Cli\CliApplication
         ' / ___/ __/ | / /  / _ )/ /_ _____ ___  ____(_)__  / /_',
         '/ /___\ \ | |/ /  / _  / / // / -_) _ \/ __/ / _ \/ __/',
         '\___/___/ |___/  /____/_/\_,_/\__/ .__/_/ /_/_//_/\__/ ',
-        '                               /_/                    ',
+        '                                /_/                    ',
     ];
 
     public function getLongVersion(): string
     {
         $logo = '<info>' . \implode("</info>\n<info>", $this->appLogo) . '</info>';
 
-        return "{$logo}</info>\n" . Utils::getVersion(false);
+        return "{$logo}\n" . Utils::getVersion(false);
     }
 }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -322,7 +322,11 @@ final class Utils
         $version = ["<info>{$tag}</info>", $dateStr];
 
         if (!bool($isStable)) {
-            $version[] = '<comment>Experimental!</comment>';
+            if ($branch === 'master' || $branch === 'main') {
+                $version[] = '<comment>Night build</comment>';
+            } else {
+                $version[] = '<comment>Experimental!</comment>';
+            }
             $version[] = "\nBranch: {$branch} ({$hash})";
         }
 


### PR DESCRIPTION
This commit introduces a delay in the demo GitHub Action workflow to diminish the issue of the Docker image not being available immediately after release. Additionally, the workflows have been expanded on with more conditions for pushing to Docker and testing PHAR files. Lastly, some trivial changes have been made to output content for improved readability.
