### PR TITLE
Refactor tests to handle integers as strings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 
         "league/csv"                          : "^9.15.0",
         "jbzoo/data"                          : "^7.1.1",
-        "jbzoo/cli"                           : "^7.2.1",
+        "jbzoo/cli"                           : "^7.2.2",
         "jbzoo/utils"                         : "^7.2.1",
         "jbzoo/ci-report-converter"           : "^7.2.1",
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "044e0e165042c8d9d38be2e786209913",
+    "content-hash": "36f97cb9f275e6a0d29b9241ab3084ca",
     "packages": [
         {
             "name": "bluepsyduck/symfony-process-manager",
@@ -287,16 +287,16 @@
         },
         {
             "name": "jbzoo/cli",
-            "version": "7.2.1",
+            "version": "7.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/JBZoo/Cli.git",
-                "reference": "afb6b31f4d155967a021215b142f15725ddd5039"
+                "reference": "eaf5e090746f87f5e7feb940b80c1b1c79b18b87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JBZoo/Cli/zipball/afb6b31f4d155967a021215b142f15725ddd5039",
-                "reference": "afb6b31f4d155967a021215b142f15725ddd5039",
+                "url": "https://api.github.com/repos/JBZoo/Cli/zipball/eaf5e090746f87f5e7feb940b80c1b1c79b18b87",
+                "reference": "eaf5e090746f87f5e7feb940b80c1b1c79b18b87",
                 "shasum": ""
             },
             "require": {
@@ -358,9 +358,9 @@
             ],
             "support": {
                 "issues": "https://github.com/JBZoo/Cli/issues",
-                "source": "https://github.com/JBZoo/Cli/tree/7.2.1"
+                "source": "https://github.com/JBZoo/Cli/tree/7.2.2"
             },
-            "time": "2024-03-28T20:21:50+00:00"
+            "time": "2024-03-29T11:53:39+00:00"
         },
         {
             "name": "jbzoo/data",

--- a/src/Rules/AbstarctRule.php
+++ b/src/Rules/AbstarctRule.php
@@ -83,6 +83,8 @@ abstract class AbstarctRule
                     $line,
                 );
             }
+        } else {
+            throw new \RuntimeException('Method "validateRule" not found in ' . static::class);
         }
 
         return null;

--- a/src/Rules/AbstarctRule.php
+++ b/src/Rules/AbstarctRule.php
@@ -68,23 +68,19 @@ abstract class AbstarctRule
             return null;
         }
 
