### PR TITLE
Refactor Github Actions workflow for clarity and flexibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   phar:
-    name: PHAR
+    name: Publish PHAR
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -47,14 +47,8 @@ jobs:
             ./build/csv-blueprint.phar
 
   docker:
-    name: Docker
+    name: Publish Docker
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64/v8
-          - linux/386
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -82,7 +76,7 @@ jobs:
           tags: |
             jbzoo/csv-blueprint:latest
             jbzoo/csv-blueprint:${{ github.event.release.tag_name }}
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64/v8,linux/386
           build-args: |
             VERSION=${{ github.event.release.tag_name }}
 


### PR DESCRIPTION
Changes have been made in the publish.yml of the Github Actions workflow for better readability and flexibility. Specifically, Docker's build matrix has been expanded and it now includes three platforms: linux/amd64, linux/arm64/v8, and linux/386. Moreover, the job names have been updated to more clearly reflect their operations.
