### PR TITLE
Optimize CSV validation and header mapping logic if header is enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,11 @@ BENCH_ROWS_SRC    ?= 2000
 BENCH_CSV_PATH    := ./build/bench/$(BENCH_COLS)_$(BENCH_ROWS_SRC)_000.csv
 BENCH_CSV         := --csv='$(BENCH_CSV_PATH)'
 BENCH_FLAGS       := --debug --profile --report=text -vvv
-BENCH_SCHEMAS   := --schema='./tests/Benchmarks/bench_*.yml'
+BENCH_SCHEMAS_ALL := --schema='./tests/Benchmarks/bench_*.yml'
+BENCH_SCHEMAS_0   := --schema='./tests/Benchmarks/bench_0_*.yml'
+BENCH_SCHEMAS_1   := --schema='./tests/Benchmarks/bench_1_*.yml'
+BENCH_SCHEMAS_2   := --schema='./tests/Benchmarks/bench_2_*.yml'
+BENCH_SCHEMAS_3   := --schema='./tests/Benchmarks/bench_3_*.yml'
 
 
 bench: ##@Benchmarks Run all benchmarks
@@ -109,23 +113,37 @@ bench-create-csv: ##@Benchmarks Create CSV file
 
 
 bench-docker: ##@Benchmarks Run CSV file with Docker
+	@docker run --rm  $(DOCKER_IMAGE) --ansi --version
 	@echo "::group::Quickest"
-	-$(BLUEPRINT_DOCKER) $(BENCH_CSV) --schema='./tests/Benchmarks/bench_0_*.yml' $(BENCH_FLAGS)
+	-$(BLUEPRINT_DOCKER) $(BENCH_CSV) $(BENCH_SCHEMAS_0) $(BENCH_FLAGS)
 	@echo "::endgroup::"
 	@echo "::group::Minimum"
-	-$(BLUEPRINT_DOCKER) $(BENCH_CSV) --schema='./tests/Benchmarks/bench_1_*.yml' $(BENCH_FLAGS)
+	-$(BLUEPRINT_DOCKER) $(BENCH_CSV) $(BENCH_SCHEMAS_1) $(BENCH_FLAGS)
 	@echo "::endgroup::"
 	@echo "::group::Realistic"
-	-$(BLUEPRINT_DOCKER) $(BENCH_CSV) --schema='./tests/Benchmarks/bench_2_*.yml' $(BENCH_FLAGS)
+	-$(BLUEPRINT_DOCKER) $(BENCH_CSV) $(BENCH_SCHEMAS_2) $(BENCH_FLAGS)
 	@echo "::endgroup::"
 	@echo "::group::All aggregations at once"
-	-$(BLUEPRINT_DOCKER) $(BENCH_CSV) --schema='./tests/Benchmarks/bench_3_*.yml' $(BENCH_FLAGS)
+	-$(BLUEPRINT_DOCKER) $(BENCH_CSV) $(BENCH_SCHEMAS_3) $(BENCH_FLAGS)
 	@echo "::endgroup::"
 
 
 bench-phar: ##@Benchmarks Run CSV file with Phar
-	-$(BLUEPRINT_PHAR) $(BENCH_CSV) $(BENCH_SCHEMAS) $(BENCH_FLAGS)
+	./build/csv-blueprint.phar --ansi --version
+	@echo "::group::Quickest"
+	-$(BLUEPRINT_PHAR) $(BENCH_CSV) $(BENCH_SCHEMAS_0) $(BENCH_FLAGS)
+	@echo "::endgroup::"
+	@echo "::group::Minimum"
+	-$(BLUEPRINT_PHAR) $(BENCH_CSV) $(BENCH_SCHEMAS_1) $(BENCH_FLAGS)
+	@echo "::endgroup::"
+	@echo "::group::Realistic"
+	-$(BLUEPRINT_PHAR) $(BENCH_CSV) $(BENCH_SCHEMAS_2) $(BENCH_FLAGS)
+	@echo "::endgroup::"
+	@echo "::group::All aggregations at once"
+	-$(BLUEPRINT_PHAR) $(BENCH_CSV) $(BENCH_SCHEMAS_3) $(BENCH_FLAGS)
+	@echo "::endgroup::"
 
 
 bench-php: ##@Benchmarks Run CSV file with classic PHP binary
