### PR TITLE
Add `validate:schema` command

### DIFF
--- a/.phan.php
+++ b/.phan.php
@@ -30,6 +30,7 @@ return \array_merge($default, [
         'vendor/league/csv/src',
         'vendor/symfony/console',
         'vendor/symfony/finder',
+        'vendor/symfony/yaml',
         'vendor/markrogoyski/math-php/src',
         'vendor/respect/validation',
     ],

--- a/README.md
+++ b/README.md
@@ -867,7 +867,7 @@ So there are options here for all occasions.
 
 
 Description:
-  Validate CSV file(s) by schema.
+  Validate CSV file(s) by schema(s).
 
 Usage:
   validate:csv [options]
@@ -881,14 +881,14 @@ Options:
                                    It can be a YAML, JSON or PHP. See examples on GitHub.Also, you can specify path in which schema files will be searched (max depth is 10).
                                    Feel free to use glob pattrens. Usage examples:
                                    /full/path/file.yml, p/file.yml, p/*.yml, p/**/*.yml, p/**/name-*.json, **/*.php, etc. (multiple values allowed)
+  -S, --skip-schema[=SKIP-SCHEMA]  Skip schema validation.
+                                   If you are sure that the schema is correct, you can skip this check.
+                                   Empty value or "yes" will be treated as "true". [default: "no"]
   -r, --report=REPORT              Report output format. Available options:
                                    ["text", "table", "github", "gitlab", "teamcity", "junit"] [default: "table"]
   -Q, --quick[=QUICK]              Immediately terminate the check at the first error found.
                                    Of course it will speed up the check, but you will get only 1 message out of many.
                                    If any error is detected, the utility will return a non-zero exit code.
-                                   Empty value or "yes" will be treated as "true". [default: "no"]
-  -S, --skip-schema[=SKIP-SCHEMA]  Skip schema validation.
-                                   If you are sure that the schema is correct, you can skip this check.
                                    Empty value or "yes" will be treated as "true". [default: "no"]
       --debug                      It's ONLY for debugging and advanced profiling!
       --no-progress                Disable progress bar animation for logs. It will be used only for text output format.
@@ -934,19 +934,19 @@ Pairs by pattern: 1
 Check schema syntax: 1
 (1/1) Schema: ./tests/schemas/demo_invalid.yml
 (1/1) Issues: 2
-+-------+------------------+--------------+----- demo_invalid.yml -----------------------------------------------+
++-------+------------------+------------- tests/schemas/demo_invalid.yml ----------------------------------------+
 | Line  | id:Column        | Rule         | Message                                                              |
 +-------+------------------+--------------+----------------------------------------------------------------------+
 | undef | 2:Float          | is_float     | Value "Qwerty" is not a float number                                 |
 | undef | 4:Favorite color | allow_values | Value "123" is not allowed. Allowed values: ["red", "green", "Blue"] |
-+-------+------------------+--------------+----- demo_invalid.yml -----------------------------------------------+
++-------+------------------+------------- tests/schemas/demo_invalid.yml ----------------------------------------+
 
 
 CSV file validation: 1
 (1/1) Schema: ./tests/schemas/demo_invalid.yml
 (1/1) CSV   : ./tests/fixtures/demo.csv; Size: 123.34 MB
 (1/1) Issues: 10
-+------+------------------+---------------------+---------------------- demo.csv ----------------------------------------------------------------------+
++------+------------------+---------------------+-------------- tests/fixtures/demo.csv ---------------------------------------------------------------+
 | Line | id:Column        | Rule                | Message                                                                                              |
 +------+------------------+---------------------+------------------------------------------------------------------------------------------------------+
 | 1    |                  | allow_extra_columns | Column(s) not found in CSV: "wrong_column_name"                                                      |
@@ -962,7 +962,7 @@ CSV file validation: 1
 | 9    | 3:Birthday       | date_max            | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", which is greater than  |
 |      |                  |                     | the expected "2009-01-01 00:00:00 +00:00 (2009-01-01)"                                               |
 | 5    | 4:Favorite color | allow_values        | Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"]                                |
-+------+------------------+---------------------+---------------------- demo.csv ----------------------------------------------------------------------+
++------+------------------+---------------------+-------------- tests/fixtures/demo.csv ---------------------------------------------------------------+
 
 
 Summary:

--- a/README.md
+++ b/README.md
@@ -857,15 +857,16 @@ Behind the scenes to what is outlined in the yml above, there are additional che
 ## Complete CLI Help Message
 
 Here you can see all available options and commands. Tool uses [JBZoo/Cli](https://github.com/JBZoo/Cli) package for the
-CLI interface.
-So there are options here for all occasions.
+CLI interface. So there are options here for all occasions.
 
+
+`./csv-blueprint validate:csv --help`
+
+<details>
+  <summary>CLICK to see validate:csv help messege</summary>
 
 <!-- auto-update:validate-csv-help -->
-```
-./csv-blueprint validate:csv --help
-
-
+```text
 Description:
   Validate CSV file(s) by schema(s).
 
@@ -914,6 +915,58 @@ Options:
 ```
 <!-- auto-update:/validate-csv-help -->
 
+</details>
+
+
+`./csv-blueprint validate:schema --help`
+
+<details>
+  <summary>CLICK to see validate:schema help messege</summary>
+
+<!-- auto-update:validate-schema-help -->
+```text
+Description:
+  Validate syntax in schema file(s).
+
+Usage:
+  validate:schema [options]
+
+Options:
+  -s, --schema=SCHEMA            Path(s) to schema file(s).
+                                 It can be a YAML, JSON or PHP. See examples on GitHub.Also, you can specify path in which schema files will be searched (max depth is 10).
+                                 Feel free to use glob pattrens. Usage examples:
+                                 /full/path/file.yml, p/file.yml, p/*.yml, p/**/*.yml, p/**/name-*.json, **/*.php, etc. (multiple values allowed)
+  -r, --report=REPORT            Report output format. Available options:
+                                 ["text", "table", "github", "gitlab", "teamcity", "junit"] [default: "table"]
+  -Q, --quick[=QUICK]            Immediately terminate the check at the first error found.
+                                 Of course it will speed up the check, but you will get only 1 message out of many.
+                                 If any error is detected, the utility will return a non-zero exit code.
+                                 Empty value or "yes" will be treated as "true". [default: "no"]
+      --debug                    It's ONLY for debugging and advanced profiling!
+      --no-progress              Disable progress bar animation for logs. It will be used only for text output format.
+      --mute-errors              Mute any sort of errors. So exit code will be always "0" (if it's possible).
+                                 It has major priority then --non-zero-on-error. It's on your own risk!
+      --stdout-only              For any errors messages application will use StdOut instead of StdErr. It's on your own risk!
+      --non-zero-on-error        None-zero exit code on any StdErr message.
+      --timestamp                Show timestamp at the beginning of each message.It will be used only for text output format.
+      --profile                  Display timing and memory usage information.
+      --output-mode=OUTPUT-MODE  Output format. Available options:
+                                 text - Default text output format, userfriendly and easy to read.
+                                 cron - Shortcut for crontab. It's basically focused on human-readable logs output.
+                                 It's combination of --timestamp --profile --stdout-only --no-progress -vv.
+                                 logstash - Logstash output format, for integration with ELK stack.
+                                  [default: "text"]
+      --cron                     Alias for --output-mode=cron. Deprecated!
+  -h, --help                     Display help for the given command. When no command is given display help for the list command
+  -q, --quiet                    Do not output any message
+  -V, --version                  Display this application version
+      --ansi|--no-ansi           Force (or disable --no-ansi) ANSI output
+  -n, --no-interaction           Do not ask any interactive question
+  -v|vv|vvv, --verbose           Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+```
+<!-- auto-update:/validate-schema-help -->
+
+</details>
 
 ## Report examples
 

--- a/csv-blueprint.php
+++ b/csv-blueprint.php
@@ -16,6 +16,10 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint;
 
+if ('cli' !== \PHP_SAPI) {
+    throw new \RuntimeException('This script must be run from the command line.');
+}
+
 \define('PATH_ROOT', __DIR__);
 require_once __DIR__ . '/vendor/autoload.php';
 

--- a/src/Commands/AbstractValidate.php
+++ b/src/Commands/AbstractValidate.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Commands;
+
+use JBZoo\Cli\CliCommand;
+use JBZoo\CsvBlueprint\Exception;
+use JBZoo\CsvBlueprint\Utils;
+use JBZoo\CsvBlueprint\Validators\ErrorSuite;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Finder\SplFileInfo;
+
+use function JBZoo\Utils\bool;
+
+/**
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+abstract class AbstractValidate extends CliCommand
+{
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'report',
+                'r',
+                InputOption::VALUE_REQUIRED,
+                "Report output format. Available options:\n" .
+                Utils::printList(ErrorSuite::getAvaiableRenderFormats(), 'info'),
+                ErrorSuite::REPORT_DEFAULT,
+            )
+            ->addOption(
+                'quick',
+                'Q',
+                InputOption::VALUE_OPTIONAL,
+                "Immediately terminate the check at the first error found.\n" .
+                "Of course it will speed up the check, but you will get only 1 message out of many.\n" .
+                "If any error is detected, the utility will return a non-zero exit code.\n" .
+                'Empty value or "yes" will be treated as "true".',
+                'no',
+            )
+            ->addOption(
+                'debug',
+                null,
+                InputOption::VALUE_NONE,
+                "It's ONLY for debugging and advanced profiling!",
+            );
+
+        parent::configure();
+    }
+
+    protected function preparation(): void
+    {
+        if ($this->isHumanReadableMode()) {
+            $this->_('CSV Blueprint: ' . Utils::getVersion(true));
+        }
+
+        if ($this->getOptBool('debug')) {
+            \define('DEBUG_MODE', true);
+        }
+    }
+
+    protected function isHumanReadableMode(): bool
+    {
+        return $this->getReportType() !== ErrorSuite::REPORT_GITLAB
+            && $this->getReportType() !== ErrorSuite::REPORT_JUNIT
+            && $this->getReportType() !== ErrorSuite::REPORT_TEAMCITY;
+    }
+
+    protected function getReportType(): string
+    {
+        return $this->getOptString('report', ErrorSuite::RENDER_TABLE, ErrorSuite::getAvaiableRenderFormats());
+    }
+
+    protected function isQuickMode(): bool
+    {
+        $value = $this->getOptString('quick');
+        return $value === '' || bool($value);
+    }
+
+    protected function out(null|array|string $messge): void
+    {
+        if ($this->isHumanReadableMode()) {
+            $this->_($messge);
+        }
+    }
+
+    /**
+     * @return SplFileInfo[]
+     */
+    protected function findFiles(string $option, bool $throwException = true): array
+    {
+        $patterns = $this->getOptArray($option);
+        $filenames = \array_values(Utils::findFiles($patterns));
+
+        if ($throwException && \count($filenames) === 0) {
+            throw new Exception('File(s) not found: ' . Utils::printList($patterns));
+        }
+
+        return $filenames;
+    }
+}

