### PR TITLE
Add 'ds' PHP extension and transition array to vector

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -80,6 +80,7 @@ jobs:
         with:
           php-version: 8.3
           coverage: none
+          extensions: ds
           ini-values: opcache.enable_cli=1, opcache.jit=1255
 
       - name: Build local Phar file

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           php-version: 8.3
           coverage: xdebug
-          extensions: ast
+          extensions: ast, ds
 
       - name: Build project
         run: make build --no-print-directory
@@ -100,7 +100,7 @@ jobs:
         with:
           php-version: 8.1
           coverage: none
-          extensions: ast
+          extensions: ast, ds
 
       - name: Install project
         run: make build --no-print-directory
@@ -142,7 +142,7 @@ jobs:
         with:
           php-version: highest
           coverage: none
-          extensions: ast
+          extensions: ast, ds
 
       - name: Install project
         run: make build --no-print-directory
@@ -182,6 +182,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.3
+          extensions: ds
 
       - name: Build project in production mode
         run: make build-prod --no-print-directory
@@ -214,6 +215,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          extensions: ds
 
       - name: Build project in production mode
         run: make build-prod build-phar-file --no-print-directory

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           php-version: 8.3
           tools: composer
+          extensions: ds
 
       - name: Build project in production mode
         run: make build-prod build-phar-file --no-print-directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ FROM php:8.3-cli-alpine
 
 # Install PHP extensions
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN install-php-extensions opcache @composer
+RUN install-php-extensions opcache ds @composer
 
 # Install application
 # run `make build-version` before!

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name"              : "jbzoo/csv-blueprint",
-    "type" : "project",
+    "type"              : "project",
     "description"       : "CLI Utility for Validating and Generating CSV Files Based on Custom Rules. It ensures your data meets specified criteria, streamlining data management and integrity checks.",
     "license"           : "MIT",
     "keywords"          : [
@@ -29,6 +29,7 @@
     "require"           : {
         "php"                                 : "^8.1",
         "ext-mbstring"                        : "*",
+        "ext-ds" : "*",
 
         "league/csv"                          : "^9.15.0",
         "jbzoo/data"                          : "^7.1.1",

--- a/src/Rules/AbstarctRule.php
+++ b/src/Rules/AbstarctRule.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Utils;
 use JBZoo\CsvBlueprint\Validators\Error;
 use JBZoo\CsvBlueprint\Validators\ValidatorColumn;
@@ -61,7 +62,7 @@ abstract class AbstarctRule
         // TODO: Move resolving and validating expected value on this stage to make it only once (before validation).
     }
 
-    public function validate(array|string $cellValue, int $line = ValidatorColumn::FALLBACK_LINE): ?Error
+    public function validate(array|string|Vector $cellValue, int $line = ValidatorColumn::FALLBACK_LINE): ?Error
     {
         // TODO: Extract to abstract boolean cell/agregate rule
         if ($this->isEnabled($cellValue) === false) {
@@ -185,7 +186,7 @@ abstract class AbstarctRule
      * Optimize performance
      * There is no need to validate empty values for predicates or if it's disabled.
      */
-    protected function isEnabled(array|string $cellValue): bool
+    protected function isEnabled(string|Vector $cellValue): bool
     {
         // List of rules that should be checked for empty values
         $exclusions = [

--- a/src/Rules/AbstarctRuleCombo.php
+++ b/src/Rules/AbstarctRuleCombo.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\Aggregate\AbstractAggregateRuleCombo;
 use JBZoo\CsvBlueprint\Rules\Cell\AbstractCellRuleCombo;
 use JBZoo\CsvBlueprint\Validators\Error;
@@ -38,7 +39,7 @@ abstract class AbstarctRuleCombo extends AbstarctRule
 
     abstract protected function getActual(array|string $value): float;
 
-    public function validate(array|string $cellValue, int $line = ValidatorColumn::FALLBACK_LINE): ?Error
+    public function validate(string|Vector $cellValue, int $line = ValidatorColumn::FALLBACK_LINE): ?Error
     {
         $error = $this->validateCombo($cellValue);
 
@@ -51,7 +52,7 @@ abstract class AbstarctRuleCombo extends AbstarctRule
 
     public function test(array|string $cellValue, bool $isHtml = false): string
     {
-        $errorMessage = (string)$this->validateCombo($cellValue);
+        $errorMessage = (string)$this->validateCombo(new Vector($cellValue));
 
         return $isHtml ? $errorMessage : \strip_tags($errorMessage);
     }
@@ -96,7 +97,7 @@ abstract class AbstarctRuleCombo extends AbstarctRule
         };
     }
 
-    private function validateCombo(array|string $cellValue): ?string
+    private function validateCombo(string|Vector $cellValue): ?string
     {
         if ($this instanceof AbstractCellRuleCombo) {
             if (!\is_string($cellValue)) {
@@ -107,7 +108,7 @@ abstract class AbstarctRuleCombo extends AbstarctRule
         }
 
         if ($this instanceof AbstractAggregateRuleCombo) {
-            if (!\is_array($cellValue)) {
+            if (!$cellValue instanceof Vector) {
                 throw new \InvalidArgumentException('The value should be an array of numbers/strings');
             }
 

--- a/src/Rules/Aggregate/AbstractAggregateRule.php
+++ b/src/Rules/Aggregate/AbstractAggregateRule.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 
 abstract class AbstractAggregateRule extends AbstarctRule
@@ -28,10 +29,8 @@ abstract class AbstractAggregateRule extends AbstarctRule
      * TODO: This method takes an array reference &$columnValues as input and returns a nullable string.
      * We use a reference to the array to avoid copying the array. Important memory optimization!
      * Please DO NOT change the array in this method!
-     *
-     * @param string[] $columnValues
      */
-    abstract public function validateRule(array $columnValues): ?string;
+    abstract public function validateRule(Vector $columnValues): ?string;
 
     public function test(array $cellValue, bool $isHtml = false): string
     {

--- a/src/Rules/Aggregate/AbstractAggregateRuleCombo.php
+++ b/src/Rules/Aggregate/AbstractAggregateRuleCombo.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use JBZoo\CsvBlueprint\Rules\AbstarctRuleCombo;
 
@@ -23,7 +24,7 @@ abstract class AbstractAggregateRuleCombo extends AbstarctRuleCombo
 {
     public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_STRINGS;
 
-    abstract protected function getActualAggregate(array $colValues): ?float;
+    abstract protected function getActualAggregate(Vector $colValues): ?float;
 
     public function getRuleCode(?string $mode = null): string
     {
@@ -46,7 +47,7 @@ abstract class AbstractAggregateRuleCombo extends AbstarctRuleCombo
         return $this->getOptionAsFloat();
     }
 
-    protected function validateComboAggregate(array $colValues, string $mode): ?string
+    protected function validateComboAggregate(Vector $colValues, string $mode): ?string
     {
         $prefix = $mode === self::NOT ? 'not ' : '';
         $verb = static::VERBS[$mode];
@@ -54,13 +55,13 @@ abstract class AbstractAggregateRuleCombo extends AbstarctRuleCombo
 
         try {
             // TODO: Think about the performance optimization here
-            if (static::INPUT_TYPE === AbstarctRule::INPUT_TYPE_FLOATS) {
-                $colValues = \array_map('floatval', $colValues);
-            }
-
-            if (static::INPUT_TYPE === AbstarctRule::INPUT_TYPE_INTS) {
-                $colValues = \array_map('intval', $colValues);
-            }
+            // if (static::INPUT_TYPE === AbstarctRule::INPUT_TYPE_FLOATS) {
+            //     $colValues = \array_map('floatval', $colValues);
+            // }
+            //
+            // if (static::INPUT_TYPE === AbstarctRule::INPUT_TYPE_INTS) {
+            //     $colValues = \array_map('intval', $colValues);
+            // }
 
             $actual = $this->getActualAggregate($colValues); // Important to use the original method here!
         } catch (\Throwable $exception) {

--- a/src/Rules/Aggregate/ComboAverage.php
+++ b/src/Rules/Aggregate/ComboAverage.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use MathPHP\Statistics\Average;
 
@@ -30,12 +31,12 @@ final class ComboAverage extends AbstractAggregateRuleCombo
         return [['Regular the arithmetic mean. The sum of the numbers divided by the count.'], []];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;
         }
 
-        return Average::mean($colValues);
+        return Average::mean($colValues->toArray());
     }
 }

--- a/src/Rules/Aggregate/ComboCoefOfVar.php
+++ b/src/Rules/Aggregate/ComboCoefOfVar.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use MathPHP\Statistics\Descriptive;
 
@@ -38,7 +39,7 @@ final class ComboCoefOfVar extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboContraharmonicMean.php
+++ b/src/Rules/Aggregate/ComboContraharmonicMean.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use MathPHP\Statistics\Average;
 
@@ -37,7 +38,7 @@ final class ComboContraharmonicMean extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboCount.php
+++ b/src/Rules/Aggregate/ComboCount.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 
 final class ComboCount extends AbstractAggregateRuleCombo
@@ -36,7 +37,7 @@ final class ComboCount extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         return \count($colValues);
     }

--- a/src/Rules/Aggregate/ComboCountDistinct.php
+++ b/src/Rules/Aggregate/ComboCountDistinct.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 
 final class ComboCountDistinct extends AbstractAggregateRuleCombo
@@ -29,7 +30,7 @@ final class ComboCountDistinct extends AbstractAggregateRuleCombo
         return [['Number of unique values.'], []];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboCountEmpty.php
+++ b/src/Rules/Aggregate/ComboCountEmpty.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 
 final class ComboCountEmpty extends AbstractAggregateRuleCombo
@@ -29,7 +30,7 @@ final class ComboCountEmpty extends AbstractAggregateRuleCombo
         return [['Counts only empty values (string length is 0).'], []];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboCountEven.php
+++ b/src/Rules/Aggregate/ComboCountEven.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 
 final class ComboCountEven extends AbstractAggregateRuleCombo
@@ -29,7 +30,7 @@ final class ComboCountEven extends AbstractAggregateRuleCombo
         return [['Number of even values.'], []];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboCountNegative.php
+++ b/src/Rules/Aggregate/ComboCountNegative.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 
 final class ComboCountNegative extends AbstractAggregateRuleCombo
@@ -29,7 +30,7 @@ final class ComboCountNegative extends AbstractAggregateRuleCombo
         return [['Number of negative values.'], []];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboCountNotEmpty.php
+++ b/src/Rules/Aggregate/ComboCountNotEmpty.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 
 final class ComboCountNotEmpty extends AbstractAggregateRuleCombo
@@ -29,7 +30,7 @@ final class ComboCountNotEmpty extends AbstractAggregateRuleCombo
         return [['Counts only not empty values (string length is not 0).'], []];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboCountOdd.php
+++ b/src/Rules/Aggregate/ComboCountOdd.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 
 final class ComboCountOdd extends AbstractAggregateRuleCombo
@@ -29,7 +30,7 @@ final class ComboCountOdd extends AbstractAggregateRuleCombo
         return [['Number of odd values.'], []];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboCountPositive.php
+++ b/src/Rules/Aggregate/ComboCountPositive.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 
 final class ComboCountPositive extends AbstractAggregateRuleCombo
@@ -29,7 +30,7 @@ final class ComboCountPositive extends AbstractAggregateRuleCombo
         return [['Number of positive values.'], []];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboCountPrime.php
+++ b/src/Rules/Aggregate/ComboCountPrime.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use Respect\Validation\Validator;
 
@@ -30,7 +31,7 @@ final class ComboCountPrime extends AbstractAggregateRuleCombo
         return [['Number of prime values.'], []];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboCountZero.php
+++ b/src/Rules/Aggregate/ComboCountZero.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 
 final class ComboCountZero extends AbstractAggregateRuleCombo
@@ -35,7 +36,7 @@ final class ComboCountZero extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboCubicMean.php
+++ b/src/Rules/Aggregate/ComboCubicMean.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use MathPHP\Statistics\Average;
 
@@ -30,7 +31,7 @@ final class ComboCubicMean extends AbstractAggregateRuleCombo
         return [['Cubic mean. See: https://en.wikipedia.org/wiki/Cubic_mean'], []];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboFirstNum.php
+++ b/src/Rules/Aggregate/ComboFirstNum.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 
 final class ComboFirstNum extends AbstractAggregateRuleCombo
@@ -29,7 +30,7 @@ final class ComboFirstNum extends AbstractAggregateRuleCombo
         return [['First number in the column. Expected value is float or integer.'], []];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (!isset($colValues[0])) {
             return null;

--- a/src/Rules/Aggregate/ComboGeometricMean.php
+++ b/src/Rules/Aggregate/ComboGeometricMean.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use MathPHP\Statistics\Average;
 
@@ -38,7 +39,7 @@ final class ComboGeometricMean extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboHarmonicMean.php
+++ b/src/Rules/Aggregate/ComboHarmonicMean.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use MathPHP\Statistics\Average;
 
@@ -38,7 +39,7 @@ final class ComboHarmonicMean extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboInterquartileMean.php
+++ b/src/Rules/Aggregate/ComboInterquartileMean.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use MathPHP\Statistics\Average;
 
@@ -40,7 +41,7 @@ final class ComboInterquartileMean extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboLastNum.php
+++ b/src/Rules/Aggregate/ComboLastNum.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 
 final class ComboLastNum extends AbstractAggregateRuleCombo
@@ -29,7 +30,7 @@ final class ComboLastNum extends AbstractAggregateRuleCombo
         return [['Last number in the column. Expected value is float or integer.'], []];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboMeanAbsDev.php
+++ b/src/Rules/Aggregate/ComboMeanAbsDev.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use MathPHP\Statistics\Descriptive;
 
@@ -37,7 +38,7 @@ final class ComboMeanAbsDev extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboMedian.php
+++ b/src/Rules/Aggregate/ComboMedian.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use MathPHP\Statistics\Average;
 
@@ -36,7 +37,7 @@ final class ComboMedian extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboMedianAbsDev.php
+++ b/src/Rules/Aggregate/ComboMedianAbsDev.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use MathPHP\Statistics\Descriptive;
 
@@ -38,7 +39,7 @@ final class ComboMedianAbsDev extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboMidhinge.php
+++ b/src/Rules/Aggregate/ComboMidhinge.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use MathPHP\Statistics\Descriptive;
 
@@ -38,7 +39,7 @@ final class ComboMidhinge extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboNthNum.php
+++ b/src/Rules/Aggregate/ComboNthNum.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 
 use function JBZoo\Utils\float;
@@ -56,7 +57,7 @@ final class ComboNthNum extends AbstractAggregateRuleCombo
         return float($this->getParams()[self::VAL]);
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboPercentile.php
+++ b/src/Rules/Aggregate/ComboPercentile.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use MathPHP\Statistics\Descriptive;
 
@@ -59,7 +60,7 @@ final class ComboPercentile extends AbstractAggregateRuleCombo
         return float($this->getParams()[self::VAL]);
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboPopulationVariance.php
+++ b/src/Rules/Aggregate/ComboPopulationVariance.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use MathPHP\Statistics\Descriptive;
 
@@ -37,7 +38,7 @@ final class ComboPopulationVariance extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboQuartiles.php
+++ b/src/Rules/Aggregate/ComboQuartiles.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use JBZoo\CsvBlueprint\Utils;
 use MathPHP\Statistics\Descriptive;
@@ -67,7 +68,7 @@ final class ComboQuartiles extends AbstractAggregateRuleCombo
         return float($this->getParams()[self::VAL]);
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboRootMeanSquare.php
+++ b/src/Rules/Aggregate/ComboRootMeanSquare.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use MathPHP\Statistics\Average;
 
@@ -37,7 +38,7 @@ final class ComboRootMeanSquare extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboSampleVariance.php
+++ b/src/Rules/Aggregate/ComboSampleVariance.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use MathPHP\Statistics\Descriptive;
 
@@ -37,7 +38,7 @@ final class ComboSampleVariance extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboStddev.php
+++ b/src/Rules/Aggregate/ComboStddev.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use MathPHP\Statistics\Descriptive;
 
@@ -42,7 +43,7 @@ final class ComboStddev extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboStddevPop.php
+++ b/src/Rules/Aggregate/ComboStddevPop.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use MathPHP\Statistics\Descriptive;
 
@@ -35,7 +36,7 @@ final class ComboStddevPop extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/ComboSum.php
+++ b/src/Rules/Aggregate/ComboSum.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 
 final class ComboSum extends AbstractAggregateRuleCombo
@@ -29,8 +30,8 @@ final class ComboSum extends AbstractAggregateRuleCombo
         return [['Sum of the numbers in the column. Example: [1, 2, 3] => 6.'], []];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
-        return \array_sum($colValues);
+        return $colValues->sum();
     }
 }

--- a/src/Rules/Aggregate/ComboTrimean.php
+++ b/src/Rules/Aggregate/ComboTrimean.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use MathPHP\Statistics\Average;
 
@@ -38,7 +39,7 @@ final class ComboTrimean extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected function getActualAggregate(array $colValues): ?float
+    protected function getActualAggregate(Vector $colValues): ?float
     {
         if (\count($colValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/First.php
+++ b/src/Rules/Aggregate/First.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 
 final class First extends AbstractAggregateRule
@@ -30,7 +31,7 @@ final class First extends AbstractAggregateRule
         ];
     }
 
-    public function validateRule(array $columnValues): ?string
+    public function validateRule(Vector $columnValues): ?string
     {
         if (\count($columnValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/FirstNot.php
+++ b/src/Rules/Aggregate/FirstNot.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 
 final class FirstNot extends AbstractAggregateRule
@@ -35,7 +36,7 @@ final class FirstNot extends AbstractAggregateRule
         ];
     }
 
-    public function validateRule(array $columnValues): ?string
+    public function validateRule(Vector $columnValues): ?string
     {
         if (\count($columnValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/IsUnique.php
+++ b/src/Rules/Aggregate/IsUnique.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 
 final class IsUnique extends AbstractAggregateRule
@@ -30,13 +31,13 @@ final class IsUnique extends AbstractAggregateRule
         ];
     }
 
-    public function validateRule(array $columnValues): ?string
+    public function validateRule(Vector $columnValues): ?string
     {
         if (\count($columnValues) === 0) {
             return null;
         }
 
-        $uValuesCount = \count(\array_unique($columnValues));
+        $uValuesCount = \count(\array_unique($columnValues->toArray()));
         $valuesCount = \count($columnValues);
 
         if ($uValuesCount !== $valuesCount) {

--- a/src/Rules/Aggregate/Last.php
+++ b/src/Rules/Aggregate/Last.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 
 final class Last extends AbstractAggregateRule
@@ -30,7 +31,7 @@ final class Last extends AbstractAggregateRule
         ];
     }
 
-    public function validateRule(array $columnValues): ?string
+    public function validateRule(Vector $columnValues): ?string
     {
         if (\count($columnValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/LastNot.php
+++ b/src/Rules/Aggregate/LastNot.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 
 final class LastNot extends AbstractAggregateRule
@@ -35,7 +36,7 @@ final class LastNot extends AbstractAggregateRule
         ];
     }
 
-    public function validateRule(array $columnValues): ?string
+    public function validateRule(Vector $columnValues): ?string
     {
         if (\count($columnValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/Nth.php
+++ b/src/Rules/Aggregate/Nth.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 
 final class Nth extends AbstractAggregateRule
@@ -34,7 +35,7 @@ final class Nth extends AbstractAggregateRule
         ];
     }
 
-    public function validateRule(array $columnValues): ?string
+    public function validateRule(Vector $columnValues): ?string
     {
         if (\count($columnValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/NthNot.php
+++ b/src/Rules/Aggregate/NthNot.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 
 final class NthNot extends AbstractAggregateRule
@@ -39,7 +40,7 @@ final class NthNot extends AbstractAggregateRule
         ];
     }
 
-    public function validateRule(array $columnValues): ?string
+    public function validateRule(Vector $columnValues): ?string
     {
         if (\count($columnValues) === 0) {
             return null;

--- a/src/Rules/Aggregate/Sorted.php
+++ b/src/Rules/Aggregate/Sorted.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use JBZoo\CsvBlueprint\Utils;
 
@@ -50,7 +51,7 @@ final class Sorted extends AbstractAggregateRule
         ];
     }
 
-    public function validateRule(array $columnValues): ?string
+    public function validateRule(Vector $columnValues): ?string
     {
         if (\count($columnValues) === 0) {
             return null;

--- a/src/Rules/Ruleset.php
+++ b/src/Rules/Ruleset.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Rules\Cell\AbstractCellRuleCombo;
 use JBZoo\CsvBlueprint\Utils;
 use JBZoo\CsvBlueprint\Validators\ErrorSuite;
@@ -43,7 +44,7 @@ final class Ruleset
         }
     }
 
-    public function validateRuleSet(array|string $cellValue, int $line, int $linesToAggregate = 0): ErrorSuite
+    public function validateRuleSet(string|Vector $cellValue, int $line, int $linesToAggregate = 0): ErrorSuite
     {
         $errors = new ErrorSuite();
 

--- a/src/Validators/ValidatorColumn.php
+++ b/src/Validators/ValidatorColumn.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Validators;
 
+use Ds\Vector;
 use JBZoo\CsvBlueprint\Csv\Column;
 use JBZoo\CsvBlueprint\Rules\AbstarctRule;
 use JBZoo\CsvBlueprint\Rules\Ruleset;
@@ -40,7 +41,7 @@ final class ValidatorColumn
         return $this->cellRuleset->validateRuleSet($cellValue, $line);
     }
 
-    public function validateList(array $cellValue, int $linesToAggregate): ErrorSuite
+    public function validateList(Vector $cellValue, int $linesToAggregate): ErrorSuite
     {
         return $this->aggRuleset->validateRuleSet($cellValue, self::FALLBACK_LINE, $linesToAggregate);
     }

--- a/src/Validators/ValidatorCsv.php
+++ b/src/Validators/ValidatorCsv.php
@@ -112,7 +112,7 @@ final class ValidatorCsv
         foreach ($mappedColumns as $columnIndex => $column) {
             $messPrefix = "<i>Column</i> \"{$column->getHumanName()}\" -"; // System message prefix. Debug only!
 
-            $columValues = [];
+            $columValues = new \Ds\Vector();
 
             Utils::debug("{$messPrefix} Column start");
             $colValidator = $column->getValidator();

--- a/tests/Commands/ValidateCsvBasicTest.php
+++ b/tests/Commands/ValidateCsvBasicTest.php
@@ -32,7 +32,7 @@ final class ValidateCsvBasicTest extends TestCase
             'schema' => Tools::DEMO_YML_VALID,
         ]);
 
-        $expected = $expected = <<<'TXT'
+        $expected = <<<'TXT'
             CSV Blueprint: Unknown version (PhpUnit)
             Found Schemas   : 1
             Found CSV files : 1


### PR DESCRIPTION
The PHP 'ds' (data structures) extension has been added to the GitHub Actions workflows to permit targeting PHP 8.3. Array references in all aggregate rule classes have also been migrated to Ds\Vector. With this change, memory optimization and performance are expected to be enhanced due to the characteristic efficiency of vectors.