+	$(PHP_BIN) ./csv-blueprint --ansi --version
 	-$(BLUEPRINT) $(BENCH_CSV) $(BENCH_SCHEMAS) $(BENCH_FLAGS)

--- a/src/Csv/Column.php
+++ b/src/Csv/Column.php
@@ -107,6 +107,11 @@ final class Column
         return $this->getValidator()->validateCell($cellValue, $line);
     }
 
+    public function setId(int $realIndex): void
+    {
+        $this->id = $realIndex;
+    }
+
     private function prepareRuleSet(string $schemaKey): array
     {
         $rules = [];

--- a/src/Csv/CsvFile.php
+++ b/src/Csv/CsvFile.php
@@ -108,6 +108,7 @@ final class CsvFile
 
         $realHeader = $this->getHeader();
         foreach ($realHeader as $realIndex => $realColumn) {
+            $realIndex = (int)$realIndex;
             $schemaColumn = $this->schema->getColumn($realColumn);
 
             if ($schemaColumn !== null) {

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -86,35 +86,12 @@ final class Schema
         return $this->columns;
     }
 
-    /**
-     * @return Column[]|null[]
-     * @phan-suppress PhanPartialTypeMismatchReturn
-     */
-    public function getColumnsMappedByHeader(array $header): array
-    {
-        $map = [];
-
-        if ($this->getCsvStructure()->isHeader()) {
-            foreach ($header as $headerName) {
-                $map[$headerName] = $this->columns[$headerName] ?? null;
-            }
-        } else {
-            return $this->getColumns();
-        }
-
-        return $map;
-    }
-
     public function getColumn(int|string $columNameOrId): ?Column
     {
         if (\is_int($columNameOrId)) {
             $column = \array_values($this->getColumns())[$columNameOrId] ?? null;
         } else {
             $column = $this->getColumns()[$columNameOrId] ?? null;
-        }
-
-        if ($column === null) {
-            throw new Exception("Column \"{$columNameOrId}\" not found in schema \"{$this->filename}\"");
         }
 
         return $column;
@@ -152,6 +129,11 @@ final class Schema
     public function getData(): AbstractData
     {
         return clone $this->data;
+    }
+
+    public function getSchemaHeader(): array
+    {
+        return \array_keys($this->getColumns());
     }
 
     /**

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -63,8 +63,10 @@ final class Utils
 
     public static function debugSpeed(string $messPrefix, int $lines, float $startTimer): void
     {
-        $kiloLines = \round(($lines / (\microtime(true) - $startTimer)) / 1000);
-        self::debug("{$messPrefix} <blue>" . \number_format($kiloLines) . 'K</blue> lines/sec');
+        if (\defined('DEBUG_MODE')) {
+            $kiloLines = \round(($lines / (\microtime(true) - $startTimer)) / 1000);
+            self::debug("{$messPrefix} <blue>" . \number_format($kiloLines) . 'K</blue> lines/sec');
+        }
     }
 
     public static function kebabToCamelCase(string $input): string

--- a/tests/Benchmarks/bench_0_quickest.yml
+++ b/tests/Benchmarks/bench_0_quickest.yml
@@ -12,9 +12,6 @@
 
 filename_pattern: /.csv$/i
 
-csv:
-  header: false
-
 columns:
   - rules:
       not_empty: true

--- a/tests/Benchmarks/bench_0_quickest.yml
+++ b/tests/Benchmarks/bench_0_quickest.yml
@@ -13,5 +13,6 @@
 filename_pattern: /.csv$/i
 
 columns:
-  - rules:
+  - name: id
+    rules:
       not_empty: true

--- a/tests/Benchmarks/bench_0_quickest_agg.yml
+++ b/tests/Benchmarks/bench_0_quickest_agg.yml
@@ -12,9 +12,6 @@
 
 filename_pattern: /.csv$/i
 
-csv:
-  header: false
-
 columns:
   - aggregate_rules:
       count: 0

--- a/tests/Benchmarks/bench_0_quickest_agg.yml
+++ b/tests/Benchmarks/bench_0_quickest_agg.yml
@@ -13,5 +13,6 @@
 filename_pattern: /.csv$/i
 
 columns:
-  - aggregate_rules:
+  - name: id
+    aggregate_rules:
       count: 0

--- a/tests/Benchmarks/bench_0_quickest_combo.yml
+++ b/tests/Benchmarks/bench_0_quickest_combo.yml
@@ -12,9 +12,6 @@
 
 filename_pattern: /.csv$/i
 
-csv:
-  header: false
-
 columns:
   - rules:
       not_empty: true

--- a/tests/Benchmarks/bench_0_quickest_combo.yml
+++ b/tests/Benchmarks/bench_0_quickest_combo.yml
@@ -13,7 +13,8 @@
 filename_pattern: /.csv$/i
 
 columns:
-  - rules:
+  - name: id
+    rules:
       not_empty: true
     aggregate_rules:
       count: 0

--- a/tests/Benchmarks/bench_1_mini.yml
+++ b/tests/Benchmarks/bench_1_mini.yml
@@ -12,9 +12,6 @@
 
 filename_pattern: /.csv$/i
 
-csv:
-  header: false
-
 columns:
   - rules:
       not_empty: true

--- a/tests/Benchmarks/bench_1_mini.yml
+++ b/tests/Benchmarks/bench_1_mini.yml
@@ -13,6 +13,7 @@
 filename_pattern: /.csv$/i
 
 columns:
-  - rules:
+  - name: id
+    rules:
       not_empty: true
       is_int: true

--- a/tests/Benchmarks/bench_1_mini_agg.yml
+++ b/tests/Benchmarks/bench_1_mini_agg.yml
@@ -12,9 +12,6 @@
 
 filename_pattern: /.csv$/i
 
-csv:
-  header: false
-
 columns:
   - aggregate_rules:
       average: 0

--- a/tests/Benchmarks/bench_1_mini_agg.yml
+++ b/tests/Benchmarks/bench_1_mini_agg.yml
@@ -13,6 +13,7 @@
 filename_pattern: /.csv$/i
 
 columns:
-  - aggregate_rules:
+  - name: id
+    aggregate_rules:
       average: 0
       count: 0

--- a/tests/Benchmarks/bench_1_mini_combo.yml
+++ b/tests/Benchmarks/bench_1_mini_combo.yml
@@ -12,9 +12,6 @@
 
 filename_pattern: /.csv$/i
 
-csv:
-  header: false
-
 columns:
   - rules:
       not_empty: true

--- a/tests/Benchmarks/bench_1_mini_combo.yml
+++ b/tests/Benchmarks/bench_1_mini_combo.yml
@@ -13,7 +13,8 @@
 filename_pattern: /.csv$/i
 
 columns:
-  - rules:
+  - name: id
+    rules:
       not_empty: true
       is_int: true
     aggregate_rules:

--- a/tests/Benchmarks/bench_2_realistic.yml
+++ b/tests/Benchmarks/bench_2_realistic.yml
@@ -13,7 +13,8 @@
 filename_pattern: /.csv$/i
 
 columns:
-  - rules:
+  - name: id
+    rules:
       not_empty: true
       length_max: 100
       is_int: true

--- a/tests/Benchmarks/bench_2_realistic.yml
+++ b/tests/Benchmarks/bench_2_realistic.yml
@@ -12,9 +12,6 @@
 
 filename_pattern: /.csv$/i
 
-csv:
-  header: false
-
 columns:
   - rules:
       not_empty: true

--- a/tests/Benchmarks/bench_2_realistic_agg.yml
+++ b/tests/Benchmarks/bench_2_realistic_agg.yml
@@ -12,9 +12,6 @@
 
 filename_pattern: /.csv$/i
 
-csv:
-  header: false
-
 columns:
   - aggregate_rules:
       is_unique: true

--- a/tests/Benchmarks/bench_2_realistic_agg.yml
+++ b/tests/Benchmarks/bench_2_realistic_agg.yml
@@ -13,7 +13,8 @@
 filename_pattern: /.csv$/i
 
 columns:
-  - aggregate_rules:
+  - name: id
+    aggregate_rules:
       is_unique: true
       sorted: [ desc, natural ]
       count: 0

--- a/tests/Benchmarks/bench_2_realistic_combo.yml
+++ b/tests/Benchmarks/bench_2_realistic_combo.yml
@@ -13,7 +13,8 @@
 filename_pattern: /.csv$/i
 
 columns:
-  - rules:
+  - name: id
+    rules:
       not_empty: true
       length_max: 100
       is_int: true

--- a/tests/Benchmarks/bench_2_realistic_combo.yml
+++ b/tests/Benchmarks/bench_2_realistic_combo.yml
@@ -12,9 +12,6 @@
 
 filename_pattern: /.csv$/i
 
-csv:
-  header: false
-
 columns:
   - rules:
       not_empty: true

--- a/tests/Benchmarks/bench_3_all_agg.yml
+++ b/tests/Benchmarks/bench_3_all_agg.yml
@@ -13,7 +13,8 @@
 filename_pattern: /.csv$/i
 
 columns:
-  - rules:
+  - name: id
+    rules:
       not_empty: true
       length_max: 100
       is_int: true

--- a/tests/Benchmarks/bench_3_all_agg.yml
+++ b/tests/Benchmarks/bench_3_all_agg.yml
@@ -12,9 +12,6 @@
 
 filename_pattern: /.csv$/i
 
-csv:
-  header: false
-
 columns:
   - rules:
       not_empty: true

--- a/tests/Csv/CsvFileTest.php
+++ b/tests/Csv/CsvFileTest.php
@@ -29,7 +29,7 @@ final class CsvFileTest extends TestCase
         $csv = new CsvFile(Tools::CSV_SIMPLE_NO_HEADER, Tools::SCHEMA_SIMPLE_NO_HEADER);
         isSame(Tools::CSV_SIMPLE_NO_HEADER, $csv->getCsvFilename());
 
-        isSame([], $csv->getHeader());
+        isSame([0, 1], $csv->getHeader());
 
         isSame([
             ['1', 'true'],
@@ -50,18 +50,19 @@ final class CsvFileTest extends TestCase
         isSame(['seq', 'bool', 'exact'], $csv->getHeader());
 
         isSame([
-            ['seq' => '1', 'bool' => 'true', 'exact' => '1'],
-            ['seq' => '2', 'bool' => 'true', 'exact' => '1'],
-            ['seq' => '3', 'bool' => 'false', 'exact' => '1'],
+            ['seq', 'bool', 'exact'],
+            ['1', 'true', '1'],
+            ['2', 'true', '1'],
+            ['3', 'false', '1'],
         ], $this->fetchRows($csv->getRecords()));
 
         isSame(
-            [['seq' => '2', 'bool' => 'true', 'exact' => '1']],
+            [['1', 'true', '1']],
             $this->fetchRows($csv->getRecordsChunk(1, 1)),
         );
 
         isSame(
-            [['seq' => '2', 'bool' => 'true', 'exact' => '1'], ['seq' => '3', 'bool' => 'false', 'exact' => '1']],
+            [['1', 'true', '1'], ['2', 'true', '1']],
             $this->fetchRows($csv->getRecordsChunk(1, 2)),
         );
     }

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -115,18 +115,12 @@ final class SchemaTest extends TestCase
 
     public function testGetUndefinedColumnById(): void
     {
-        $this->expectExceptionMessage(
-            'Column "1000" not found in schema "' . Tools::SCHEMA_EXAMPLE_EMPTY . '"',
-        );
         $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_EMPTY);
         isNull($schemaFull->getColumn(1000));
     }
 
     public function testGetUndefinedColumnByName(): void
     {
-        $this->expectExceptionMessage(
-            'Column "undefined_column" not found in schema "' . Tools::SCHEMA_EXAMPLE_EMPTY . '"',
-        );
         $schemaFull = new Schema(Tools::SCHEMA_EXAMPLE_EMPTY);
         isNull($schemaFull->getColumn('undefined_column'));
     }


### PR DESCRIPTION
This commit addresses several changes in the CSV validation and header mapping logic. Firstly, a method to set IDs has been added in Column.php. Also, handling of headers in CSV files has been updated to better support files with and without headers. In addition, mapping of columns by header names has been moved to CsvFile.php from Schema.php for better alignment with data flow. Lastly, unnecessary exception throwing in getColumn method of Schema.php has been removed. Unit tests have also been updated to reflect these changes.