-        if (\method_exists($this, 'validateRule')) {
-            try {
-                /** @phan-suppress-next-line PhanUndeclaredMethod */
-                $error = $this->validateRule($cellValue);
-                if ($error !== null) {
-                    return new Error($this->ruleCode, $error, $this->columnNameId, $line);
-                }
-            } catch (\Exception $e) {
-                return new Error(
-                    $this->ruleCode,
-                    "Unexpected error: {$e->getMessage()}",
-                    $this->columnNameId,
-                    $line,
-                );
+        try {
+            /** @phan-suppress-next-line PhanUndeclaredMethod */
+            $error = $this->validateRule($cellValue);
+            if ($error !== null) {
+                return new Error($this->ruleCode, $error, $this->columnNameId, $line);
             }
-        } else {
-            throw new \RuntimeException('Method "validateRule" not found in ' . static::class);
+        } catch (\Exception $e) {
+            return new Error(
+                $this->ruleCode,
+                "Unexpected error: {$e->getMessage()}",
+                $this->columnNameId,
+                $line,
+            );
         }
 
         return null;

--- a/src/Rules/AbstarctRule.php
+++ b/src/Rules/AbstarctRule.php
@@ -68,19 +68,21 @@ abstract class AbstarctRule
             return null;
         }
 
-        try {
-            /** @phan-suppress-next-line PhanUndeclaredMethod */
-            $error = $this->validateRule($cellValue);
-            if ($error !== null) {
-                return new Error($this->ruleCode, $error, $this->columnNameId, $line);
+        if (\method_exists($this, 'validateRule')) { // TODO: Need to be removed
+            try {
+                /** @phan-suppress-next-line PhanUndeclaredMethod */
+                $error = $this->validateRule($cellValue);
+                if ($error !== null) {
+                    return new Error($this->ruleCode, $error, $this->columnNameId, $line);
+                }
+            } catch (\Exception $e) {
+                return new Error(
+                    $this->ruleCode,
+                    "Unexpected error: {$e->getMessage()}",
+                    $this->columnNameId,
+                    $line,
+                );
             }
-        } catch (\Exception $e) {
-            return new Error(
-                $this->ruleCode,
-                "Unexpected error: {$e->getMessage()}",
-                $this->columnNameId,
-                $line,
-            );
         }
 
         return null;

--- a/src/Rules/Aggregate/AbstractAggregateRule.php
+++ b/src/Rules/Aggregate/AbstractAggregateRule.php
@@ -25,13 +25,13 @@ abstract class AbstractAggregateRule extends AbstarctRule
     /**
      * Validate the rule.
      *
-     * This method takes an array reference &$columnValues as input and returns a nullable string.
+     * TODO: This method takes an array reference &$columnValues as input and returns a nullable string.
      * We use a reference to the array to avoid copying the array. Important memory optimization!
      * Please DO NOT change the array in this method!
      *
      * @param string[] $columnValues
      */
-    abstract public function validateRule(array &$columnValues): ?string;
+    abstract public function validateRule(array $columnValues): ?string;
 
     public function test(array $cellValue, bool $isHtml = false): string
     {

--- a/src/Rules/Aggregate/AbstractAggregateRuleCombo.php
+++ b/src/Rules/Aggregate/AbstractAggregateRuleCombo.php
@@ -53,6 +53,15 @@ abstract class AbstractAggregateRuleCombo extends AbstarctRuleCombo
         $name = static::NAME;
 
         try {
+            // TODO: Think about the performance optimization here
+            if (static::INPUT_TYPE === AbstarctRule::INPUT_TYPE_FLOATS) {
+                $colValues = \array_map('floatval', $colValues);
+            }
+
+            if (static::INPUT_TYPE === AbstarctRule::INPUT_TYPE_INTS) {
+                $colValues = \array_map('intval', $colValues);
+            }
+
             $actual = $this->getActualAggregate($colValues); // Important to use the original method here!
         } catch (\Throwable $exception) {
             return $exception->getMessage(); // TODO: Expose the error/warning message in the report?

--- a/src/Rules/Aggregate/AbstractAggregateRuleCombo.php
+++ b/src/Rules/Aggregate/AbstractAggregateRuleCombo.php
@@ -64,7 +64,7 @@ abstract class AbstractAggregateRuleCombo extends AbstarctRuleCombo
 
             $actual = $this->getActualAggregate($colValues); // Important to use the original method here!
         } catch (\Throwable $exception) {
-            return $exception->getMessage(); // TODO: Expose the error/warning message in the report?
+            return "<red>{$exception->getMessage()}</red>"; // TODO: Expose the error/warning message in the report?
         }
 
         if ($actual === null) {
@@ -74,7 +74,7 @@ abstract class AbstractAggregateRuleCombo extends AbstarctRuleCombo
         try {
             $expected = $this->getExpected();
         } catch (\Throwable $exception) {
-            return $exception->getMessage(); // TODO: Expose the error/warning message in the report?
+            return "<red>{$exception->getMessage()}</red>"; // TODO: Expose the error/warning message in the report?
         }
 
         if (!self::compare($expected, $actual, $mode)) {

--- a/src/Rules/Aggregate/ComboMeanAbsDev.php
+++ b/src/Rules/Aggregate/ComboMeanAbsDev.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
-use JBZoo\CsvBlueprint\Utils;
 use MathPHP\Statistics\Descriptive;
 
 final class ComboMeanAbsDev extends AbstractAggregateRuleCombo
@@ -44,6 +43,6 @@ final class ComboMeanAbsDev extends AbstractAggregateRuleCombo
             return null;
         }
 
-        return Descriptive::meanAbsoluteDeviation(Utils::stringsToFloat($colValues));
+        return Descriptive::meanAbsoluteDeviation($colValues);
     }
 }

--- a/src/Rules/Aggregate/ComboMedianAbsDev.php
+++ b/src/Rules/Aggregate/ComboMedianAbsDev.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
-use JBZoo\CsvBlueprint\Utils;
 use MathPHP\Statistics\Descriptive;
 
 final class ComboMedianAbsDev extends AbstractAggregateRuleCombo
@@ -45,6 +44,6 @@ final class ComboMedianAbsDev extends AbstractAggregateRuleCombo
             return null;
         }
 
-        return Descriptive::medianAbsoluteDeviation(Utils::stringsToFloat($colValues));
+        return Descriptive::medianAbsoluteDeviation($colValues);
     }
 }

--- a/src/Rules/Aggregate/ComboQuartiles.php
+++ b/src/Rules/Aggregate/ComboQuartiles.php
@@ -75,7 +75,7 @@ final class ComboQuartiles extends AbstractAggregateRuleCombo
 
         $method = $this->getMethod();
         $type = $this->getType();
-        $result = Descriptive::quartiles(Utils::stringsToFloat($colValues), $method);
+        $result = Descriptive::quartiles($colValues, $method);
 
         return $result[$type];
     }

--- a/src/Rules/Aggregate/ComboQuartiles.php
+++ b/src/Rules/Aggregate/ComboQuartiles.php
@@ -75,7 +75,7 @@ final class ComboQuartiles extends AbstractAggregateRuleCombo
 
         $method = $this->getMethod();
         $type = $this->getType();
