### PR TITLE
Reduce level of verbose and option to disable ansi in `action.yml`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,7 +10,6 @@
 # @see        https://github.com/JBZoo/CI-Report-Converter
 #
 
-.git
 .idea
 .github
 build
@@ -27,5 +26,4 @@ vendor
 action.yml
 box.json.dist
 phpunit.xml.dist
-Makefile
 *.phar

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -247,9 +247,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - name: Save the current version
-        run: make build-version --no-print-directory
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,9 +56,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
 
-      - name: Save the current version
-        run: make build-version --no-print-directory
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,24 +10,31 @@
 # @see        https://github.com/JBZoo/Csv-Blueprint
 #
 
+FROM alpine as preparatory
+RUN apk add --no-cache make git
+WORKDIR /tmp
+COPY . /tmp
+RUN make build-version
+
+########################################################################################
 FROM php:8.3-cli-alpine
 
 # Install PHP extensions
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN install-php-extensions opcache @composer
 
-
 # Install application
 # run `make build-version` before!
 ENV COMPOSER_ALLOW_SUPERUSER=1
 COPY . /app
-COPY ./.version /app/
+COPY --from=preparatory /tmp/.version /app/.version
 RUN cd /app                                         \
     && composer install --no-dev                    \
                         --classmap-authoritative    \
                         --no-progress               \
                         --no-suggest                \
                         --optimize-autoloader       \
+    && rm -rf /app/.git                             \
     && composer clear-cache                         \
     && chmod +x /app/csv-blueprint
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 # @see        https://github.com/JBZoo/Csv-Blueprint
 #
 
-FROM alpine as preparatory
+FROM alpine:latest as preparatory
 RUN apk add --no-cache make git
 WORKDIR /tmp
 COPY . /tmp

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,6 @@ demo-github: ##@Demo Run demo invalid CSV for GitHub Actions
 # Docker ###############################################################################################################
 docker-build: ##@Docker (Re-)build Docker image
 	$(call title,"Building Docker Image")
-	@make build-version
 	@docker build -t $(DOCKER_IMAGE) .
 
 docker-demo: ##@Docker Run demo via Docker

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,9 @@ build-version: ##@Project Save version info
 	$(eval LAST_COMMIT_DATE := $(shell git log -1 --format=%cI))
 	$(eval SHORT_COMMIT_HASH := $(shell git rev-parse --short HEAD))
 	$(eval STABLE_FLAG := $(shell git diff --quiet $(TAG) HEAD -- && echo "true" || echo "false"))
-	@echo "$(TAG)\n$(STABLE_FLAG)\n$(BRANCH)\n$(LAST_COMMIT_DATE)\n$(SHORT_COMMIT_HASH)" > `pwd`/.version
+	@echo "$(TAG) | $(STABLE_FLAG) | $(BRANCH) | $(LAST_COMMIT_DATE) | $(SHORT_COMMIT_HASH)" > `pwd`/.version
 	@echo "Version info saved to `pwd`/.version"
+	@cat `pwd`/.version
 
 update: ##@Project Update dependencies
 	@echo "Composer flags: $(JBZOO_COMPOSER_UPDATE_FLAGS)"