--- a/src/Commands/ValidateSchema.php
+++ b/src/Commands/ValidateSchema.php
@@ -68,10 +68,8 @@ final class ValidateSchema extends AbstractValidate
 
         $foundIssues = 0;
 
-        foreach ($this->findFiles('schema') as $index => $file) {
-            $prefix = '(' . ((int)$index + 1) . "/{$totalFiles})";
-
-            $filename = $file->getRealPath();
+        foreach ($this->findFiles('schema') as $file) {
+            $filename = (string)$file->getRealPath();
             $coloredPath = Utils::printFile($filename);
             $schemaErrors = new ErrorSuite($filename);
 

--- a/src/Commands/ValidateSchema.php
+++ b/src/Commands/ValidateSchema.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Commands;
+
+use JBZoo\CsvBlueprint\Schema;
+use JBZoo\CsvBlueprint\Utils;
+use JBZoo\CsvBlueprint\Validators\Error;
+use JBZoo\CsvBlueprint\Validators\ErrorSuite;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Yaml\Exception\ParseException;
+
+/**
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+final class ValidateSchema extends AbstractValidate
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('validate:schema')
+            ->setDescription('Validate syntax in schema file(s).')
+            ->addOption(
+                'schema',
+                's',
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                \implode('', [
+                    "Path(s) to schema file(s).\n",
+                    'It can be a YAML, JSON or PHP. See examples on GitHub.',
+                    'Also, you can specify path in which schema files will be searched ',
+                    '(max depth is ' . Utils::MAX_DIRECTORY_DEPTH . ").\n",
+                    "Feel free to use glob pattrens. Usage examples: \n",
+                    '<info>/full/path/file.yml</info>, ',
+                    '<info>p/file.yml</info>, ',
+                    '<info>p/*.yml</info>, ',
+                    '<info>p/**/*.yml</info>, ',
+                    '<info>p/**/name-*.json</info>, ',
+                    '<info>**/*.php</info>, ',
+                    'etc.',
+                ]),
+            );
+
+        parent::configure();
+    }
+
+    protected function executeAction(): int
+    {
+        $this->preparation();
+
+        $schemas = $this->findFiles('schema');
+        $totalFiles = \count($schemas);
+
+        $this->out("Found schemas: {$totalFiles}");
+        $this->out('');
+
+        $foundIssues = 0;
+
+        foreach ($this->findFiles('schema') as $index => $file) {
+            $prefix = '(' . ((int)$index + 1) . "/{$totalFiles})";
+
+            $filename = $file->getRealPath();
+            $coloredPath = Utils::printFile($filename);
+            $schemaErrors = new ErrorSuite($filename);
+
+            try {
+                $schemaErrors = (new Schema($filename))->validate($this->isQuickMode());
+            } catch (ParseException $e) {
+                $schemaErrors->addError(new Error('schema.syntax', $e->getMessage(), '', $e->getParsedLine()));
+            } catch (\Throwable $e) {
+                $schemaErrors->addError(new Error('schema.error', $e->getMessage()));
+            }
+
+            if ($schemaErrors->count() > 0) {
+                $this->out(["<yellow>Issues:</yellow> {$coloredPath}"]);
+                $this->_($schemaErrors->render($this->getReportType()));
+            } else {
+                $this->out("<green>OK:</green> {$coloredPath}");
+            }
+
+            $foundIssues += $schemaErrors->count();
+        }
+
+        return $foundIssues === 0 ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/src/Validators/ErrorSuite.php
+++ b/src/Validators/ErrorSuite.php
@@ -22,6 +22,7 @@ use JBZoo\CIReportConverter\Converters\JUnitConverter;
 use JBZoo\CIReportConverter\Converters\TeamCityTestsConverter;
 use JBZoo\CIReportConverter\Formats\Source\SourceSuite;
 use JBZoo\CsvBlueprint\Utils;
+use JBZoo\Utils\FS;
 use JBZoo\Utils\Vars;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -191,7 +192,11 @@ final class ErrorSuite
 
     private function getTestcaseName(): string
     {
-        return \pathinfo((string)\realpath((string)$this->csvFilename), \PATHINFO_BASENAME);
+        if ((string)$this->csvFilename === '') {
+            return '';
+        }
+
+        return FS::getRelative(($file = new \SplFileInfo($this->csvFilename))->getRealPath());
     }
 
     /**

--- a/src/Validators/ErrorSuite.php
+++ b/src/Validators/ErrorSuite.php
@@ -192,11 +192,17 @@ final class ErrorSuite
 
     private function getTestcaseName(): string
     {
-        if ((string)$this->csvFilename === '') {
+        $csvFilename = \trim((string)$this->csvFilename);
+
+        if ($csvFilename === '') {
             return '';
         }
 
-        return FS::getRelative(($file = new \SplFileInfo($this->csvFilename))->getRealPath());
+        if (!\file_exists($csvFilename)) {
+            return $csvFilename;
+        }
+
+        return FS::getRelative((string)(new \SplFileInfo($csvFilename))->getRealPath());
     }
 
     /**

--- a/tests/Commands/ValidateCsvBasicTest.php
+++ b/tests/Commands/ValidateCsvBasicTest.php
@@ -32,7 +32,7 @@ final class ValidateCsvBasicTest extends TestCase
             'schema' => Tools::DEMO_YML_VALID,
         ]);
 
-        $expected = $expected = <<<'TXT'
+        $expected = <<<'TXT'
             CSV Blueprint: Unknown version (PhpUnit)
             Found Schemas   : 1
             Found CSV files : 1
@@ -79,12 +79,12 @@ final class ValidateCsvBasicTest extends TestCase
             (1/1) Schema: ./tests/schemas/demo_valid.yml
             (1/1) CSV   : ./tests/fixtures/demo_invalid.csv; Size: 123.34 MB
             (1/1) Issues: 2
-            +------+------------------+--------------+-------------- demo_invalid.csv --------------------------------------------------------+
+            +------+------------------+--------------+------- tests/fixtures/demo_invalid.csv ------------------------------------------------+
             | Line | id:Column        | Rule         | Message                                                                                |
             +------+------------------+--------------+----------------------------------------------------------------------------------------+
             | 6    | 0:Name           | length_max   | The length of the value "Long-long-name" is 14, which is greater than the expected "7" |
             | 11   | 4:Favorite color | allow_values | Value "YELLOW" is not allowed. Allowed values: ["red", "green", "blue"]                |
-            +------+------------------+--------------+-------------- demo_invalid.csv --------------------------------------------------------+
+            +------+------------------+--------------+------- tests/fixtures/demo_invalid.csv ------------------------------------------------+
             
             
             Summary:
@@ -115,19 +115,19 @@ final class ValidateCsvBasicTest extends TestCase
             Check schema syntax: 1
             (1/1) Schema: ./tests/schemas/demo_invalid.yml
             (1/1) Issues: 2
-            +-------+------------------+--------------+----- demo_invalid.yml -----------------------------------------------+
+            +-------+------------------+------------- tests/schemas/demo_invalid.yml ----------------------------------------+
             | Line  | id:Column        | Rule         | Message                                                              |
             +-------+------------------+--------------+----------------------------------------------------------------------+
             | undef | 2:Float          | is_float     | Value "Qwerty" is not a float number                                 |
             | undef | 4:Favorite color | allow_values | Value "123" is not allowed. Allowed values: ["red", "green", "Blue"] |
-            +-------+------------------+--------------+----- demo_invalid.yml -----------------------------------------------+
+            +-------+------------------+------------- tests/schemas/demo_invalid.yml ----------------------------------------+
             
             
             CSV file validation: 1
             (1/1) Schema: ./tests/schemas/demo_invalid.yml
             (1/1) CSV   : ./tests/fixtures/demo.csv; Size: 123.34 MB
             (1/1) Issues: 10
-            +------+------------------+---------------------+---------------------- demo.csv ----------------------------------------------------------------------+
+            +------+------------------+---------------------+-------------- tests/fixtures/demo.csv ---------------------------------------------------------------+
             | Line | id:Column        | Rule                | Message                                                                                              |
             +------+------------------+---------------------+------------------------------------------------------------------------------------------------------+
             | 1    |                  | allow_extra_columns | Column(s) not found in CSV: "wrong_column_name"                                                      |
@@ -143,7 +143,7 @@ final class ValidateCsvBasicTest extends TestCase
             | 9    | 3:Birthday       | date_max            | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", which is greater than  |
             |      |                  |                     | the expected "2009-01-01 00:00:00 +00:00 (2009-01-01)"                                               |
             | 5    | 4:Favorite color | allow_values        | Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"]                                |
-            +------+------------------+---------------------+---------------------- demo.csv ----------------------------------------------------------------------+
+            +------+------------------+---------------------+-------------- tests/fixtures/demo.csv ---------------------------------------------------------------+
             
             
             Summary:
@@ -178,7 +178,7 @@ final class ValidateCsvBasicTest extends TestCase
             Check schema syntax: 1
             (1/1) Schema: ./tests/schemas/invalid_schema.yml
             (1/1) Issues: 8
-            +-------+------------+--------+----------- invalid_schema.yml ------------------------------------------+
+            +-------+------------+--------+---- tests/schemas/invalid_schema.yml -----------------------------------+
             | Line  | id:Column  | Rule   | Message                                                                 |
             +-------+------------+--------+-------------------------------------------------------------------------+
             | undef | meta       | schema | Unknown key: .unknow_root_option                                        |
@@ -189,7 +189,7 @@ final class ValidateCsvBasicTest extends TestCase
             | undef | 4:         | schema | The key "name" must be non-empty because the option "csv.header" = true |
             | undef | 4:         | schema | Expected type "boolean", actual "string" in .columns.4.rules.not_empty  |
             | undef | 4:         | schema | Expected type "array", actual "string" in .columns.4.rules.allow_values |
-            +-------+------------+--------+----------- invalid_schema.yml ------------------------------------------+
+            +-------+------------+--------+---- tests/schemas/invalid_schema.yml -----------------------------------+
             
             
             CSV file validation: 0
@@ -228,7 +228,7 @@ final class ValidateCsvBasicTest extends TestCase
             Check schema syntax: 1
             (1/1) Schema: ./tests/schemas/invalid_schema.yml
             (1/1) Issues: 8
-            +-------+------------+--------+----------- invalid_schema.yml ------------------------------------------+
+            +-------+------------+--------+---- tests/schemas/invalid_schema.yml -----------------------------------+
             | Line  | id:Column  | Rule   | Message                                                                 |
             +-------+------------+--------+-------------------------------------------------------------------------+
             | undef | meta       | schema | Unknown key: .unknow_root_option                                        |
@@ -239,7 +239,7 @@ final class ValidateCsvBasicTest extends TestCase
             | undef | 4:         | schema | The key "name" must be non-empty because the option "csv.header" = true |
             | undef | 4:         | schema | Expected type "boolean", actual "string" in .columns.4.rules.not_empty  |
             | undef | 4:         | schema | Expected type "array", actual "string" in .columns.4.rules.allow_values |
-            +-------+------------+--------+----------- invalid_schema.yml ------------------------------------------+
+            +-------+------------+--------+---- tests/schemas/invalid_schema.yml -----------------------------------+
             
             
             CSV file validation: 0
@@ -265,7 +265,7 @@ final class ValidateCsvBasicTest extends TestCase
             'schema' => './tests/schemas/simple_no_header.yml',
         ]);
 
-        $expected = $expected = <<<'TXT'
+        $expected = <<<'TXT'
             CSV Blueprint: Unknown version (PhpUnit)
             Found Schemas   : 1
             Found CSV files : 1
@@ -278,12 +278,12 @@ final class ValidateCsvBasicTest extends TestCase
             (1/1) Schema: ./tests/schemas/simple_no_header.yml
             (1/1) CSV   : ./tests/fixtures/demo.csv; Size: 123.34 MB
             (1/1) Issues: 2
-            +------+-----------+---------- demo.csv -----------------------------+
+            +------+-----------+-- tests/fixtures/demo.csv ----------------------+
             | Line | id:Column | Rule             | Message                      |
             +------+-----------+------------------+------------------------------+
             | 2    | 0:        | not_allow_values | Value "Clyde" is not allowed |
             | 5    | 2:        | not_allow_values | Value "74" is not allowed    |
-            +------+-----------+---------- demo.csv -----------------------------+
+            +------+-----------+-- tests/fixtures/demo.csv ----------------------+
             
             
             Summary:
@@ -300,12 +300,33 @@ final class ValidateCsvBasicTest extends TestCase
         isSame($expected, $actual);
     }
 
-    public function testSchemaNotFound(): void
+    public function testNothingFound(): void
     {
-        $this->expectExceptionMessage('Schema file(s) not found: "invalid_schema_path.yml"');
-        Tools::virtualExecution('validate:csv', [
+        [$actual, $exitCode] = Tools::virtualExecution('validate:csv', [
             'csv'    => './tests/fixtures/no-found-file.csv',
             'schema' => 'invalid_schema_path.yml',
         ]);
+
+        $expected = <<<'TXT'
+            CSV Blueprint: Unknown version (PhpUnit)
+            Found Schemas   : 0
+            Found CSV files : 0
+            Pairs by pattern: 0
+            
+            Check schema syntax: 0
+            
+            CSV file validation: 0
+            
+            Summary:
+              No schema files found!
+              0 pairs (schema to csv) were found based on `filename_pattern`.
+              No issues in 0 schemas.
+              No issues in 0 CSV files.
+            
+            
+            TXT;
+
+        isSame(1, $exitCode, $actual);
+        isSame($expected, $actual);
     }
 }

--- a/tests/Commands/ValidateCsvBatchCsvTest.php
+++ b/tests/Commands/ValidateCsvBatchCsvTest.php
@@ -38,7 +38,7 @@ final class ValidateCsvBatchCsvTest extends TestCase
 
         [$actual, $exitCode] = Tools::virtualExecution('validate:csv', $optionsAsString);
 
-        $expected = $expected = <<<'TXT'
+        $expected = <<<'TXT'
             CSV Blueprint: Unknown version (PhpUnit)
             Found Schemas   : 1
             Found CSV files : 4
@@ -92,19 +92,19 @@ final class ValidateCsvBatchCsvTest extends TestCase
             Check schema syntax: 1
             (1/1) Schema: ./tests/schemas/demo_invalid.yml
             (1/1) Issues: 2
-            +-------+------------------+--------------+----- demo_invalid.yml -----------------------------------------------+
+            +-------+------------------+------------- tests/schemas/demo_invalid.yml ----------------------------------------+
             | Line  | id:Column        | Rule         | Message                                                              |
             +-------+------------------+--------------+----------------------------------------------------------------------+
             | undef | 2:Float          | is_float     | Value "Qwerty" is not a float number                                 |
             | undef | 4:Favorite color | allow_values | Value "123" is not allowed. Allowed values: ["red", "green", "Blue"] |
-            +-------+------------------+--------------+----- demo_invalid.yml -----------------------------------------------+
+            +-------+------------------+------------- tests/schemas/demo_invalid.yml ----------------------------------------+
             
             
             CSV file validation: 3
             (1/3) Schema: ./tests/schemas/demo_invalid.yml
             (1/3) CSV   : ./tests/fixtures/batch/demo-1.csv; Size: 123.34 MB
             (1/3) Issues: 5
-            +------+------------------+---------------------+--------------------- demo-1.csv ---------------------------------------------------------------------+
+            +------+------------------+---------------------+---------- tests/fixtures/batch/demo-1.csv -----------------------------------------------------------+
             | Line | id:Column        | Rule                | Message                                                                                              |
             +------+------------------+---------------------+------------------------------------------------------------------------------------------------------+
             | 1    |                  | allow_extra_columns | Column(s) not found in CSV: "wrong_column_name"                                                      |
@@ -112,12 +112,12 @@ final class ValidateCsvBatchCsvTest extends TestCase
             | 1    | 2:Float          | ag:nth_num          | The column does not have a line 4, so the value cannot be checked.                                   |
             | 1    | 3:Birthday       | ag:nth              | The value on line 2 in the column is "1998-02-28", which is not equal than the expected "2000-12-01" |
             | 3    | 4:Favorite color | allow_values        | Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"]                                |
-            +------+------------------+---------------------+--------------------- demo-1.csv ---------------------------------------------------------------------+
+            +------+------------------+---------------------+---------- tests/fixtures/batch/demo-1.csv -----------------------------------------------------------+
             
             (2/3) Schema: ./tests/schemas/demo_invalid.yml
             (2/3) CSV   : ./tests/fixtures/batch/demo-2.csv; Size: 123.34 MB
             (2/3) Issues: 7
-            +------+------------+---------------------+------------------------ demo-2.csv ------------------------------------------------------------------+
+            +------+------------+---------------------+------------- tests/fixtures/batch/demo-2.csv --------------------------------------------------------+
             | Line | id:Column  | Rule                | Message                                                                                              |
             +------+------------+---------------------+------------------------------------------------------------------------------------------------------+
             | 1    |            | allow_extra_columns | Column(s) not found in CSV: "wrong_column_name"                                                      |
@@ -130,16 +130,16 @@ final class ValidateCsvBatchCsvTest extends TestCase
             | 5    | 3:Birthday | date_max            | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", which is greater than  |
             |      |            |                     | the expected "2009-01-01 00:00:00 +00:00 (2009-01-01)"                                               |
             | 1    | 3:Birthday | ag:nth              | The value on line 2 in the column is "1989-05-15", which is not equal than the expected "2000-12-01" |
-            +------+------------+---------------------+------------------------ demo-2.csv ------------------------------------------------------------------+
+            +------+------------+---------------------+------------- tests/fixtures/batch/demo-2.csv --------------------------------------------------------+
             
             (3/3) Schema: ./tests/schemas/demo_invalid.yml
             (3/3) CSV   : ./tests/fixtures/batch/sub/demo-3.csv; Size: 123.34 MB
             (3/3) Issues: 1
-            +------+-----------+-------------------- demo-3.csv ---------------------------------------+
+            +------+-----------+------- tests/fixtures/batch/sub/demo-3.csv ---------------------------+
             | Line | id:Column | Rule                | Message                                         |
             +------+-----------+---------------------+-------------------------------------------------+
             | 1    |           | allow_extra_columns | Column(s) not found in CSV: "wrong_column_name" |
-            +------+-----------+-------------------- demo-3.csv ---------------------------------------+
+            +------+-----------+------- tests/fixtures/batch/sub/demo-3.csv ---------------------------+
             
             
             Summary:

--- a/tests/Commands/ValidateCsvBatchSchemaTest.php
+++ b/tests/Commands/ValidateCsvBatchSchemaTest.php
@@ -45,17 +45,17 @@ final class ValidateCsvBatchSchemaTest extends TestCase
             Check schema syntax: 3
             (1/3) Schema: ./tests/schemas/demo_invalid.yml
             (1/3) Issues: 2
-            +-------+------------------+--------------+----- demo_invalid.yml -----------------------------------------------+
+            +-------+------------------+------------- tests/schemas/demo_invalid.yml ----------------------------------------+
             | Line  | id:Column        | Rule         | Message                                                              |
             +-------+------------------+--------------+----------------------------------------------------------------------+
             | undef | 2:Float          | is_float     | Value "Qwerty" is not a float number                                 |
             | undef | 4:Favorite color | allow_values | Value "123" is not allowed. Allowed values: ["red", "green", "Blue"] |
-            +-------+------------------+--------------+----- demo_invalid.yml -----------------------------------------------+
+            +-------+------------------+------------- tests/schemas/demo_invalid.yml ----------------------------------------+
             
             (2/3) OK: ./tests/schemas/demo_valid.yml
             (3/3) Schema: ./tests/schemas/invalid_schema.yml
             (3/3) Issues: 8
-            +-------+------------+--------+----------- invalid_schema.yml ------------------------------------------+
+            +-------+------------+--------+---- tests/schemas/invalid_schema.yml -----------------------------------+
             | Line  | id:Column  | Rule   | Message                                                                 |
             +-------+------------+--------+-------------------------------------------------------------------------+
             | undef | meta       | schema | Unknown key: .unknow_root_option                                        |
@@ -66,14 +66,14 @@ final class ValidateCsvBatchSchemaTest extends TestCase
             | undef | 4:         | schema | The key "name" must be non-empty because the option "csv.header" = true |
             | undef | 4:         | schema | Expected type "boolean", actual "string" in .columns.4.rules.not_empty  |
             | undef | 4:         | schema | Expected type "array", actual "string" in .columns.4.rules.allow_values |
-            +-------+------------+--------+----------- invalid_schema.yml ------------------------------------------+
+            +-------+------------+--------+---- tests/schemas/invalid_schema.yml -----------------------------------+
             
             
             CSV file validation: 2
             (1/2) Schema: ./tests/schemas/demo_invalid.yml
             (1/2) CSV   : ./tests/fixtures/demo.csv; Size: 123.34 MB
             (1/2) Issues: 10
-            +------+------------------+---------------------+---------------------- demo.csv ----------------------------------------------------------------------+
+            +------+------------------+---------------------+-------------- tests/fixtures/demo.csv ---------------------------------------------------------------+
             | Line | id:Column        | Rule                | Message                                                                                              |
             +------+------------------+---------------------+------------------------------------------------------------------------------------------------------+
             | 1    |                  | allow_extra_columns | Column(s) not found in CSV: "wrong_column_name"                                                      |
@@ -89,7 +89,7 @@ final class ValidateCsvBatchSchemaTest extends TestCase
             | 9    | 3:Birthday       | date_max            | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", which is greater than  |
             |      |                  |                     | the expected "2009-01-01 00:00:00 +00:00 (2009-01-01)"                                               |
             | 5    | 4:Favorite color | allow_values        | Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"]                                |
-            +------+------------------+---------------------+---------------------- demo.csv ----------------------------------------------------------------------+
+            +------+------------------+---------------------+-------------- tests/fixtures/demo.csv ---------------------------------------------------------------+
             
             (2/2) Schema: ./tests/schemas/demo_valid.yml
             (2/2) CSV   : ./tests/fixtures/demo.csv; Size: 123.34 MB
@@ -135,12 +135,12 @@ final class ValidateCsvBatchSchemaTest extends TestCase
             (1/2) Schema: ./tests/schemas/demo_invalid_no_pattern.yml
             (1/2) CSV   : ./tests/fixtures/demo.csv; Size: 123.34 MB
             (1/2) Issues: 2
-            +------+-----------+---------+------ demo.csv -----------------------------------+
+            +------+-----------+-------- tests/fixtures/demo.csv ----------------------------+
             | Line | id:Column | Rule    | Message                                           |
             +------+-----------+---------+---------------------------------------------------+
             | 4    | 2:Float   | num_min | The value "-177.90" is less than the expected "0" |
             | 11   | 2:Float   | num_min | The value "-200.1" is less than the expected "0"  |
-            +------+-----------+---------+------ demo.csv -----------------------------------+
+            +------+-----------+-------- tests/fixtures/demo.csv ----------------------------+
             
             (2/2) Schema: ./tests/schemas/demo_valid.yml
             (2/2) CSV   : ./tests/fixtures/demo.csv; Size: 123.34 MB

--- a/tests/Commands/ValidateCsvReportsTest.php
+++ b/tests/Commands/ValidateCsvReportsTest.php
@@ -35,19 +35,19 @@ final class ValidateCsvReportsTest extends TestCase
             Check schema syntax: 1
             (1/1) Schema: ./tests/schemas/demo_invalid.yml
             (1/1) Issues: 2
-            +-------+------------------+--------------+----- demo_invalid.yml -----------------------------------------------+
+            +-------+------------------+------------- tests/schemas/demo_invalid.yml ----------------------------------------+
             | Line  | id:Column        | Rule         | Message                                                              |
             +-------+------------------+--------------+----------------------------------------------------------------------+
             | undef | 2:Float          | is_float     | Value "Qwerty" is not a float number                                 |
             | undef | 4:Favorite color | allow_values | Value "123" is not allowed. Allowed values: ["red", "green", "Blue"] |
-            +-------+------------------+--------------+----- demo_invalid.yml -----------------------------------------------+
+            +-------+------------------+------------- tests/schemas/demo_invalid.yml ----------------------------------------+
             
             
             CSV file validation: 1
             (1/1) Schema: ./tests/schemas/demo_invalid.yml
             (1/1) CSV   : ./tests/fixtures/demo.csv; Size: 123.34 MB
             (1/1) Issues: 10
-            +------+------------------+---------------------+---------------------- demo.csv ----------------------------------------------------------------------+
+            +------+------------------+---------------------+-------------- tests/fixtures/demo.csv ---------------------------------------------------------------+
             | Line | id:Column        | Rule                | Message                                                                                              |
             +------+------------------+---------------------+------------------------------------------------------------------------------------------------------+
             | 1    |                  | allow_extra_columns | Column(s) not found in CSV: "wrong_column_name"                                                      |
@@ -63,7 +63,7 @@ final class ValidateCsvReportsTest extends TestCase
             | 9    | 3:Birthday       | date_max            | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", which is greater than  |
             |      |                  |                     | the expected "2009-01-01 00:00:00 +00:00 (2009-01-01)"                                               |
             | 5    | 4:Favorite color | allow_values        | Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"]                                |
-            +------+------------------+---------------------+---------------------- demo.csv ----------------------------------------------------------------------+
+            +------+------------------+---------------------+-------------- tests/fixtures/demo.csv ---------------------------------------------------------------+
             
             
             Summary:
@@ -177,7 +177,7 @@ final class ValidateCsvReportsTest extends TestCase
             
             ##teamcity[testCount count='2' flowId='42']
             
-            ##teamcity[testSuiteStarted name='demo_invalid.yml' flowId='42']
+            ##teamcity[testSuiteStarted name='tests/schemas/demo_invalid.yml' flowId='42']
             
             ##teamcity[testStarted name='is_float at column 2:Float' locationHint='php_qn://./tests/schemas/demo_invalid.yml' flowId='42']
             "is_float", column "2:Float". Value "Qwerty" is not a float number.
@@ -187,12 +187,12 @@ final class ValidateCsvReportsTest extends TestCase
             "allow_values", column "4:Favorite color". Value "123" is not allowed. Allowed values: ["red", "green", "Blue"].
             ##teamcity[testFinished name='allow_values at column 4:Favorite color' flowId='42']
             
-            ##teamcity[testSuiteFinished name='demo_invalid.yml' flowId='42']
+            ##teamcity[testSuiteFinished name='tests/schemas/demo_invalid.yml' flowId='42']
             
             
             ##teamcity[testCount count='10' flowId='42']
             
-            ##teamcity[testSuiteStarted name='demo.csv' flowId='42']
+            ##teamcity[testSuiteStarted name='tests/fixtures/demo.csv' flowId='42']
             
             ##teamcity[testStarted name='allow_extra_columns at column' locationHint='php_qn://<root>/tests/fixtures/demo.csv' flowId='42']
             "allow_extra_columns" at line 1. Column(s) not found in CSV: "wrong_column_name".
@@ -234,7 +234,7 @@ final class ValidateCsvReportsTest extends TestCase
             "allow_values" at line 5, column "4:Favorite color". Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"].
             ##teamcity[testFinished name='allow_values at column 4:Favorite color' flowId='42']
             
-            ##teamcity[testSuiteFinished name='demo.csv' flowId='42']
+            ##teamcity[testSuiteFinished name='tests/fixtures/demo.csv' flowId='42']
             
             
             TXT;
@@ -248,7 +248,7 @@ final class ValidateCsvReportsTest extends TestCase
         $expected = <<<'TXT'
             <?xml version="1.0" encoding="UTF-8"?>
             <testsuites>
-              <testsuite name="demo_invalid.yml" tests="2">
+              <testsuite name="tests/schemas/demo_invalid.yml" tests="2">
                 <testcase name="is_float at column 2:Float" file="./tests/schemas/demo_invalid.yml" line="0">
                   <system-out>"is_float", column "2:Float". Value "Qwerty" is not a float number.</system-out>
                 </testcase>
@@ -260,7 +260,7 @@ final class ValidateCsvReportsTest extends TestCase
             
             <?xml version="1.0" encoding="UTF-8"?>
             <testsuites>
-              <testsuite name="demo.csv" tests="10">
+              <testsuite name="tests/fixtures/demo.csv" tests="10">
                 <testcase name="allow_extra_columns at column" file="<root>/tests/fixtures/demo.csv" line="1">
                   <system-out>"allow_extra_columns" at line 1. Column(s) not found in CSV: "wrong_column_name".</system-out>
                 </testcase>

--- a/tests/Commands/ValidateSchemaTest.php
+++ b/tests/Commands/ValidateSchemaTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Commands;
+
+use JBZoo\PHPUnit\TestCase;
+use JBZoo\PHPUnit\Tools;
+
+use function JBZoo\PHPUnit\isSame;
+
+final class ValidateSchemaTest extends TestCase
+{
+    public function testValid(): void
+    {
+        [$actual, $exitCode] = Tools::virtualExecution('validate:schema', [
+            'schema' => Tools::DEMO_YML_VALID,
+        ]);
+
+        $expected = <<<'TXT'
+            CSV Blueprint: Unknown version (PhpUnit)
+            Found schemas: 1
+            
+            OK: ./tests/schemas/demo_valid.yml
+            
+            TXT;
+
+        isSame($expected, $actual);
+        isSame(0, $exitCode, $actual);
+    }
+
+    public function testInvalidSyntax(): void
+    {
+        [$actual, $exitCode] = Tools::virtualExecution('validate:schema', [
+            'schema' => './tests/schemas/broken/syntax.yml',
+        ]);
+
+        $expected = <<<'TXT'
+            CSV Blueprint: Unknown version (PhpUnit)
+            Found schemas: 1
+            
+            Issues: ./tests/schemas/broken/syntax.yml
+            +------+-----------+------- tests/schemas/broken/syntax.yml ---------------------------+
+            | Line | id:Column | Rule          | Message                                           |
+            +------+-----------+---------------+---------------------------------------------------+
+            | 15   |           | schema.syntax | Unable to parse at line 15 (near "(*$#)@(@$*)("). |
+            +------+-----------+------- tests/schemas/broken/syntax.yml ---------------------------+
+            
+            
+            TXT;
+
+        isSame($expected, $actual);
+        isSame(1, $exitCode, $actual);
+    }
+
+    public function testInvalidSchemas(): void
+    {
+        [$actual, $exitCode] = Tools::virtualExecution('validate:schema', [
+            'schema' => './tests/schemas/broken/*.yml',
+        ]);
+
+        $expected = <<<'TXT'
+            CSV Blueprint: Unknown version (PhpUnit)
+            Found schemas: 2
+
+            Issues: ./tests/schemas/broken/invalid_schema.yml
+            +-------+--- tests/schemas/broken/invalid_schema.yml -----------+
+            | Line  | id:Column | Rule   | Message                          |
+            +-------+-----------+--------+----------------------------------+
+            | undef | meta      | schema | Unknown key: .unknow_root_option |
+            +-------+--- tests/schemas/broken/invalid_schema.yml -----------+
+            
+            Issues: ./tests/schemas/broken/syntax.yml
+            +------+-----------+------- tests/schemas/broken/syntax.yml ---------------------------+
+            | Line | id:Column | Rule          | Message                                           |
+            +------+-----------+---------------+---------------------------------------------------+
+            | 15   |           | schema.syntax | Unable to parse at line 15 (near "(*$#)@(@$*)("). |
+            +------+-----------+------- tests/schemas/broken/syntax.yml ---------------------------+
+            
+            
+            TXT;
+
+        isSame($expected, $actual);
+        isSame(1, $exitCode, $actual);
+    }
+
+    public function testInvalidSchemasTextReport(): void
+    {
+        [$actual, $exitCode] = Tools::virtualExecution('validate:schema', [
+            'schema' => './tests/schemas/broken/*.yml',
+            'report' => 'text',
+        ]);
+
+        $expected = <<<'TXT'
+            CSV Blueprint: Unknown version (PhpUnit)
+            Found schemas: 2
+
+            Issues: ./tests/schemas/broken/invalid_schema.yml
+            "schema", column "meta". Unknown key: .unknow_root_option.
+            
+            Issues: ./tests/schemas/broken/syntax.yml
+            "schema.syntax" at line 15. Unable to parse at line 15 (near "(*$#)@(@$*)(").
+            
+            
+            TXT;
+
+        isSame($expected, $actual);
+        isSame(1, $exitCode, $actual);
+    }
+}

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -34,18 +34,26 @@ final class ReadmeTest extends TestCase
         '  * If `csv.header: false`. Compare the number of columns in the schema and the CSV file.',
     ];
 
-    public function testCreateCsvHelp(): void
+    public function testCalidateCsvHelp(): void
     {
         $text = \implode("\n", [
-            '```',
-            './csv-blueprint validate:csv --help',
-            '',
-            '',
+            '```text',
             \trim(Tools::realExecution('validate:csv', ['help' => null])),
             '```',
         ]);
 
         Tools::insertInReadme('validate-csv-help', $text);
+    }
+
+    public function testCalidateSchemaHelp(): void
+    {
+        $text = \implode("\n", [
+            '```text',
+            \trim(Tools::realExecution('validate:schema', ['help' => null])),
+            '```',
+        ]);
+
+        Tools::insertInReadme('validate-schema-help', $text);
     }
 
     public function testTableOutputExample(): void

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -212,6 +212,7 @@ final class SchemaTest extends TestCase
             ->in(PROJECT_ROOT . '/tests/Benchmarks')
             ->in(PROJECT_ROOT . '/schema-examples')
             ->name('*.yml')
+            ->depth(0)
             ->notName([
                 'todo.yml',
                 'invalid_schema.yml',
@@ -230,7 +231,7 @@ final class SchemaTest extends TestCase
         $schema = new Schema(Tools::SCHEMA_INVALID);
         isSame(
             <<<'TABLE'
-                +-------+------------+--------+----------- invalid_schema.yml ------------------------------------------+
+                +-------+------------+--------+---- tests/schemas/invalid_schema.yml -----------------------------------+
                 | Line  | id:Column  | Rule   | Message                                                                 |
                 +-------+------------+--------+-------------------------------------------------------------------------+
                 | undef | meta       | schema | Unknown key: .unknow_root_option                                        |
@@ -241,7 +242,7 @@ final class SchemaTest extends TestCase
                 | undef | 4:         | schema | The key "name" must be non-empty because the option "csv.header" = true |
                 | undef | 4:         | schema | Expected type "boolean", actual "string" in .columns.4.rules.not_empty  |
                 | undef | 4:         | schema | Expected type "array", actual "string" in .columns.4.rules.allow_values |
-                +-------+------------+--------+----------- invalid_schema.yml ------------------------------------------+
+                +-------+------------+--------+---- tests/schemas/invalid_schema.yml -----------------------------------+
                 
                 TABLE,
             $schema->validate()->render(ErrorSuite::RENDER_TABLE),

--- a/tests/Tools.php
+++ b/tests/Tools.php
@@ -18,6 +18,7 @@ namespace JBZoo\PHPUnit;
 
 use JBZoo\Cli\CliApplication;
 use JBZoo\CsvBlueprint\Commands\ValidateCsv;
+use JBZoo\CsvBlueprint\Commands\ValidateSchema;
 use JBZoo\Utils\Cli;
 use JBZoo\Utils\Sys;
 use Symfony\Component\Console\Input\StringInput;
@@ -55,6 +56,7 @@ final class Tools
     {
         $application = new CliApplication();
         $application->add(new ValidateCsv());
+        $application->add(new ValidateSchema());
         $command = $application->find($action);
 
         $buffer = new BufferedOutput();

--- a/tests/schemas/broken/invalid_schema.yml
+++ b/tests/schemas/broken/invalid_schema.yml
@@ -1,0 +1,17 @@
+#
+# JBZoo Toolbox - Csv-Blueprint.
+#
+# This file is part of the JBZoo Toolbox project.
+# For the full copyright and license information, please view the LICENSE
+# file that was distributed with this source code.
+#
+# @license    MIT
+# @copyright  Copyright (C) JBZoo.com, All rights reserved.
+# @see        https://github.com/JBZoo/Csv-Blueprint
+#
+
+# This schema is invalid because does not match the CSV file (tests/fixtures/demo.csv).
+
+filename_pattern: /invalid-pattern\.csv$/i
+
+unknow_root_option: true

--- a/tests/schemas/broken/syntax.yml
+++ b/tests/schemas/broken/syntax.yml
@@ -1,0 +1,15 @@
+#
+# JBZoo Toolbox - Csv-Blueprint.
+#
+# This file is part of the JBZoo Toolbox project.
+# For the full copyright and license information, please view the LICENSE
+# file that was distributed with this source code.
+#
+# @license    MIT
+# @copyright  Copyright (C) JBZoo.com, All rights reserved.
+# @see        https://github.com/JBZoo/Csv-Blueprint
+#
+
+# This schema is valid because match the CSV file (tests/fixtures/demo.csv) perfectly.
+
+(*$#)@(@$*)(


### PR DESCRIPTION
This command is designed to validate syntax in schema files. Files can be of YAML, JSON or PHP format and the path to these schema files can be defined. Errors in schema syntax are caught and reported.