-        $result = Descriptive::quartiles($colValues, $method);
+        $result = Descriptive::quartiles(Utils::stringsToFloat($colValues), $method);
 
         return $result[$type];
     }

--- a/src/Rules/Aggregate/First.php
+++ b/src/Rules/Aggregate/First.php
@@ -30,7 +30,7 @@ final class First extends AbstractAggregateRule
         ];
     }
 
-    public function validateRule(array &$columnValues): ?string
+    public function validateRule(array $columnValues): ?string
     {
         if (\count($columnValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/FirstNot.php
+++ b/src/Rules/Aggregate/FirstNot.php
@@ -35,7 +35,7 @@ final class FirstNot extends AbstractAggregateRule
         ];
     }
 
-    public function validateRule(array &$columnValues): ?string
+    public function validateRule(array $columnValues): ?string
     {
         if (\count($columnValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/IsUnique.php
+++ b/src/Rules/Aggregate/IsUnique.php
@@ -30,7 +30,7 @@ final class IsUnique extends AbstractAggregateRule
         ];
     }
 
-    public function validateRule(array &$columnValues): ?string
+    public function validateRule(array $columnValues): ?string
     {
         if (\count($columnValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/Last.php
+++ b/src/Rules/Aggregate/Last.php
@@ -30,7 +30,7 @@ final class Last extends AbstractAggregateRule
         ];
     }
 
-    public function validateRule(array &$columnValues): ?string
+    public function validateRule(array $columnValues): ?string
     {
         if (\count($columnValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/LastNot.php
+++ b/src/Rules/Aggregate/LastNot.php
@@ -35,7 +35,7 @@ final class LastNot extends AbstractAggregateRule
         ];
     }
 
-    public function validateRule(array &$columnValues): ?string
+    public function validateRule(array $columnValues): ?string
     {
         if (\count($columnValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/Nth.php
+++ b/src/Rules/Aggregate/Nth.php
@@ -34,7 +34,7 @@ final class Nth extends AbstractAggregateRule
         ];
     }
 
-    public function validateRule(array &$columnValues): ?string
+    public function validateRule(array $columnValues): ?string
     {
         if (\count($columnValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/NthNot.php
+++ b/src/Rules/Aggregate/NthNot.php
@@ -39,7 +39,7 @@ final class NthNot extends AbstractAggregateRule
         ];
     }
 
-    public function validateRule(array &$columnValues): ?string
+    public function validateRule(array $columnValues): ?string
     {
         if (\count($columnValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/Sorted.php
+++ b/src/Rules/Aggregate/Sorted.php
@@ -73,7 +73,7 @@ final class Sorted extends AbstractAggregateRule
         }
 
         if ($sorted !== $columnValues) {
-            return "The column is not sorted \"{$dir}\" using method \"{$methodHuman}\"";
+            return "The column is not sorted \"<green>{$dir}</green>\" using method \"<green>{$methodHuman}</green>\"";
         }
 
         return null;

--- a/src/Rules/Aggregate/Sorted.php
+++ b/src/Rules/Aggregate/Sorted.php
@@ -50,7 +50,7 @@ final class Sorted extends AbstractAggregateRule
         ];
     }
 
-    public function validateRule(array &$columnValues): ?string
+    public function validateRule(array $columnValues): ?string
     {
         if (\count($columnValues) === 0) {
             return null;

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -362,14 +362,6 @@ final class Utils
         return FS::format((int)\filesize($csv));
     }
 
-    /**
-     * @param float[] $colValues
-     */
-    public static function stringsToFloat(array $colValues): array
-    {
-        return \array_map('\floatval', $colValues);
-    }
-
     public static function isPhpUnit(): bool
     {
         return \defined('PHPUNIT_COMPOSER_INSTALL') || \defined('__PHPUNIT_PHAR__');

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -370,6 +370,11 @@ final class Utils
         return \array_map('\floatval', $colValues);
     }
 
+    public static function isPhpUnit(): bool
+    {
+        return \defined('PHPUNIT_COMPOSER_INSTALL') || \defined('__PHPUNIT_PHAR__');
+    }
+
     /**
      * @param SplFileInfo[] $files
      */
@@ -387,11 +392,6 @@ final class Utils
     private static function filterNotUsedFiles(array $files): array
     {
         return \array_keys(\array_filter($files, static fn ($value) => $value === false));
-    }
-
-    private static function isPhpUnit(): bool
-    {
-        return \defined('PHPUNIT_COMPOSER_INSTALL') || \defined('__PHPUNIT_PHAR__');
     }
 
     private static function convertTzToUTC(string $dateWithSourceTZ): \DateTime

--- a/src/Validators/Error.php
+++ b/src/Validators/Error.php
@@ -33,10 +33,13 @@ final class Error
         $columnStr = $this->getColumnName() === '' ? '' : ", column \"{$this->getColumnName()}\"";
 
         if ($this->line === self::UNDEFINED_LINE) {
-            return "\"{$this->getRuleCode()}\"{$columnStr}. {$this->getMessage()}.";
+            $fullMessage = "\"{$this->getRuleCode()}\"{$columnStr}. {$this->getMessage()}.";
+        } else {
+            $fullMessage = "\"{$this->getRuleCode()}\" at line <red>{$this->getLine()}</red>{$columnStr}." .
+                " {$this->getMessage()}.";
         }
 
-        return "\"{$this->getRuleCode()}\" at line <red>{$this->getLine()}</red>{$columnStr}. {$this->getMessage()}.";
+        return \str_replace('.</', '</', $fullMessage); // Double dots fix.
     }
 
     public function getRuleCode(): string

--- a/src/Validators/Error.php
+++ b/src/Validators/Error.php
@@ -31,12 +31,12 @@ final class Error
     public function __toString(): string
     {
         $columnStr = $this->getColumnName() === '' ? '' : ", column \"{$this->getColumnName()}\"";
+        $error = \rtrim($this->getMessage(), '.');
 
         if ($this->line === self::UNDEFINED_LINE) {
-            $fullMessage = "\"{$this->getRuleCode()}\"{$columnStr}. {$this->getMessage()}.";
+            $fullMessage = "\"{$this->getRuleCode()}\"{$columnStr}. {$error}.";
         } else {
-            $fullMessage = "\"{$this->getRuleCode()}\" at line <red>{$this->getLine()}</red>{$columnStr}." .
-                " {$this->getMessage()}.";
+            $fullMessage = "\"{$this->getRuleCode()}\" at line <red>{$this->getLine()}</red>{$columnStr}. {$error}.";
         }
 
         return \str_replace('.</', '</', $fullMessage); // Double dots fix.

--- a/tests/Commands/ValidateCsvBatchCsvTest.php
+++ b/tests/Commands/ValidateCsvBatchCsvTest.php
@@ -23,7 +23,6 @@ use Symfony\Component\Console\Input\StringInput;
 
 use function JBZoo\PHPUnit\isNotEmpty;
 use function JBZoo\PHPUnit\isSame;
-use function JBZoo\PHPUnit\skip;
 
 final class ValidateCsvBatchCsvTest extends TestCase
 {
@@ -157,8 +156,6 @@ final class ValidateCsvBatchCsvTest extends TestCase
 
     public function testMultipleCsvOptions(): void
     {
-        skip('TODO: Fix filesize in tests');
-
         [$expected, $expectedCode] = Tools::virtualExecution('validate:csv', [
             'csv'    => './tests/fixtures/batch/*.csv',
             'schema' => Tools::DEMO_YML_INVALID,
@@ -181,6 +178,9 @@ final class ValidateCsvBatchCsvTest extends TestCase
         // Remove version
         $actual = \preg_replace('/^.+\n/', '', $actual);
         $expected = \preg_replace('/^.+\n/', '', $expected);
+
+        // Remove file size
+        $actual = \preg_replace('/; Size: .*B/', '; Size: 123.34 MB', $actual);
 
         isNotEmpty($expected);
         isNotEmpty($actual);

--- a/tests/Rules/Aggregate/ComboAverageTest.php
+++ b/tests/Rules/Aggregate/ComboAverageTest.php
@@ -79,7 +79,7 @@ class ComboAverageTest extends TestAbstractAggregateRuleCombo
         $rule = $this->create([1, 2], Combo::MAX);
         isSame(
             '"ag:average_max" at line <red>1</red>, column "prop". ' .
-            'Invalid option ["1", "2"] for the "ag:average_max" rule. It should be integer/float.',
+            '<red>Invalid option ["1", "2"] for the "ag:average_max" rule. It should be integer/float</red>.',
             (string)$rule->validate(['1', '2', '3']),
         );
     }

--- a/tests/Rules/Aggregate/ComboCoefOfVarTest.php
+++ b/tests/Rules/Aggregate/ComboCoefOfVarTest.php
@@ -29,13 +29,13 @@ class ComboCoefOfVarTest extends TestAbstractAggregateRuleCombo
     public function testEqual(): void
     {
         $rule = $this->create(0.18856180831641, Combo::EQ);
-        isSame('', $rule->test([13, 18, 13, 14, 13, 16, 14, 21, 13]));
+        isSame('', $rule->test(['13', '18', '13', '14', '13', '16', '14', '21', '13']));
 
         $rule = $this->create(3, Combo::EQ);
         isSame(
             'The Coefficient of variation in the column is "0.18856180831641", ' .
             'which is not equal than the expected "3"',
-            $rule->test([13, 18, 13, 14, 13, 16, 14, 21, 13]),
+            $rule->test(['13', '18', '13', '14', '13', '16', '14', '21', '13']),
         );
     }
 }

--- a/tests/Rules/Aggregate/ComboContraharmonicMeanTest.php
+++ b/tests/Rules/Aggregate/ComboContraharmonicMeanTest.php
@@ -30,12 +30,12 @@ class ComboContraharmonicMeanTest extends TestAbstractAggregateRuleCombo
     {
         $rule = $this->create(15.474074074074, Combo::EQ);
         isSame('', $rule->test([]));
-        isSame('', $rule->test([13, 18, 13, 14, 13, 16, 14, 21, 13]));
+        isSame('', $rule->test(['13', '18', '13', '14', '13', '16', '14', '21', '13']));
 
         $rule = $this->create(1, Combo::EQ);
         isSame(
             'The contraharmonic mean in the column is "15.474074074074", which is not equal than the expected "1"',
-            $rule->test([13, 18, 13, 14, 13, 16, 14, 21, 13]),
+            $rule->test(['13', '18', '13', '14', '13', '16', '14', '21', '13']),
         );
     }
 }

--- a/tests/Rules/Aggregate/ComboCountEmptyTest.php
+++ b/tests/Rules/Aggregate/ComboCountEmptyTest.php
@@ -85,7 +85,7 @@ class ComboCountEmptyTest extends TestAbstractAggregateRuleCombo
         $rule = $this->create([1, 2], Combo::MAX);
         isSame(
             '"ag:count_empty_max" at line <red>1</red>, column "prop". ' .
-            'Invalid option ["1", "2"] for the "ag:count_empty_max" rule. It should be integer/float.',
+            '<red>Invalid option ["1", "2"] for the "ag:count_empty_max" rule. It should be integer/float</red>.',
             (string)$rule->validate(['1', '2', '3']),
         );
     }

--- a/tests/Rules/Aggregate/ComboCountEvenTest.php
+++ b/tests/Rules/Aggregate/ComboCountEvenTest.php
@@ -31,11 +31,11 @@ class ComboCountEvenTest extends TestAbstractAggregateRuleCombo
         $rule = $this->create(1, Combo::EQ);
 
         isSame('', $rule->test([]));
-        isSame('', $rule->test([1, 2, 3]));
+        isSame('', $rule->test(['1', '2', '3']));
 
         isSame(
             'The number of even values in the column is "2", which is not equal than the expected "1"',
-            $rule->test([1, 2, 3, 4, 5]),
+            $rule->test(['1', '2', '3', '4', '5']),
         );
     }
 }

--- a/tests/Rules/Aggregate/ComboCountNotEmptyTest.php
+++ b/tests/Rules/Aggregate/ComboCountNotEmptyTest.php
@@ -74,7 +74,7 @@ class ComboCountNotEmptyTest extends TestAbstractAggregateRuleCombo
 
         isSame(
             'The number of not empty rows in the column is "5", which is greater than the expected "3"',
-            $rule->test([1, 2, 3, 4, 5]),
+            $rule->test(['1', '2', '3', '4', '5']),
         );
     }
 

--- a/tests/Rules/Aggregate/ComboCountOddTest.php
+++ b/tests/Rules/Aggregate/ComboCountOddTest.php
@@ -31,11 +31,11 @@ class ComboCountOddTest extends TestAbstractAggregateRuleCombo
         $rule = $this->create(1, Combo::EQ);
 
         isSame('', $rule->test([]));
-        isSame('', $rule->test([2, 3, 4]));
+        isSame('', $rule->test(['2', '3', '4']));
 
         isSame(
             'The number of odd values in the column is "3", which is not equal than the expected "1"',
-            $rule->test([1, 2, 3, 4, 5]),
+            $rule->test(['1', '2', '3', '4', '5']),
         );
     }
 }

--- a/tests/Rules/Aggregate/ComboCountPrimeTest.php
+++ b/tests/Rules/Aggregate/ComboCountPrimeTest.php
@@ -19,6 +19,7 @@ namespace JBZoo\PHPUnit\Rules\Aggregate;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboCountPrime;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
+use JBZoo\PHPUnit\Tools;
 
 use function JBZoo\PHPUnit\isSame;
 
@@ -31,11 +32,11 @@ class ComboCountPrimeTest extends TestAbstractAggregateRuleCombo
         $rule = $this->create(25, Combo::EQ);
 
         isSame('', $rule->test([]));
-        isSame('', $rule->test(\range(1, 100)));
+        isSame('', $rule->test(Tools::range(1, 100)));
 
         isSame(
             'The number of prime values in the column is "4", which is not equal than the expected "25"',
-            $rule->test(\range(1, 10)),
+            $rule->test(Tools::range(1, 10)),
         );
     }
 }

