### PR TITLE
Fix typo in GitHub Action push command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -273,7 +273,7 @@ jobs:
         if: github.ref == 'refs/heads/master'
         with:
           context: .
-          puth: true
+          push: true
           tags: jbzoo/csv-blueprint:master
 
 


### PR DESCRIPTION
This commit corrects a typographical error in the GitHub Action main workflow file, changing 'puth' to 'push'. This ensures the correct Docker command is triggered and avoids potential failures in the image publishing process.