--- a/README.md
+++ b/README.md
@@ -706,7 +706,8 @@ You can find launch examples in the [workflow demo](https://github.com/JBZoo/Csv
     verbose: -vv
 
     # ANSI output. You can disable ANSI colors if you want with `--no-ansi`. Also see documentation on GitHub for other options.
-    # Default value: '--ansi' '--profile'
+    # Default value: --ansi
+    # You can skip it
     extra: --ansi
 
 ```

--- a/README.md
+++ b/README.md
@@ -706,8 +706,7 @@ You can find launch examples in the [workflow demo](https://github.com/JBZoo/Csv
     verbose: -vv
 
     # ANSI output. You can disable ANSI colors if you want with `--no-ansi`. Also see documentation on GitHub for other options.
-    # Default value: --ansi
-    # You can skip it
+    # Default value: '--ansi' '--profile'
     extra: --ansi
 
 ```

--- a/README.md
+++ b/README.md
@@ -700,16 +700,6 @@ You can find launch examples in the [workflow demo](https://github.com/JBZoo/Csv
     # You can skip it
     skip-schema: no
 
-    # Verbosity level. Available options: `-v`, `-vv`, `-vvv`. And also there is option `--profile`.
-    # Default value: -vv
-    # You can skip it
-    verbose: -vv
-
-    # ANSI output. You can disable ANSI colors if you want with `--no-ansi`. Also see documentation on GitHub for other options.
-    # Default value: --ansi
-    # You can skip it
-    extra: --ansi
-
 ```
 <!-- /github-actions-yml -->
 

--- a/README.md
+++ b/README.md
@@ -700,6 +700,16 @@ You can find launch examples in the [workflow demo](https://github.com/JBZoo/Csv
     # You can skip it
     skip-schema: no
 
+    # ANSI output. You can disable ANSI colors if you want with `--no-ansi`.
+    # Default value: --ansi
+    # You can skip it
+    ansi: --ansi
+
+    # Verbosity level. Available options: `-v`, `-vv`, `-vvv`. And also there is option `--profile`.
+    # Default value: -vv
+    # You can skip it
+    verbose: -vv
+
 ```
 <!-- /github-actions-yml -->
 

--- a/README.md
+++ b/README.md
@@ -700,15 +700,15 @@ You can find launch examples in the [workflow demo](https://github.com/JBZoo/Csv
     # You can skip it
     skip-schema: no
 
-    # ANSI output. You can disable ANSI colors if you want with `--no-ansi`.
-    # Default value: --ansi
-    # You can skip it
-    ansi: --ansi
-
     # Verbosity level. Available options: `-v`, `-vv`, `-vvv`. And also there is option `--profile`.
     # Default value: -vv
     # You can skip it
     verbose: -vv
+
+    # ANSI output. You can disable ANSI colors if you want with `--no-ansi`. Also see documentation on GitHub for other options.
+    # Default value: --ansi
+    # You can skip it
+    extra: --ansi
 
 ```
 <!-- /github-actions-yml -->

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ inputs:
     required: true
   extra:
     description: 'Any extra options for the CSV Blueprint. See more in the documentation.'
-    default: '--ansi -vv'
+    default: '--ansi'
     required: false
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -56,11 +56,10 @@ runs:
     GITHUB_ACTIONS: 'true'
   args:
     - validate:csv
-#    - --csv=${{ inputs.csv }}
-#    - --schema=${{ inputs.schema }}
-#    - --report=${{ inputs.report }}
-#    - --quick=${{ inputs.quick }}
-#    - --skip-schema=${{ inputs.skip-schema }}
-#    - ${{ inputs.verbose }}
-#    - ${{ inputs.extra }}
-#
+    - --csv='${{ inputs.csv }}'
+    - --schema='${{ inputs.schema }}'
+    - --report='${{ inputs.report }}'
+    - --quick='${{ inputs.quick }}'
+    - --skip-schema='${{ inputs.skip-schema }}'
+    - ${{ inputs.verbose }}
+    - ${{ inputs.extra }}

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ inputs:
     required: false
   verbose:
     description: 'Verbosity level. Available options: `-v`, `-vv`, `-vvv`. And also there is option `--profile`.'
-    default: -vv --profile
+    default: '-vv" "--profile'
     required: false
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ inputs:
     required: false
   verbose:
     description: 'Verbosity level. Available options: `-v`, `-vv`, `-vvv`. And also there is option `--profile`.'
-    default: '-vv" "--profile'
+    default: --profile
     required: false
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -46,14 +46,12 @@ inputs:
     required: false
   extra:
     description: 'ANSI output. You can disable ANSI colors if you want with `--no-ansi`. Also see documentation on GitHub for other options.'
-    default: "'--ansi' '--profile'"
+    default: --ansi
     required: false
 
 runs:
   using: 'docker'
   image: 'docker://jbzoo/csv-blueprint'
-  env:
-    GITHUB_ACTIONS: 'true'
   args:
     - validate:csv
     - --csv='${{ inputs.csv }}'

--- a/action.yml
+++ b/action.yml
@@ -44,13 +44,10 @@ inputs:
   # Only for debbuging and profiling
   verbose:
     description: 'Verbosity level. Available options: `-v`, `-vv`, `-vvv`'
-    default: ''
   profile:
     description: 'Setup this option to `--profile` if you want to see profiling info. Add details with `-vvv`.'
-    default: ''
   debug:
     description: 'Setup this option to `--debug` if you want to see more really deep details.'
-    default: ''
   ansi:
     description: 'ANSI output. You can disable ANSI colors if you want with `--no-ansi`.'
     default: --ansi

--- a/action.yml
+++ b/action.yml
@@ -40,13 +40,13 @@ inputs:
     description: 'Skip schema validation. If you are sure that the schema is correct, you can skip this check.'
     default: no
     required: true
-  ansi:
-    description: 'ANSI output. You can disable ANSI colors if you want with `--no-ansi`.'
-    default: --ansi
-    required: false
   verbose:
     description: 'Verbosity level. Available options: `-v`, `-vv`, `-vvv`. And also there is option `--profile`.'
-    default: [ --profile -vv ]
+    default: -vv
+    required: false
+  extra:
+    description: 'ANSI output. You can disable ANSI colors if you want with `--no-ansi`. Also see documentation on GitHub for other options.'
+    default: --ansi
     required: false
 
 runs:
@@ -66,5 +66,5 @@ runs:
     - ${{ inputs.quick }}
     - '--skip-schema'
     - ${{ inputs.skip-schema }}
-    - ${{ inputs.ansi }}
     - ${{ inputs.verbose }}
+    - ${{ inputs.extra }}

--- a/action.yml
+++ b/action.yml
@@ -56,15 +56,10 @@ runs:
     GITHUB_ACTIONS: 'true'
   args:
     - validate:csv
-    - '--csv'
-    - ${{ inputs.csv }}
-    - '--schema'
-    - ${{ inputs.schema }}
-    - '--report'
-    - ${{ inputs.report }}
-    - '--quick'
-    - ${{ inputs.quick }}
-    - '--skip-schema'
-    - ${{ inputs.skip-schema }}
+    - --csv=${{ inputs.csv }}
+    - --schema="${{ inputs.schema }}"
+    - --report=${{ inputs.report }}
+    - --quick=${{ inputs.quick }}
+    - --skip-schema=${{ inputs.skip-schema }}
     - ${{ inputs.verbose }}
     - ${{ inputs.extra }}

--- a/action.yml
+++ b/action.yml
@@ -56,10 +56,11 @@ runs:
     GITHUB_ACTIONS: 'true'
   args:
     - validate:csv
-    - --csv=${{ inputs.csv }}
-    - --schema=${{ inputs.schema }}
-    - --report=${{ inputs.report }}
-    - --quick=${{ inputs.quick }}
-    - --skip-schema=${{ inputs.skip-schema }}
-    - ${{ inputs.verbose }}
-    - ${{ inputs.extra }}
+#    - --csv=${{ inputs.csv }}
+#    - --schema=${{ inputs.schema }}
+#    - --report=${{ inputs.report }}
+#    - --quick=${{ inputs.quick }}
+#    - --skip-schema=${{ inputs.skip-schema }}
+#    - ${{ inputs.verbose }}
+#    - ${{ inputs.extra }}
+#

--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ inputs:
 
 runs:
   using: 'docker'
-  image: Dockerfile
+  image: 'docker://jbzoo/csv-blueprint'
   args:
     - validate:csv
     - '--csv'

--- a/action.yml
+++ b/action.yml
@@ -45,8 +45,10 @@ inputs:
     default: '--ansi'
     required: true
   verbose:
-    description: 'Verbosity level. Available options: -v, -vv, -vvv.'
-    default: '-vv'
+    description: 'Verbosity level. Available options: `-v`, `-vv`, `-vvv`. And also there is option `--profile`.'
+    default: |
+      -vv
+      --profile
     required: true
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ inputs:
     required: false
   verbose:
     description: 'Verbosity level. Available options: `-v`, `-vv`, `-vvv`. And also there is option `--profile`.'
-    default: --profile
+    default: [ --profile -vv ]
     required: false
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -42,15 +42,13 @@ inputs:
     required: true
 
   # Only for debbuging and profiling
-  ansi:
-    description: 'ANSI output. You can disable ANSI colors if you want with `--no-ansi`.'
-    default: --ansi
-  verbose:
-    description: 'Verbosity level. Available options: `-v`, `-vv`, `-vvv`'
-  profile:
-    description: 'Setup this option to `--profile` if you want to see profiling info. Add details with `-vvv`.'
-  debug:
-    description: 'Setup this option to `--debug` if you want to see more really deep details.'
+  extra:
+    description: >
+      ANSI output. You can disable ANSI colors if you want with `--no-ansi`.
+      Verbosity level: Available options: `-v`, `-vv`, `-vvv`
+      Add flag `--profile` if you want to see profiling info. Add details with `-vvv`.
+      Add flag `--debug` if you want to see more really deep details.
+    default: --ansi --profile --debug -vvv
 
 runs:
   using: 'docker'
@@ -67,4 +65,4 @@ runs:
     - ${{ inputs.quick }}
     - '--skip-schema'
     - ${{ inputs.skip-schema }}
-    - ${{ inputs.verbose }} ${{ inputs.profile }} ${{ inputs.debug }} ${{ inputs.ansi }}
+    - ${{ inputs.extra }}

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ inputs:
 
 runs:
   using: 'docker'
-  image: Dockerfile
+  image: 'docker://jbzoo/csv-blueprint'
   env:
     GITHUB_ACTIONS: 'true'
   args:

--- a/action.yml
+++ b/action.yml
@@ -48,11 +48,11 @@ inputs:
       Verbosity level: Available options: `-v`, `-vv`, `-vvv`
       Add flag `--profile` if you want to see profiling info. Add details with `-vvv`.
       Add flag `--debug` if you want to see more really deep details.
-    default: 'flags: --ansi --profile --debug -vvv'
+    default: 'extra: --ansi'
 
 runs:
   using: 'docker'
-  image: 'docker://jbzoo/csv-blueprint'
+  image: Dockerfile
   args:
     - validate:csv
     - '--csv'

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ inputs:
       Verbosity level: Available options: `-v`, `-vv`, `-vvv`
       Add flag `--profile` if you want to see profiling info. Add details with `-vvv`.
       Add flag `--debug` if you want to see more really deep details.
-    default: --ansi --profile --debug -vvv
+    default: 'flags: --ansi --profile --debug -vvv'
 
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: 'Skip schema validation. If you are sure that the schema is correct, you can skip this check.'
     default: no
     required: true
+  extra:
+    description: 'Any extra options for the CSV Blueprint. See more in the documentation.'
+    default: '--ansi -vv'
+    required: false
 
 runs:
   using: 'docker'
@@ -58,5 +62,4 @@ runs:
     - ${{ inputs.quick }}
     - '--skip-schema'
     - ${{ inputs.skip-schema }}
-    - '--ansi'
-    - '-vvv'
+    - ${{ inputs.extra }}

--- a/action.yml
+++ b/action.yml
@@ -42,14 +42,12 @@ inputs:
     required: true
   ansi:
     description: 'ANSI output. You can disable ANSI colors if you want with `--no-ansi`.'
-    default: '--ansi'
-    required: true
+    default: --ansi
+    required: false
   verbose:
     description: 'Verbosity level. Available options: `-v`, `-vv`, `-vvv`. And also there is option `--profile`.'
-    default: |
-      -vv
-      --profile
-    required: true
+    default: -vv
+    required: false
 
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -40,10 +40,14 @@ inputs:
     description: 'Skip schema validation. If you are sure that the schema is correct, you can skip this check.'
     default: no
     required: true
-  extra:
-    description: 'Any extra options for the CSV Blueprint. See more in the documentation.'
+  ansi:
+    description: 'ANSI output. You can disable ANSI colors if you want with `--no-ansi`.'
     default: '--ansi'
-    required: false
+    required: true
+  verbose:
+    description: 'Verbosity level. Available options: -v, -vv, -vvv.'
+    default: '-vv'
+    required: true
 
 runs:
   using: 'docker'
@@ -62,4 +66,5 @@ runs:
     - ${{ inputs.quick }}
     - '--skip-schema'
     - ${{ inputs.skip-schema }}
-    - ${{ inputs.extra }}
+    - ${{ inputs.ansi }}
+    - ${{ inputs.verbose }}

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'docker://jbzoo/csv-blueprint'
+  image: Dockerfile
   env:
     GITHUB_ACTIONS: 'true'
   args:

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ inputs:
     required: false
   extra:
     description: 'ANSI output. You can disable ANSI colors if you want with `--no-ansi`. Also see documentation on GitHub for other options.'
-    default: --ansi
+    default: "'--ansi' '--profile'"
     required: false
 
 runs:
@@ -57,7 +57,7 @@ runs:
   args:
     - validate:csv
     - --csv=${{ inputs.csv }}
-    - --schema="${{ inputs.schema }}"
+    - --schema=${{ inputs.schema }}
     - --report=${{ inputs.report }}
     - --quick=${{ inputs.quick }}
     - --skip-schema=${{ inputs.skip-schema }}

--- a/action.yml
+++ b/action.yml
@@ -42,15 +42,15 @@ inputs:
     required: true
 
   # Only for debbuging and profiling
+  ansi:
+    description: 'ANSI output. You can disable ANSI colors if you want with `--no-ansi`.'
+    default: --ansi
   verbose:
     description: 'Verbosity level. Available options: `-v`, `-vv`, `-vvv`'
   profile:
     description: 'Setup this option to `--profile` if you want to see profiling info. Add details with `-vvv`.'
   debug:
     description: 'Setup this option to `--debug` if you want to see more really deep details.'
-  ansi:
-    description: 'ANSI output. You can disable ANSI colors if you want with `--no-ansi`.'
-    default: --ansi
 
 runs:
   using: 'docker'
@@ -67,7 +67,4 @@ runs:
     - ${{ inputs.quick }}
     - '--skip-schema'
     - ${{ inputs.skip-schema }}
-    - ${{ inputs.verbose }}
-    - ${{ inputs.profile }}
-    - ${{ inputs.debug }}
-    - ${{ inputs.ansi }}
+    - ${{ inputs.verbose }} ${{ inputs.profile }} ${{ inputs.debug }} ${{ inputs.ansi }}

--- a/action.yml
+++ b/action.yml
@@ -40,14 +40,20 @@ inputs:
     description: 'Skip schema validation. If you are sure that the schema is correct, you can skip this check.'
     default: no
     required: true
+
+  # Only for debbuging and profiling
   verbose:
-    description: 'Verbosity level. Available options: `-v`, `-vv`, `-vvv`. And also there is option `--profile`.'
-    default: -vv
-    required: false
-  extra:
-    description: 'ANSI output. You can disable ANSI colors if you want with `--no-ansi`. Also see documentation on GitHub for other options.'
+    description: 'Verbosity level. Available options: `-v`, `-vv`, `-vvv`'
+    default: ''
+  profile:
+    description: 'Setup this option to `--profile` if you want to see profiling info. Add details with `-vvv`.'
+    default: ''
+  debug:
+    description: 'Setup this option to `--debug` if you want to see more really deep details.'
+    default: ''
+  ansi:
+    description: 'ANSI output. You can disable ANSI colors if you want with `--no-ansi`.'
     default: --ansi
-    required: false
 
 runs:
   using: 'docker'
@@ -65,4 +71,6 @@ runs:
     - '--skip-schema'
     - ${{ inputs.skip-schema }}
     - ${{ inputs.verbose }}
-    - ${{ inputs.extra }}
+    - ${{ inputs.profile }}
+    - ${{ inputs.debug }}
+    - ${{ inputs.ansi }}

--- a/action.yml
+++ b/action.yml
@@ -54,10 +54,15 @@ runs:
   image: 'docker://jbzoo/csv-blueprint'
   args:
     - validate:csv
-    - --csv='${{ inputs.csv }}'
-    - --schema='${{ inputs.schema }}'
-    - --report='${{ inputs.report }}'
-    - --quick='${{ inputs.quick }}'
-    - --skip-schema='${{ inputs.skip-schema }}'
+    - '--csv'
+    - ${{ inputs.csv }}
+    - '--schema'
+    - ${{ inputs.schema }}
+    - '--report'
+    - ${{ inputs.report }}
+    - '--quick'
+    - ${{ inputs.quick }}
+    - '--skip-schema'
+    - ${{ inputs.skip-schema }}
     - ${{ inputs.verbose }}
     - ${{ inputs.extra }}

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ inputs:
     required: false
   verbose:
     description: 'Verbosity level. Available options: `-v`, `-vv`, `-vvv`. And also there is option `--profile`.'
-    default: -vv
+    default: -vv --profile
     required: false
 
 runs:

--- a/csv-blueprint.php
+++ b/csv-blueprint.php
@@ -16,12 +16,31 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint;
 
-$_SERVER['argv'] = \array_map('trim', $_SERVER['argv']); // Fix for GitHub actions. See action.yml
+// Fix for GitHub actions. See action.yml
+$_SERVER['argv'] ??= [];
+$_SERVER['argv'] = \array_map('trim', $_SERVER['argv']);
+
+// Extract flags from the command line arguments `extra: --ansi --profile --debug -vvv`
+foreach ($_SERVER['argv'] as $key => $arg) {
+    if (\str_starts_with($arg, 'extra:')) {
+        $arg = \str_replace('extra:', '', $arg);
+        $flags = \array_filter(\array_map('trim', \explode(' ', $arg)), static fn ($flag): bool => $flag !== '');
+        foreach ($flags as $flag) {
+            $_SERVER['argv'][] = $flag;
+        }
+        unset($_SERVER['argv'][$key]);
+    }
+}
 
 \define('PATH_ROOT', __DIR__);
 require_once __DIR__ . '/vendor/autoload.php';
 
+
+// Set default timezone
 \date_default_timezone_set('UTC');
+
+// Convert all errors to exceptions. Looks like we have critical case, and we need to stop or handle it.
+// We have to do it becase tool uses 3rd-party libraries, and we can't trust them.
 \set_error_handler(static function ($severity, $message, $file, $line): void {
     throw new \ErrorException($message, 0, $severity, $file, $line);
 });

--- a/csv-blueprint.php
+++ b/csv-blueprint.php
@@ -16,25 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint;
 
+$_SERVER['argv'] = \array_map('trim', $_SERVER['argv']); // Fix for GitHub actions. See action.yml
+
 \define('PATH_ROOT', __DIR__);
-
-$vendorPaths = [
-    __DIR__ . '/../../autoload.php',
-    __DIR__ . '/../vendor/autoload.php',
-    __DIR__ . '/vendor/autoload.php',
-];
-
-foreach ($vendorPaths as $file) {
-    if (\file_exists($file)) {
-        \define('JBZOO_AUTOLOAD_FILE', $file);
-        break;
-    }
-}
-
-require_once JBZOO_AUTOLOAD_FILE;
+require_once __DIR__ . '/vendor/autoload.php';
 
 \date_default_timezone_set('UTC');
-
 \set_error_handler(static function ($severity, $message, $file, $line): void {
     throw new \ErrorException($message, 0, $severity, $file, $line);
 });

--- a/csv-blueprint.php
+++ b/csv-blueprint.php
@@ -35,7 +35,6 @@ foreach ($_SERVER['argv'] as $key => $arg) {
 \define('PATH_ROOT', __DIR__);
 require_once __DIR__ . '/vendor/autoload.php';
 
-
 // Set default timezone
 \date_default_timezone_set('UTC');
 

--- a/csv-blueprint.php
+++ b/csv-blueprint.php
@@ -16,24 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint;
 
-// Fix for GitHub actions. See action.yml
-$_SERVER['argv'] ??= [];
-$_SERVER['argv'] = \array_map('trim', $_SERVER['argv']);
-
-// Extract flags from the command line arguments `extra: --ansi --profile --debug -vvv`
-foreach ($_SERVER['argv'] as $key => $arg) {
-    if (\str_starts_with($arg, 'extra:')) {
-        $arg = \str_replace('extra:', '', $arg);
-        $flags = \array_filter(\array_map('trim', \explode(' ', $arg)), static fn ($flag): bool => $flag !== '');
-        foreach ($flags as $flag) {
-            $_SERVER['argv'][] = $flag;
-        }
-        unset($_SERVER['argv'][$key]);
-    }
-}
-
 \define('PATH_ROOT', __DIR__);
 require_once __DIR__ . '/vendor/autoload.php';
+
+// Fix for GitHub actions. See action.yml
+$_SERVER['argv'] = Utils::fixArgv($_SERVER['argv'] ?? []);
+$_SERVER['argc'] = \count($_SERVER['argv']);
 
 // Set default timezone
 \date_default_timezone_set('UTC');

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -321,7 +321,7 @@ final class Utils
             return 'Version file not found';
         }
 
-        $parts = \array_filter(\explode("\n", (string)\file_get_contents($versionFile)));
+        $parts = \array_map('trim', \explode('|', (string)\file_get_contents($versionFile)));
         $expectedParts = 5;
         if (\count($parts) < $expectedParts) {
             return 'Invalid version file format';

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -367,6 +367,35 @@ final class Utils
         return \defined('PHPUNIT_COMPOSER_INSTALL') || \defined('__PHPUNIT_PHAR__');
     }
 
+    public static function fixArgv(array $originalArgs): array
+    {
+        $newArgumens = [];
+
+        // Extract flags from the command line arguments `extra: --ansi --profile --debug -vvv`
+        foreach ($originalArgs as $argValue) {
+            $argValue = \trim($argValue);
+            if ($argValue === '') {
+                continue;
+            }
+
+            if (\str_starts_with($argValue, 'extra:')) {
+                $extraArgs = \str_replace('extra:', '', $argValue);
+                $flags = \array_filter(
+                    \array_map('trim', \explode(' ', $extraArgs)),
+                    static fn ($flag): bool => $flag !== '',
+                );
+
+                foreach ($flags as $flag) {
+                    $newArgumens[] = $flag;
+                }
+            } else {
+                $newArgumens[] = $argValue;
+            }
+        }
+
+        return $newArgumens;
+    }
+
     /**
      * @param SplFileInfo[] $files
      */

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -321,7 +321,12 @@ final class Utils
             return 'Version file not found';
         }
 
-        $parts = \array_map('trim', \explode('|', (string)\file_get_contents($versionFile)));
+        return self::parseVersion((string)\file_get_contents($versionFile), $showFull);
+    }
+
+    public static function parseVersion(string $content, bool $showFull): string
+    {
+        $parts = \array_map('trim', \explode('|', $content));
         $expectedParts = 5;
         if (\count($parts) < $expectedParts) {
             return 'Invalid version file format';

--- a/tests/GithubActionsTest.php
+++ b/tests/GithubActionsTest.php
@@ -31,12 +31,12 @@ final class GithubActionsTest extends TestCase
         $expectedArgs = ['validate:csv'];
 
         foreach ($availableOptions as $option) {
-            $expectedArgs[] = "--{$option}";
+            if ($option !== 'extra') {
+                $expectedArgs[] = "--{$option}";
+            }
+
             $expectedArgs[] = '${{ inputs.' . $option . ' }}';
         }
-
-        $expectedArgs[] = '--ansi';
-        $expectedArgs[] = '-vvv';
 
         isSame($expectedArgs, $action->findArray('runs.args'));
 

--- a/tests/GithubActionsTest.php
+++ b/tests/GithubActionsTest.php
@@ -31,7 +31,7 @@ final class GithubActionsTest extends TestCase
         $expectedArgs = ['validate:csv'];
 
         foreach ($availableOptions as $option) {
-            if ($option !== 'ansi' && $option !== 'verbose') {
+            if ($option !== 'extra' && $option !== 'verbose') {
                 $expectedArgs[] = "--{$option}";
             }
 
@@ -55,8 +55,8 @@ final class GithubActionsTest extends TestCase
             'report'      => ErrorSuite::REPORT_DEFAULT,
             'quick'       => 'no',
             'skip-schema' => 'no',
-            'ansi'        => '--ansi',
             'verbose'     => '-vv',
+            'extra'       => '--ansi',
         ];
 
         $expectedMessage = [

--- a/tests/GithubActionsTest.php
+++ b/tests/GithubActionsTest.php
@@ -55,6 +55,8 @@ final class GithubActionsTest extends TestCase
             'report'      => ErrorSuite::REPORT_DEFAULT,
             'quick'       => 'no',
             'skip-schema' => 'no',
+            'ansi'        => '--ansi',
+            'verbose'     => '-vv',
         ];
 
         $expectedMessage = [

--- a/tests/GithubActionsTest.php
+++ b/tests/GithubActionsTest.php
@@ -31,7 +31,7 @@ final class GithubActionsTest extends TestCase
         $expectedArgs = ['validate:csv'];
 
         foreach ($availableOptions as $option) {
-            if ($option !== 'extra') {
+            if ($option !== 'ansi' && $option !== 'verbose') {
                 $expectedArgs[] = "--{$option}";
             }
 

--- a/tests/GithubActionsTest.php
+++ b/tests/GithubActionsTest.php
@@ -31,11 +31,10 @@ final class GithubActionsTest extends TestCase
         $expectedArgs = ['validate:csv'];
 
         foreach ($availableOptions as $option) {
-            if ($option !== 'extra' && $option !== 'verbose') {
+            if ($option !== 'extra') {
                 $expectedArgs[] = "--{$option}";
             }
-
-            $expectedArgs[] = '${{ inputs.' . $option . ' }}';
+            $expectedArgs[] = "\${{ inputs.{$option} }}";
         }
 
         isSame($expectedArgs, $action->findArray('runs.args'));
@@ -55,8 +54,6 @@ final class GithubActionsTest extends TestCase
             'report'      => ErrorSuite::REPORT_DEFAULT,
             'quick'       => 'no',
             'skip-schema' => 'no',
-            'verbose'     => '-vv',
-            'extra'       => '--ansi',
         ];
 
         $expectedMessage = [
@@ -66,6 +63,10 @@ final class GithubActionsTest extends TestCase
         ];
 
         foreach ($inputs as $key => $input) {
+            if ($key === 'extra') {
+                continue;
+            }
+
             $expectedMessage[] = '    # ' . \trim($input['description']);
 
             if (isset($input['default'])) {

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -177,6 +177,30 @@ final class UtilsTest extends TestCase
         );
     }
 
+    public function testParseVersion(): void
+    {
+        // Stable
+        isSame(
+            '<info>v0.34</info>  29 Mar 2024 18:09 UTC',
+            Utils::parseVersion("0.34 | true | master | 2024-03-29T22:09:21+04:00 | 03c14cc\n", true),
+        );
+        isSame('v0.34', Utils::parseVersion("0.34 | true | master | 2024-03-29T22:09:21+04:00 | 03c14cc\n", false));
+
+        // Development
+        isSame(
+            '<info>v0.34</info>  29 Mar 2024 18:09 UTC  <comment>Experimental!</comment>  Branch: branch (03c14cc)',
+            Utils::parseVersion("0.34 | false | branch | 2024-03-29T22:09:21+04:00 | 03c14cc\n", true),
+        );
+        isSame('v0.34', Utils::parseVersion("0.34 | false | branch | 2024-03-29T22:09:21+04:00 | 03c14cc\n", false));
+
+        // Night build
+        isSame(
+            '<info>v0.34</info>  29 Mar 2024 18:09 UTC  <comment>Night build</comment>  Branch: master (03c14cc)',
+            Utils::parseVersion("0.34 | false | master | 2024-03-29T22:09:21+04:00 | 03c14cc\n", true),
+        );
+        isSame('v0.34', Utils::parseVersion("0.34 | false | master | 2024-03-29T22:09:21+04:00 | 03c14cc\n", false));
+    }
+
     public function testColorOfCellValue(): void
     {
         $packs = [

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -143,6 +143,40 @@ final class UtilsTest extends TestCase
         }
     }
 
+    public function testFixCliArguments(): void
+    {
+        isSame([], Utils::fixArgv([]));
+
+        isSame(['cmd'], Utils::fixArgv(['cmd']));
+        isSame(['cmd'], Utils::fixArgv(['cmd', '']));
+
+        isSame(['cmd', '-h'], Utils::fixArgv(['cmd', '', '-h']));
+        isSame(['cmd', '-h'], Utils::fixArgv(['cmd', '', '-h']));
+        isSame(['cmd', '-h'], Utils::fixArgv(['cmd', '', ' -h ']));
+        isSame(['cmd', '"-h"'], Utils::fixArgv(['cmd', '', ' "-h" ']));
+
+        isSame(
+            ['cmd', '-h', '--ansi'],
+            Utils::fixArgv(['cmd', '', ' -h ', 'extra: --ansi']),
+        );
+        isSame(
+            ['cmd', '-h'],
+            Utils::fixArgv(['cmd', '', ' -h ', 'extra:']),
+        );
+        isSame(
+            ['cmd', '-h'],
+            Utils::fixArgv(['cmd', '', ' -h ', ' extra: ']),
+        );
+        isSame(
+            ['cmd', '-h', '--ansi', '--no'],
+            Utils::fixArgv(['cmd', '', ' -h ', 'extra: --ansi --no']),
+        );
+        isSame(
+            ['cmd', '-h', '--ansi', '--no'],
+            Utils::fixArgv(['cmd', '', ' -h ', 'extra: --ansi   --no  ']),
+        );
+    }
+
     public function testColorOfCellValue(): void
     {
         $packs = [


### PR DESCRIPTION
The commit updates the action.yml file by including a new 'extra' input field that helps set individual options. Simultaneously, it eliminates hardcoded `--ansi` and `-vvv` arguments from expected inputs, making the configurations more flexible.