--- a/tests/Rules/Aggregate/ComboCubicMeanTest.php
+++ b/tests/Rules/Aggregate/ComboCubicMeanTest.php
@@ -30,12 +30,12 @@ class ComboCubicMeanTest extends TestAbstractAggregateRuleCombo
     {
         $rule = $this->create(15.492307432707, Combo::EQ);
         isSame('', $rule->test([]));
-        isSame('', $rule->test([13, 18, 13, 14, 13, 16, 14, 21, 13]));
+        isSame('', $rule->test(['13', '18', '13', '14', '13', '16', '14', '21', '13']));
 
         $rule = $this->create(1, Combo::EQ);
         isSame(
             'The cubic mean in the column is "15.492307432707", which is not equal than the expected "1"',
-            $rule->test([13, 18, 13, 14, 13, 16, 14, 21, 13]),
+            $rule->test(['13', '18', '13', '14', '13', '16', '14', '21', '13']),
         );
     }
 }

--- a/tests/Rules/Aggregate/ComboGeometricMeanTest.php
+++ b/tests/Rules/Aggregate/ComboGeometricMeanTest.php
@@ -30,12 +30,12 @@ class ComboGeometricMeanTest extends TestAbstractAggregateRuleCombo
     {
         $rule = $this->create(14.789726414533, Combo::EQ);
         isSame('', $rule->test([]));
-        isSame('', $rule->test([13, 18, 13, 14, 13, 16, 14, 21, 13]));
+        isSame('', $rule->test(['13', '18', '13', '14', '13', '16', '14', '21', '13']));
 
         $rule = $this->create(1, Combo::EQ);
         isSame(
             'The geometric mean in the column is "14.789726414533", which is not equal than the expected "1"',
-            $rule->test([13, 18, 13, 14, 13, 16, 14, 21, 13]),
+            $rule->test(['13', '18', '13', '14', '13', '16', '14', '21', '13']),
         );
     }
 }

