### PR TITLE
Add hexadecimal check to schema rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 <!-- /top-badges -->
 
 <!-- rules-counter -->
-[![Static Badge](https://img.shields.io/badge/Rules-379-green?label=Total%20number%20of%20rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)
-[![Static Badge](https://img.shields.io/badge/Rules-165-green?label=Cell%20rules&labelColor=blue&color=gray)](src/Rules/Cell)
+[![Static Badge](https://img.shields.io/badge/Rules-380-green?label=Total%20number%20of%20rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)
+[![Static Badge](https://img.shields.io/badge/Rules-166-green?label=Cell%20rules&labelColor=blue&color=gray)](src/Rules/Cell)
 [![Static Badge](https://img.shields.io/badge/Rules-206-green?label=Aggregate%20rules&labelColor=blue&color=gray)](src/Rules/Aggregate)
 [![Static Badge](https://img.shields.io/badge/Rules-8-green?label=Extra%20checks&labelColor=blue&color=gray)](#extra-checks)
-[![Static Badge](https://img.shields.io/badge/Rules-29/54/9-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
+[![Static Badge](https://img.shields.io/badge/Rules-28/54/9-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
 <!-- /rules-counter -->
 
 A console utility designed for validating CSV files against a strictly defined schema and validation rules outlined
@@ -432,6 +432,7 @@ columns:
 
       # Specific formats
       is_bool: true                     # Allow only boolean values "true" and "false", case-insensitive.
+      is_hex: true                      # Both: with or without "0x" prefix. Example: "0x1A" or "1A"
       is_uuid: true                     # Validates whether the input is a valid UUID. It also supports validation of specific versions 1, 3, 4 and 5.
       is_slug: true                     # Only slug format. Example: "my-slug-123". It can contain letters, numbers, and dashes.
       is_currency_code: true            # Validates an ISO 4217 currency code like GBP or EUR. Case-sensitive. See: https://en.wikipedia.org/wiki/ISO_4217.

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -104,6 +104,7 @@
                 "date_age_max"            : 100,
 
                 "is_bool"                 : true,
+                "is_hex"                  : true,
                 "is_uuid"                 : true,
                 "is_slug"                 : true,
                 "is_currency_code"        : true,

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -125,6 +125,7 @@ This example serves as a comprehensive guide for creating robust CSV file valida
                 'date_age_max'     => 100,
 
                 'is_bool'          => true,
+                'is_hex'           => true,
                 'is_uuid'          => true,
                 'is_slug'          => true,
                 'is_currency_code' => true,

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -171,6 +171,7 @@ columns:
 
       # Specific formats
       is_bool: true                     # Allow only boolean values "true" and "false", case-insensitive.
+      is_hex: true                      # Both: with or without "0x" prefix. Example: "0x1A" or "1A"
       is_uuid: true                     # Validates whether the input is a valid UUID. It also supports validation of specific versions 1, 3, 4 and 5.
       is_slug: true                     # Only slug format. Example: "my-slug-123". It can contain letters, numbers, and dashes.
       is_currency_code: true            # Validates an ISO 4217 currency code like GBP or EUR. Case-sensitive. See: https://en.wikipedia.org/wiki/ISO_4217.

--- a/schema-examples/full_clean.yml
+++ b/schema-examples/full_clean.yml
@@ -132,6 +132,7 @@ columns:
       date_age_max: 100
 
       is_bool: true
+      is_hex: true
       is_uuid: true
       is_slug: true
       is_currency_code: true

--- a/src/Rules/Cell/IsHex.php
+++ b/src/Rules/Cell/IsHex.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Rules\Cell;
+
+final class IsHex extends AbstractCellRule
+{
+    public function getHelpMeta(): array
+    {
+        return [
+            [],
+            [
+                self::DEFAULT => [
+                    'true',
+                    'Both: with or without "0x" prefix. Example: "0x1A" or "1A"',
+                ],
+            ],
+        ];
+    }
+
+    public function validateRule(string $cellValue): ?string
+    {
+        if (
+            \preg_match('/^[0-9a-fA-F]+$/i', $cellValue) === 0
+            && \preg_match('/^0x[0-9a-fA-F]+$/i', $cellValue) === 0
+        ) {
+            return "Value \"<c>{$cellValue}</c>\" is not a valid hexadecimal number. Example: \"0x1A\" or \"1A\"";
+        }
+
+        return null;
+    }
+}

--- a/tests/Rules/Cell/IsHexTest.php
+++ b/tests/Rules/Cell/IsHexTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Rules\Cell;
+
+use JBZoo\CsvBlueprint\Rules\Cell\IsHex;
+use JBZoo\PHPUnit\Rules\TestAbstractCellRule;
+
+use function JBZoo\PHPUnit\isSame;
+
+final class IsHexTest extends TestAbstractCellRule
+{
+    protected string $ruleClass = IsHex::class;
+
+    public function testPositive(): void
+    {
+        $rule = $this->create(true);
+        isSame(null, $rule->validate(''));
+        isSame('', $rule->test('0'));
+        isSame('', $rule->test('1'));
+        isSame('', $rule->test('11'));
+        isSame('', $rule->test('1F'));
+        isSame('', $rule->test('ff'));
+        isSame('', $rule->test('fa'));
+
+        isSame('', $rule->test('0x1'));
+        isSame('', $rule->test('0x0'));
+        isSame('', $rule->test('0x11'));
+        isSame('', $rule->test('0x1F'));
+        isSame('', $rule->test('0xff'));
+        isSame('', $rule->test('0xfa'));
+
+        $rule = $this->create(false);
+        isSame(null, $rule->validate('1'));
+    }
+
+    public function testNegative(): void
+    {
+        $rule = $this->create(true);
+        isSame(
+            'Value "qwerty" is not a valid hexadecimal number. Example: "0x1A" or "1A"',
+            $rule->test('qwerty'),
+        );
+
+        $rule = $this->create(true);
+        isSame(
+            '"is_hex" at line <red>1</red>, column "prop". ' .
+            'Value "<c>qwerty</c>" is not a valid hexadecimal number. Example: "0x1A" or "1A".',
+            (string)$rule->validate('qwerty'),
+        );
+    }
+}

--- a/tests/schemas/todo.yml
+++ b/tests/schemas/todo.yml
@@ -75,7 +75,6 @@ columns:
       is_card_number: true
 
       # Strings
-      is_hex: true
       is_binary: true
       is_charset: true
       is_hex_rgb_color: true


### PR DESCRIPTION
A new hexadecimal validation check, `is_hex`, has been added to the rules in the schema. This check validates values against hexadecimal number formats, being able to handle those with or without a '0x' prefix. As a result, the functionality of validating inputs as hexadecimal values has been added to the system's validation checks.