### PR TITLE
All line numbers in tables are padded to the left

### DIFF
--- a/README.md
+++ b/README.md
@@ -999,7 +999,7 @@ Pairs by pattern: 1
 Check schema syntax: 1
   2 issues in ./tests/schemas/demo_invalid.yml
     +-------+------------------+--------------+----------------------------------------------------------------------+
-    | Line  | id:Column        | Rule         | Message                                                              |
+    |  Line | id:Column        | Rule         | Message                                                              |
     +-------+------------------+--------------+----------------------------------------------------------------------+
     | undef | 2:Float          | is_float     | Value "Qwerty" is not a float number                                 |
     | undef | 4:Favorite color | allow_values | Value "123" is not allowed. Allowed values: ["red", "green", "Blue"] |
@@ -1011,19 +1011,19 @@ Schema: ./tests/schemas/demo_invalid.yml
     +------+------------------+---------------------+------------------------------------------------------------------------------------------------------+
     | Line | id:Column        | Rule                | Message                                                                                              |
     +------+------------------+---------------------+------------------------------------------------------------------------------------------------------+
-    | 1    |                  | allow_extra_columns | Column(s) not found in CSV: "wrong_column_name"                                                      |
-    | 6    | 0:Name           | length_min          | The length of the value "Carl" is 4, which is less than the expected "5"                             |
-    | 11   | 0:Name           | length_min          | The length of the value "Lois" is 4, which is less than the expected "5"                             |
-    | 1    | 1:City           | ag:is_unique        | Column has non-unique values. Unique: 9, total: 10                                                   |
-    | 2    | 2:Float          | num_max             | The value "4825.185" is greater than the expected "4825.184"                                         |
-    | 1    | 2:Float          | ag:nth_num          | The N-th value in the column is "74", which is not equal than the expected "0.001"                   |
-    | 6    | 3:Birthday       | date_min            | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
+    |    1 |                  | allow_extra_columns | Column(s) not found in CSV: "wrong_column_name"                                                      |
+    |    6 | 0:Name           | length_min          | The length of the value "Carl" is 4, which is less than the expected "5"                             |
+    |   11 | 0:Name           | length_min          | The length of the value "Lois" is 4, which is less than the expected "5"                             |
+    |    1 | 1:City           | ag:is_unique        | Column has non-unique values. Unique: 9, total: 10                                                   |
+    |    2 | 2:Float          | num_max             | The value "4825.185" is greater than the expected "4825.184"                                         |
+    |    1 | 2:Float          | ag:nth_num          | The N-th value in the column is "74", which is not equal than the expected "0.001"                   |
+    |    6 | 3:Birthday       | date_min            | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
     |      |                  |                     | expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"                                                   |
-    | 8    | 3:Birthday       | date_min            | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
+    |    8 | 3:Birthday       | date_min            | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
     |      |                  |                     | expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"                                                   |
-    | 9    | 3:Birthday       | date_max            | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", which is greater than  |
+    |    9 | 3:Birthday       | date_max            | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", which is greater than  |
     |      |                  |                     | the expected "2009-01-01 00:00:00 +00:00 (2009-01-01)"                                               |
-    | 5    | 4:Favorite color | allow_values        | Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"]                                |
+    |    5 | 4:Favorite color | allow_values        | Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"]                                |
     +------+------------------+---------------------+------------------------------------------------------------------------------------------------------+
 
 Summary:

--- a/src/Validators/ErrorSuite.php
+++ b/src/Validators/ErrorSuite.php
@@ -25,6 +25,7 @@ use JBZoo\CsvBlueprint\Utils;
 use JBZoo\Utils\FS;
 use JBZoo\Utils\Vars;
 use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableStyle;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 final class ErrorSuite
@@ -157,7 +158,8 @@ final class ErrorSuite
             ->setColumnMaxWidth(0, $floatingSizes['line'])
             ->setColumnMaxWidth(1, $floatingSizes['column'])
             ->setColumnMaxWidth(2, $floatingSizes['rule'])