--- a/tests/Rules/Aggregate/ComboHarmonicMeanTest.php
+++ b/tests/Rules/Aggregate/ComboHarmonicMeanTest.php
@@ -30,12 +30,12 @@ class ComboHarmonicMeanTest extends TestAbstractAggregateRuleCombo
     {
         $rule = $this->create(14.605077399381, Combo::EQ);
         isSame('', $rule->test([]));
-        isSame('', $rule->test([13, 18, 13, 14, 13, 16, 14, 21, 13]));
+        isSame('', $rule->test(['13', '18', '13', '14', '13', '16', '14', '21', '13']));
 
         $rule = $this->create(1, Combo::EQ);
         isSame(
             'The harmonic mean in the column is "14.605077399381", which is not equal than the expected "1"',
-            $rule->test([13, 18, 13, 14, 13, 16, 14, 21, 13]),
+            $rule->test(['13', '18', '13', '14', '13', '16', '14', '21', '13']),
         );
     }
 }

--- a/tests/Rules/Aggregate/ComboInterquartileMeanTest.php
+++ b/tests/Rules/Aggregate/ComboInterquartileMeanTest.php
@@ -30,12 +30,12 @@ class ComboInterquartileMeanTest extends TestAbstractAggregateRuleCombo
     {
         $rule = $this->create(14, Combo::EQ);
         isSame('', $rule->test([]));
-        isSame('', $rule->test([13, 18, 13, 14, 13, 16, 14, 21, 13]));
+        isSame('', $rule->test(['13', '18', '13', '14', '13', '16', '14', '21', '13']));
 
         $rule = $this->create(1, Combo::EQ);
         isSame(
             'The interquartile mean (IQM) in the column is "14", which is not equal than the expected "1"',
-            $rule->test([13, 18, 13, 14, 13, 16, 14, 21, 13]),
+            $rule->test(['13', '18', '13', '14', '13', '16', '14', '21', '13']),
         );
     }
 }

