### PR TITLE
Add 'is_octal' validation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 <!-- /top-badges -->
 
 <!-- rules-counter -->
-[![Static Badge](https://img.shields.io/badge/Rules-381-green?label=Total%20number%20of%20rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)
-[![Static Badge](https://img.shields.io/badge/Rules-167-green?label=Cell%20rules&labelColor=blue&color=gray)](src/Rules/Cell)
+[![Static Badge](https://img.shields.io/badge/Rules-382-green?label=Total%20number%20of%20rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)
+[![Static Badge](https://img.shields.io/badge/Rules-168-green?label=Cell%20rules&labelColor=blue&color=gray)](src/Rules/Cell)
 [![Static Badge](https://img.shields.io/badge/Rules-206-green?label=Aggregate%20rules&labelColor=blue&color=gray)](src/Rules/Aggregate)
 [![Static Badge](https://img.shields.io/badge/Rules-8-green?label=Extra%20checks&labelColor=blue&color=gray)](#extra-checks)
 [![Static Badge](https://img.shields.io/badge/Rules-27/54/9-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
@@ -433,6 +433,7 @@ columns:
       # Specific formats
       is_bool: true                     # Allow only boolean values "true" and "false", case-insensitive.
       is_binary: true                   # Both: with or without "0b" prefix. Example: "0b10" or "10"
+      is_octal: true                    # Validates octal numbers in the format "0o123" or "0123".
       is_hex: true                      # Both: with or without "0x" prefix. Example: "0x1A" or "1A"
       is_uuid: true                     # Validates whether the input is a valid UUID. It also supports validation of specific versions 1, 3, 4 and 5.
       is_slug: true                     # Only slug format. Example: "my-slug-123". It can contain letters, numbers, and dashes.

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -105,6 +105,7 @@
 
                 "is_bool"                 : true,
                 "is_binary"               : true,
+                "is_octal"                : true,
                 "is_hex"                  : true,
                 "is_uuid"                 : true,
                 "is_slug"                 : true,

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -126,6 +126,7 @@ This example serves as a comprehensive guide for creating robust CSV file valida
 
                 'is_bool'          => true,
                 'is_binary'        => true,
+                'is_octal'         => true,
                 'is_hex'           => true,
                 'is_uuid'          => true,
                 'is_slug'          => true,

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -172,6 +172,7 @@ columns:
       # Specific formats
       is_bool: true                     # Allow only boolean values "true" and "false", case-insensitive.
       is_binary: true                   # Both: with or without "0b" prefix. Example: "0b10" or "10"
+      is_octal: true                    # Validates octal numbers in the format "0o123" or "0123".
       is_hex: true                      # Both: with or without "0x" prefix. Example: "0x1A" or "1A"
       is_uuid: true                     # Validates whether the input is a valid UUID. It also supports validation of specific versions 1, 3, 4 and 5.
       is_slug: true                     # Only slug format. Example: "my-slug-123". It can contain letters, numbers, and dashes.

--- a/schema-examples/full_clean.yml
+++ b/schema-examples/full_clean.yml
@@ -133,6 +133,7 @@ columns:
 
       is_bool: true
       is_binary: true
+      is_octal: true
       is_hex: true
       is_uuid: true
       is_slug: true

--- a/src/Rules/Cell/IsOctal.php
+++ b/src/Rules/Cell/IsOctal.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Rules\Cell;
+
+final class IsOctal extends AbstractCellRule
+{
+    public function getHelpMeta(): array
+    {
+        return [
+            [],
+            [
+                self::DEFAULT => [
+                    'true',
+                    'Validates octal numbers in the format "0o123" or "0123".',
+                ],
+            ],
+        ];
+    }
+
+    public function validateRule(string $cellValue): ?string
+    {
+        if (
+            \preg_match('/^[0-7]+(_[0-7]+)*$/', $cellValue) === 0
+            && \preg_match('/^0[oO]?[0-7]+(_[0-7]+)*$/', $cellValue) === 0
+        ) {
+            return "Value \"<c>{$cellValue}</c>\" is not a valid octal number. Examples: \"0o123\" or \"0123\"";
+        }
+
+        return null;
+    }
+}

--- a/tests/Rules/Cell/IsOctalTest.php
+++ b/tests/Rules/Cell/IsOctalTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Rules\Cell;
+
+use JBZoo\CsvBlueprint\Rules\Cell\IsOctal;
+use JBZoo\PHPUnit\Rules\TestAbstractCellRule;
+
+use function JBZoo\PHPUnit\isSame;
+
+final class IsOctalTest extends TestAbstractCellRule
+{
+    protected string $ruleClass = IsOctal::class;
+
+    public function testPositive(): void
+    {
+        $rule = $this->create(true);
+        isSame(null, $rule->validate(''));
+        isSame('', $rule->test('0'));
+        isSame('', $rule->test('7'));
+        isSame('', $rule->test('01'));
+
+        isSame('', $rule->test('0o1'));
+        isSame('', $rule->test('0o123'));
+
+        isSame('', $rule->test('0O1'));
+        isSame('', $rule->test('0O123'));
+
+        $rule = $this->create(false);
+        isSame(null, $rule->validate('1'));
+    }
+
+    public function testNegative(): void
+    {
+        $rule = $this->create(true);
+        isSame(
+            'Value "8" is not a valid octal number. Examples: "0o123" or "0123"',
+            $rule->test('8'),
+        );
+
+        $rule = $this->create(true);
+        isSame(
+            '"is_octal" at line <red>1</red>, column "prop". Value "<c>qwerty</c>" is not a valid octal number. ' .
+            'Examples: "0o123" or "0123".',
+            (string)$rule->validate('qwerty'),
+        );
+    }
+}


### PR DESCRIPTION
This new rule will help in validating octal number formats like "0o123" or "0123".