-            ->setColumnMaxWidth(3, $floatingSizes['message']);
+            ->setColumnMaxWidth(3, $floatingSizes['message'])
+            ->setColumnStyle(0, (new TableStyle())->setPadType(\STR_PAD_LEFT));
 
         foreach ($this->errors as $error) {
             $table->addRow([

--- a/tests/Commands/ValidateCsvBasicTest.php
+++ b/tests/Commands/ValidateCsvBasicTest.php
@@ -80,8 +80,8 @@ final class ValidateCsvBasicTest extends TestCase
                 +------+------------------+--------------+----------------------------------------------------------------------------------------+
                 | Line | id:Column        | Rule         | Message                                                                                |
                 +------+------------------+--------------+----------------------------------------------------------------------------------------+
-                | 6    | 0:Name           | length_max   | The length of the value "Long-long-name" is 14, which is greater than the expected "7" |
-                | 11   | 4:Favorite color | allow_values | Value "YELLOW" is not allowed. Allowed values: ["red", "green", "blue"]                |
+                |    6 | 0:Name           | length_max   | The length of the value "Long-long-name" is 14, which is greater than the expected "7" |
+                |   11 | 4:Favorite color | allow_values | Value "YELLOW" is not allowed. Allowed values: ["red", "green", "blue"]                |
                 +------+------------------+--------------+----------------------------------------------------------------------------------------+
 
             Summary:
@@ -112,7 +112,7 @@ final class ValidateCsvBasicTest extends TestCase
             Check schema syntax: 1
               2 issues in ./tests/schemas/demo_invalid.yml
                 +-------+------------------+--------------+----------------------------------------------------------------------+
-                | Line  | id:Column        | Rule         | Message                                                              |
+                |  Line | id:Column        | Rule         | Message                                                              |
                 +-------+------------------+--------------+----------------------------------------------------------------------+
                 | undef | 2:Float          | is_float     | Value "Qwerty" is not a float number                                 |
                 | undef | 4:Favorite color | allow_values | Value "123" is not allowed. Allowed values: ["red", "green", "Blue"] |
@@ -124,19 +124,19 @@ final class ValidateCsvBasicTest extends TestCase
                 +------+------------------+---------------------+------------------------------------------------------------------------------------------------------+
                 | Line | id:Column        | Rule                | Message                                                                                              |
                 +------+------------------+---------------------+------------------------------------------------------------------------------------------------------+
-                | 1    |                  | allow_extra_columns | Column(s) not found in CSV: "wrong_column_name"                                                      |
-                | 6    | 0:Name           | length_min          | The length of the value "Carl" is 4, which is less than the expected "5"                             |
-                | 11   | 0:Name           | length_min          | The length of the value "Lois" is 4, which is less than the expected "5"                             |
-                | 1    | 1:City           | ag:is_unique        | Column has non-unique values. Unique: 9, total: 10                                                   |
-                | 2    | 2:Float          | num_max             | The value "4825.185" is greater than the expected "4825.184"                                         |
-                | 1    | 2:Float          | ag:nth_num          | The N-th value in the column is "74", which is not equal than the expected "0.001"                   |
-                | 6    | 3:Birthday       | date_min            | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
+                |    1 |                  | allow_extra_columns | Column(s) not found in CSV: "wrong_column_name"                                                      |
+                |    6 | 0:Name           | length_min          | The length of the value "Carl" is 4, which is less than the expected "5"                             |
+                |   11 | 0:Name           | length_min          | The length of the value "Lois" is 4, which is less than the expected "5"                             |
+                |    1 | 1:City           | ag:is_unique        | Column has non-unique values. Unique: 9, total: 10                                                   |
+                |    2 | 2:Float          | num_max             | The value "4825.185" is greater than the expected "4825.184"                                         |
+                |    1 | 2:Float          | ag:nth_num          | The N-th value in the column is "74", which is not equal than the expected "0.001"                   |
+                |    6 | 3:Birthday       | date_min            | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
                 |      |                  |                     | expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"                                                   |
-                | 8    | 3:Birthday       | date_min            | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
+                |    8 | 3:Birthday       | date_min            | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
                 |      |                  |                     | expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"                                                   |
-                | 9    | 3:Birthday       | date_max            | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", which is greater than  |
+                |    9 | 3:Birthday       | date_max            | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", which is greater than  |
                 |      |                  |                     | the expected "2009-01-01 00:00:00 +00:00 (2009-01-01)"                                               |
-                | 5    | 4:Favorite color | allow_values        | Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"]                                |
+                |    5 | 4:Favorite color | allow_values        | Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"]                                |
                 +------+------------------+---------------------+------------------------------------------------------------------------------------------------------+
             
             Summary:
@@ -171,7 +171,7 @@ final class ValidateCsvBasicTest extends TestCase
             Check schema syntax: 1
               8 issues in ./tests/schemas/invalid_schema.yml
                 +-------+------------+--------+-------------------------------------------------------------------------+
-                | Line  | id:Column  | Rule   | Message                                                                 |
+                |  Line | id:Column  | Rule   | Message                                                                 |
                 +-------+------------+--------+-------------------------------------------------------------------------+
                 | undef | meta       | schema | Unknown key: .unknow_root_option                                        |
                 | undef | meta       | schema | Unknown key: .csv.unknow_csv_param                                      |
@@ -219,7 +219,7 @@ final class ValidateCsvBasicTest extends TestCase
             Check schema syntax: 1
               8 issues in ./tests/schemas/invalid_schema.yml
                 +-------+------------+--------+-------------------------------------------------------------------------+
-                | Line  | id:Column  | Rule   | Message                                                                 |
+                |  Line | id:Column  | Rule   | Message                                                                 |
                 +-------+------------+--------+-------------------------------------------------------------------------+
                 | undef | meta       | schema | Unknown key: .unknow_root_option                                        |
                 | undef | meta       | schema | Unknown key: .csv.unknow_csv_param                                      |
@@ -269,8 +269,8 @@ final class ValidateCsvBasicTest extends TestCase
                 +------+-----------+------------------+------------------------------+
                 | Line | id:Column | Rule             | Message                      |
                 +------+-----------+------------------+------------------------------+
-                | 2    | 0:        | not_allow_values | Value "Clyde" is not allowed |
-                | 5    | 2:        | not_allow_values | Value "74" is not allowed    |
+                |    2 | 0:        | not_allow_values | Value "Clyde" is not allowed |
+                |    5 | 2:        | not_allow_values | Value "74" is not allowed    |
                 +------+-----------+------------------+------------------------------+
             
             Summary:

--- a/tests/Commands/ValidateCsvBatchSchemaTest.php
+++ b/tests/Commands/ValidateCsvBatchSchemaTest.php
@@ -45,7 +45,7 @@ final class ValidateCsvBatchSchemaTest extends TestCase
             Check schema syntax: 3
               (1/3) 2 issues in ./tests/schemas/demo_invalid.yml
                 +-------+------------------+--------------+----------------------------------------------------------------------+
-                | Line  | id:Column        | Rule         | Message                                                              |
+                |  Line | id:Column        | Rule         | Message                                                              |
                 +-------+------------------+--------------+----------------------------------------------------------------------+
                 | undef | 2:Float          | is_float     | Value "Qwerty" is not a float number                                 |
                 | undef | 4:Favorite color | allow_values | Value "123" is not allowed. Allowed values: ["red", "green", "Blue"] |
@@ -53,7 +53,7 @@ final class ValidateCsvBatchSchemaTest extends TestCase
               (2/3) OK ./tests/schemas/demo_valid.yml
               (3/3) 8 issues in ./tests/schemas/invalid_schema.yml
                 +-------+------------+--------+-------------------------------------------------------------------------+
-                | Line  | id:Column  | Rule   | Message                                                                 |
+                |  Line | id:Column  | Rule   | Message                                                                 |
                 +-------+------------+--------+-------------------------------------------------------------------------+
                 | undef | meta       | schema | Unknown key: .unknow_root_option                                        |
                 | undef | meta       | schema | Unknown key: .csv.unknow_csv_param                                      |
@@ -71,19 +71,19 @@ final class ValidateCsvBatchSchemaTest extends TestCase
                 +------+------------------+---------------------+------------------------------------------------------------------------------------------------------+
                 | Line | id:Column        | Rule                | Message                                                                                              |
                 +------+------------------+---------------------+------------------------------------------------------------------------------------------------------+
-                | 1    |                  | allow_extra_columns | Column(s) not found in CSV: "wrong_column_name"                                                      |
-                | 6    | 0:Name           | length_min          | The length of the value "Carl" is 4, which is less than the expected "5"                             |
-                | 11   | 0:Name           | length_min          | The length of the value "Lois" is 4, which is less than the expected "5"                             |
-                | 1    | 1:City           | ag:is_unique        | Column has non-unique values. Unique: 9, total: 10                                                   |
-                | 2    | 2:Float          | num_max             | The value "4825.185" is greater than the expected "4825.184"                                         |
-                | 1    | 2:Float          | ag:nth_num          | The N-th value in the column is "74", which is not equal than the expected "0.001"                   |
-                | 6    | 3:Birthday       | date_min            | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
+                |    1 |                  | allow_extra_columns | Column(s) not found in CSV: "wrong_column_name"                                                      |
+                |    6 | 0:Name           | length_min          | The length of the value "Carl" is 4, which is less than the expected "5"                             |
+                |   11 | 0:Name           | length_min          | The length of the value "Lois" is 4, which is less than the expected "5"                             |
+                |    1 | 1:City           | ag:is_unique        | Column has non-unique values. Unique: 9, total: 10                                                   |
+                |    2 | 2:Float          | num_max             | The value "4825.185" is greater than the expected "4825.184"                                         |
+                |    1 | 2:Float          | ag:nth_num          | The N-th value in the column is "74", which is not equal than the expected "0.001"                   |
+                |    6 | 3:Birthday       | date_min            | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
                 |      |                  |                     | expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"                                                   |
-                | 8    | 3:Birthday       | date_min            | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
+                |    8 | 3:Birthday       | date_min            | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
                 |      |                  |                     | expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"                                                   |
-                | 9    | 3:Birthday       | date_max            | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", which is greater than  |
+                |    9 | 3:Birthday       | date_max            | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", which is greater than  |
                 |      |                  |                     | the expected "2009-01-01 00:00:00 +00:00 (2009-01-01)"                                               |
-                | 5    | 4:Favorite color | allow_values        | Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"]                                |
+                |    5 | 4:Favorite color | allow_values        | Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"]                                |
                 +------+------------------+---------------------+------------------------------------------------------------------------------------------------------+
             
             Schema: ./tests/schemas/demo_valid.yml
@@ -131,8 +131,8 @@ final class ValidateCsvBatchSchemaTest extends TestCase
                 +------+-----------+---------+---------------------------------------------------+
                 | Line | id:Column | Rule    | Message                                           |
                 +------+-----------+---------+---------------------------------------------------+
-                | 4    | 2:Float   | num_min | The value "-177.90" is less than the expected "0" |
-                | 11   | 2:Float   | num_min | The value "-200.1" is less than the expected "0"  |
+                |    4 | 2:Float   | num_min | The value "-177.90" is less than the expected "0" |
+                |   11 | 2:Float   | num_min | The value "-200.1" is less than the expected "0"  |
                 +------+-----------+---------+---------------------------------------------------+
             
             Schema: ./tests/schemas/demo_valid.yml

--- a/tests/Commands/ValidateCsvReportsTest.php
+++ b/tests/Commands/ValidateCsvReportsTest.php
@@ -35,7 +35,7 @@ final class ValidateCsvReportsTest extends TestCase
             Check schema syntax: 1
               2 issues in ./tests/schemas/demo_invalid.yml
                 +-------+------------------+--------------+----------------------------------------------------------------------+
-                | Line  | id:Column        | Rule         | Message                                                              |
+                |  Line | id:Column        | Rule         | Message                                                              |
                 +-------+------------------+--------------+----------------------------------------------------------------------+
                 | undef | 2:Float          | is_float     | Value "Qwerty" is not a float number                                 |
                 | undef | 4:Favorite color | allow_values | Value "123" is not allowed. Allowed values: ["red", "green", "Blue"] |
@@ -47,19 +47,19 @@ final class ValidateCsvReportsTest extends TestCase
                 +------+------------------+---------------------+------------------------------------------------------------------------------------------------------+
                 | Line | id:Column        | Rule                | Message                                                                                              |
                 +------+------------------+---------------------+------------------------------------------------------------------------------------------------------+
-                | 1    |                  | allow_extra_columns | Column(s) not found in CSV: "wrong_column_name"                                                      |
-                | 6    | 0:Name           | length_min          | The length of the value "Carl" is 4, which is less than the expected "5"                             |
-                | 11   | 0:Name           | length_min          | The length of the value "Lois" is 4, which is less than the expected "5"                             |
-                | 1    | 1:City           | ag:is_unique        | Column has non-unique values. Unique: 9, total: 10                                                   |
-                | 2    | 2:Float          | num_max             | The value "4825.185" is greater than the expected "4825.184"                                         |
-                | 1    | 2:Float          | ag:nth_num          | The N-th value in the column is "74", which is not equal than the expected "0.001"                   |
-                | 6    | 3:Birthday       | date_min            | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
+                |    1 |                  | allow_extra_columns | Column(s) not found in CSV: "wrong_column_name"                                                      |
+                |    6 | 0:Name           | length_min          | The length of the value "Carl" is 4, which is less than the expected "5"                             |
+                |   11 | 0:Name           | length_min          | The length of the value "Lois" is 4, which is less than the expected "5"                             |
+                |    1 | 1:City           | ag:is_unique        | Column has non-unique values. Unique: 9, total: 10                                                   |
+                |    2 | 2:Float          | num_max             | The value "4825.185" is greater than the expected "4825.184"                                         |
+                |    1 | 2:Float          | ag:nth_num          | The N-th value in the column is "74", which is not equal than the expected "0.001"                   |
+                |    6 | 3:Birthday       | date_min            | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
                 |      |                  |                     | expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"                                                   |
-                | 8    | 3:Birthday       | date_min            | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
+                |    8 | 3:Birthday       | date_min            | The date of the value "1955-05-14" is parsed as "1955-05-14 00:00:00 +00:00", which is less than the |
                 |      |                  |                     | expected "1955-05-15 00:00:00 +00:00 (1955-05-15)"                                                   |
-                | 9    | 3:Birthday       | date_max            | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", which is greater than  |
+                |    9 | 3:Birthday       | date_max            | The date of the value "2010-07-20" is parsed as "2010-07-20 00:00:00 +00:00", which is greater than  |
                 |      |                  |                     | the expected "2009-01-01 00:00:00 +00:00 (2009-01-01)"                                               |
-                | 5    | 4:Favorite color | allow_values        | Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"]                                |
+                |    5 | 4:Favorite color | allow_values        | Value "blue" is not allowed. Allowed values: ["red", "green", "Blue"]                                |
                 +------+------------------+---------------------+------------------------------------------------------------------------------------------------------+
             
             Summary:

--- a/tests/Commands/ValidateSchemaTest.php
+++ b/tests/Commands/ValidateSchemaTest.php
@@ -55,7 +55,7 @@ final class ValidateSchemaTest extends TestCase
               +------+-----------+---------------+---------------------------------------------------+
               | Line | id:Column | Rule          | Message                                           |
               +------+-----------+---------------+---------------------------------------------------+
-              | 15   |           | schema.syntax | Unable to parse at line 15 (near "(*$#)@(@$*)("). |
+              |   15 |           | schema.syntax | Unable to parse at line 15 (near "(*$#)@(@$*)("). |
               +------+-----------+---------------+---------------------------------------------------+
             
             TXT;
@@ -73,10 +73,10 @@ final class ValidateSchemaTest extends TestCase
         $expected = <<<'TXT'
             CSV Blueprint: Unknown version (PhpUnit)
             Found schemas: 2
-
+            
             (1/2) 1 issue in ./tests/schemas/broken/invalid_schema.yml
               +-------+-----------+--------+----------------------------------+
-              | Line  | id:Column | Rule   | Message                          |
+              |  Line | id:Column | Rule   | Message                          |
               +-------+-----------+--------+----------------------------------+
               | undef | meta      | schema | Unknown key: .unknow_root_option |
               +-------+-----------+--------+----------------------------------+
@@ -84,7 +84,7 @@ final class ValidateSchemaTest extends TestCase
               +------+-----------+---------------+---------------------------------------------------+
               | Line | id:Column | Rule          | Message                                           |
               +------+-----------+---------------+---------------------------------------------------+
-              | 15   |           | schema.syntax | Unable to parse at line 15 (near "(*$#)@(@$*)("). |
+              |   15 |           | schema.syntax | Unable to parse at line 15 (near "(*$#)@(@$*)("). |
               +------+-----------+---------------+---------------------------------------------------+
             
             TXT;

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -232,7 +232,7 @@ final class SchemaTest extends TestCase
         isSame(
             <<<'TABLE'
                 +-------+------------+--------+-------------------------------------------------------------------------+
-                | Line  | id:Column  | Rule   | Message                                                                 |
+                |  Line | id:Column  | Rule   | Message                                                                 |
                 +-------+------------+--------+-------------------------------------------------------------------------+
                 | undef | meta       | schema | Unknown key: .unknow_root_option                                        |
                 | undef | meta       | schema | Unknown key: .csv.unknow_csv_param                                      |


### PR DESCRIPTION
Now all line numbers in tables are padded to the left. This improves readability especially for larger tables with many entries and enhances consistence in data presentation across the different outputs.