--- a/tests/Rules/Aggregate/ComboMedianTest.php
+++ b/tests/Rules/Aggregate/ComboMedianTest.php
@@ -19,6 +19,7 @@ namespace JBZoo\PHPUnit\Rules\Aggregate;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboMedian;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
+use JBZoo\PHPUnit\Tools;
 
 use function JBZoo\PHPUnit\isSame;
 
@@ -30,11 +31,11 @@ class ComboMedianTest extends TestAbstractAggregateRuleCombo
     {
         $rule = $this->create(5.5, Combo::EQ);
 
-        isSame('', $rule->test(\range(1, 10)));
+        isSame('', $rule->test(Tools::range(1, 10)));
 
         isSame(
             'The median in the column is "6", which is not equal than the expected "5.5"',
-            $rule->test(\range(1, 11)),
+            $rule->test(Tools::range(1, 11)),
         );
     }
 
@@ -42,11 +43,11 @@ class ComboMedianTest extends TestAbstractAggregateRuleCombo
     {
         $rule = $this->create(6, Combo::NOT);
 
-        isSame('', $rule->test(\range(1, 10)));
+        isSame('', $rule->test(Tools::range(1, 10)));
 
         isSame(
             'The median in the column is "6", which is equal than the not expected "6"',
-            $rule->test(\range(1, 11)),
+            $rule->test(Tools::range(1, 11)),
         );
     }
 

--- a/tests/Rules/Aggregate/ComboMidhingeTest.php
+++ b/tests/Rules/Aggregate/ComboMidhingeTest.php
@@ -19,6 +19,7 @@ namespace JBZoo\PHPUnit\Rules\Aggregate;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboMidhinge;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
+use JBZoo\PHPUnit\Tools;
 
 use function JBZoo\PHPUnit\isSame;
 
@@ -30,12 +31,12 @@ class ComboMidhingeTest extends TestAbstractAggregateRuleCombo
     {
         $rule = $this->create(18, Combo::EQ);
         isSame('', $rule->test([]));
-        isSame('', $rule->test(\range(1, 35)));
+        isSame('', $rule->test(Tools::range(1, 35)));
 
         $rule = $this->create(3, Combo::EQ);
         isSame(
             'The midhinge in the column is "18", which is not equal than the expected "3"',
-            $rule->test(\range(1, 35)),
+            $rule->test(Tools::range(1, 35)),
         );
     }
 }

--- a/tests/Rules/Aggregate/ComboNthNumTest.php
+++ b/tests/Rules/Aggregate/ComboNthNumTest.php
@@ -38,14 +38,14 @@ class ComboNthNumTest extends TestAbstractAggregateRuleCombo
         $rule = $this->create([100, 30], Combo::EQ);
         isSame(
             '"ag:nth_num" at line <red>1</red>, column "prop". ' .
-            'The column does not have a line 100, so the value cannot be checked.',
+            '<red>The column does not have a line 100, so the value cannot be checked</red>.',
             (string)$rule->validate(['2.00', '3', '4.5']),
         );
         $rule = $this->create([], Combo::EQ);
         isSame(
             '"ag:nth_num" at line <red>1</red>, column "prop". ' .
-            'The rule expects exactly two arguments: ' .
-            'the first is the line number (without header), the second is the expected value.',
+            '<red>The rule expects exactly two arguments: the first is the line number (without header), ' .
+            'the second is the expected value</red>.',
             (string)$rule->validate(['2.00', '3', '4.5']),
         );
     }

--- a/tests/Rules/Aggregate/ComboPercentileTest.php
+++ b/tests/Rules/Aggregate/ComboPercentileTest.php
@@ -19,6 +19,7 @@ namespace JBZoo\PHPUnit\Rules\Aggregate;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboPercentile;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
+use JBZoo\PHPUnit\Tools;
 
 use function JBZoo\PHPUnit\isSame;
 
@@ -29,10 +30,10 @@ class ComboPercentileTest extends TestAbstractAggregateRuleCombo
     public function testEqual(): void
     {
         $rule = $this->create([95, 950.05], Combo::EQ);
-        isSame('', $rule->test(\range(1, 1000)));
+        isSame('', $rule->test(Tools::range(1, 1000)));
         isSame(
             'The percentile in the column is "190.05", which is not equal than the expected "950.05"',
-            $rule->test(\range(1, 200)),
+            $rule->test(Tools::range(1, 200)),
         );
     }
 
@@ -42,7 +43,7 @@ class ComboPercentileTest extends TestAbstractAggregateRuleCombo
         isSame(
             'The rule expects exactly two params: ' .
             'the first is percentile (P is beet 0.0 and 100.0), the second is the expected value (float)',
-            $rule->test(\range(1, 200)),
+            $rule->test(Tools::range(1, 200)),
         );
     }
 }

--- a/tests/Rules/Aggregate/ComboQuartilesTest.php
+++ b/tests/Rules/Aggregate/ComboQuartilesTest.php
@@ -19,6 +19,7 @@ namespace JBZoo\PHPUnit\Rules\Aggregate;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboQuartiles;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
+use JBZoo\PHPUnit\Tools;
 
 use function JBZoo\PHPUnit\isSame;
 
@@ -28,7 +29,7 @@ class ComboQuartilesTest extends TestAbstractAggregateRuleCombo
 
     public function testEqual(): void
     {
-        $range = \range(2, 400);
+        $range = Tools::range(2, 400);
 
         $rule = $this->create(['exclusive', '0%', 2], Combo::EQ);
         isSame('', $rule->test($range));
@@ -70,7 +71,7 @@ class ComboQuartilesTest extends TestAbstractAggregateRuleCombo
 
         isSame(
             'The quartile in the column is "100", which is not equal than the expected "199"',
-            $rule->test(\range(1, 200)),
+            $rule->test(Tools::range(1, 200)),
         );
     }
 
@@ -82,19 +83,19 @@ class ComboQuartilesTest extends TestAbstractAggregateRuleCombo
             'method ["exclusive", "inclusive"], ' .
             'type ["0%", "Q1", "Q2", "Q3", "100%", "IQR"], ' .
             'expected value (float)',
-            $rule->test(\range(1, 200)),
+            $rule->test(Tools::range(1, 200)),
         );
 
         $rule = $this->create(['qwerty', 'IQR', 5], Combo::EQ);
         isSame(
             'Unknown quartile method: "qwerty". Allowed: ["exclusive", "inclusive"]',
-            $rule->test(\range(1, 200)),
+            $rule->test(Tools::range(1, 200)),
         );
 
         $rule = $this->create(['inclusive', 'QQQQ', 5], Combo::EQ);
         isSame(
             'Unknown quartile type: "QQQQ". Allowed: ["0%", "Q1", "Q2", "Q3", "100%", "IQR"]',
-            $rule->test(\range(1, 200)),
+            $rule->test(Tools::range(1, 200)),
         );
     }
 }

--- a/tests/Rules/Aggregate/ComboRootMeanSquareTest.php
+++ b/tests/Rules/Aggregate/ComboRootMeanSquareTest.php
@@ -30,13 +30,13 @@ class ComboRootMeanSquareTest extends TestAbstractAggregateRuleCombo
     {
         $rule = $this->create(15.235193176035, Combo::EQ);
         isSame('', $rule->test([]));
-        isSame('', $rule->test([13, 18, 13, 14, 13, 16, 14, 21, 13]));
+        isSame('', $rule->test(['13', '18', '13', '14', '13', '16', '14', '21', '13']));
 
         $rule = $this->create(1, Combo::EQ);
         isSame(
             'The root mean square (quadratic mean) in the column is "15.235193176035", ' .
             'which is not equal than the expected "1"',
-            $rule->test([13, 18, 13, 14, 13, 16, 14, 21, 13]),
+            $rule->test(['13', '18', '13', '14', '13', '16', '14', '21', '13']),
         );
     }
 }

--- a/tests/Rules/Aggregate/ComboSampleVarianceTest.php
+++ b/tests/Rules/Aggregate/ComboSampleVarianceTest.php
@@ -29,12 +29,12 @@ class ComboSampleVarianceTest extends TestAbstractAggregateRuleCombo
     public function testEqual(): void
     {
         $rule = $this->create(10.5, Combo::EQ);
-        isSame('', $rule->test([13, 18, 13, 14, 13, 16, 14, 21, 10]));
+        isSame('', $rule->test(['13', '18', '13', '14', '13', '16', '14', '21', '10']));
 
         $rule = $this->create(10, Combo::EQ);
         isSame(
             'The population variance in the column is "10.5", which is not equal than the expected "10"',
-            $rule->test([13, 18, 13, 14, 13, 16, 14, 21, 10]),
+            $rule->test(['13', '18', '13', '14', '13', '16', '14', '21', '10']),
         );
     }
 }

--- a/tests/Rules/Aggregate/ComboStddevPopTest.php
+++ b/tests/Rules/Aggregate/ComboStddevPopTest.php
@@ -29,12 +29,12 @@ class ComboStddevPopTest extends TestAbstractAggregateRuleCombo
     public function testEqual(): void
     {
         $rule = $this->create(2.3570226039552, Combo::EQ);
-        isSame('', $rule->test([1, 5, 1, 1, 1, 2, 8, 1, 1]));
+        isSame('', $rule->test(['1', '5', '1', '1', '1', '2', '8', '1', '1']));
 
         $rule = $this->create(3, Combo::EQ);
         isSame(
             'The standard deviation (SD+) in the column is "2.3570226039552", which is not equal than the expected "3"',
-            $rule->test([1, 5, 1, 1, 1, 2, 8, 1, 1]),
+            $rule->test(['1', '5', '1', '1', '1', '2', '8', '1', '1']),
         );
     }
 }

--- a/tests/Rules/Aggregate/ComboTrimeanTest.php
+++ b/tests/Rules/Aggregate/ComboTrimeanTest.php
@@ -30,12 +30,12 @@ class ComboTrimeanTest extends TestAbstractAggregateRuleCombo
     {
         $rule = $this->create(14.5, Combo::EQ);
         isSame('', $rule->test([]));
-        isSame('', $rule->test([13, 18, 13, 14, 13, 16, 14, 21, 13]));
+        isSame('', $rule->test(['13', '18', '13', '14', '13', '16', '14', '21', '13']));
 
         $rule = $this->create(1, Combo::EQ);
         isSame(
             'The trimean in the column is "14.5", which is not equal than the expected "1"',
-            $rule->test([13, 18, 13, 14, 13, 16, 14, 21, 13]),
+            $rule->test(['13', '18', '13', '14', '13', '16', '14', '21', '13']),
         );
     }
 }

--- a/tests/Tools.php
+++ b/tests/Tools.php
@@ -163,4 +163,9 @@ final class Tools
 
         return \implode(' ', $optionsAsArray);
     }
+
+    public static function range(int $min = 1, int $max = 10): array
+    {
+        return \array_map('strval', \range($min, $max));
+    }
 }


### PR DESCRIPTION
Modified test case input for multiple aggregate rule tests to handle integers as strings. This change ensures the tests are aligned with possible real-world input where numbers could be represented as strings, improving overall test robustity.
