### PR TITLE
Add 'is_luhn' - Luhn algorithm validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 <!-- auto-update:/top-badges -->
 
 <!-- auto-update:rules-counter -->
-[![Static Badge](https://img.shields.io/badge/Rules-325-green?label=Total%20number%20of%20rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)
-[![Static Badge](https://img.shields.io/badge/Rules-111-green?label=Cell%20rules&labelColor=blue&color=gray)](src/Rules/Cell)
+[![Static Badge](https://img.shields.io/badge/Rules-326-green?label=Total%20number%20of%20rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)
+[![Static Badge](https://img.shields.io/badge/Rules-112-green?label=Cell%20rules&labelColor=blue&color=gray)](src/Rules/Cell)
 [![Static Badge](https://img.shields.io/badge/Rules-206-green?label=Aggregate%20rules&labelColor=blue&color=gray)](src/Rules/Aggregate)
 [![Static Badge](https://img.shields.io/badge/Rules-8-green?label=Extra%20checks&labelColor=blue&color=gray)](#extra-checks)
-[![Static Badge](https://img.shields.io/badge/Rules-24/54/9-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
+[![Static Badge](https://img.shields.io/badge/Rules-23/54/9-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
 <!-- auto-update:/rules-counter -->
 
 A console utility designed for validating CSV files against a strictly defined schema and validation rules outlined
@@ -521,6 +521,7 @@ columns:
       is_even: true                     # Check if the value is an even number. Example: "2", "4", "6".
       is_odd: true                      # Check if the value is an odd number. Example: "1", "7", "11".
       is_roman: true                    # Validates if the input is a Roman numeral. Example: "I", "IV", "XX".
+      is_luhn: true                     # Luhn algorithm. See https://en.wikipedia.org/wiki/Luhn_algorithm
 
       # Identifications
       phone: ALL                        # Validates if the input is a phone number. Specify the country code to validate the phone number for a specific country. Example: "ALL", "US", "BR".".

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -144,6 +144,7 @@
                 "is_even"                 : true,
                 "is_odd"                  : true,
                 "is_roman"                : true,
+                "is_luhn"                 : true,
 
                 "phone"                   : "ALL",
 

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -164,6 +164,7 @@ This example serves as a comprehensive guide for creating robust CSV file valida
                 'is_even'         => true,
                 'is_odd'          => true,
                 'is_roman'        => true,
+                'is_luhn'         => true,
 
                 'phone' => 'ALL',
 

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -224,6 +224,7 @@ columns:
       is_even: true                     # Check if the value is an even number. Example: "2", "4", "6".
       is_odd: true                      # Check if the value is an odd number. Example: "1", "7", "11".
       is_roman: true                    # Validates if the input is a Roman numeral. Example: "I", "IV", "XX".
+      is_luhn: true                     # Luhn algorithm. See https://en.wikipedia.org/wiki/Luhn_algorithm
 
       # Identifications
       phone: ALL                        # Validates if the input is a phone number. Specify the country code to validate the phone number for a specific country. Example: "ALL", "US", "BR".".

--- a/schema-examples/full_clean.yml
+++ b/schema-examples/full_clean.yml
@@ -172,6 +172,7 @@ columns:
       is_even: true
       is_odd: true
       is_roman: true
+      is_luhn: true
 
       phone: ALL
 

--- a/src/Rules/Cell/IsLuhn.php
+++ b/src/Rules/Cell/IsLuhn.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Rules\Cell;
+
+use Respect\Validation\Validator;
+
+final class IsLuhn extends AbstractCellRule
+{
+    public function getHelpMeta(): array
+    {
+        return [
+            [],
+            [
+                self::DEFAULT => [
+                    'true',
+                    'Luhn algorithm. See https://en.wikipedia.org/wiki/Luhn_algorithm',
+                ],
+            ],
+        ];
+    }
+
+    public function validateRule(string $cellValue): ?string
+    {
+        if ($cellValue === '') {
+            return null;
+        }
+
+        if (!Validator::luhn()->validate($cellValue)) {
+            return "The value \"<c>{$cellValue}</c>\" is not a valid Luhn number.";
+        }
+
+        return null;
+    }
+}

--- a/tests/Rules/Cell/IsLuhnTest.php
+++ b/tests/Rules/Cell/IsLuhnTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Rules\Cell;
+
+use JBZoo\CsvBlueprint\Rules\Cell\IsLuhn;
+use JBZoo\PHPUnit\Rules\TestAbstractCellRule;
+
+use function JBZoo\PHPUnit\isSame;
+
+final class IsLuhnTest extends TestAbstractCellRule
+{
+    protected string $ruleClass = IsLuhn::class;
+
+    public function testPositive(): void
+    {
+        $rule = $this->create(true);
+        isSame(null, $rule->validate(''));
+
+        $valid = [
+            '',
+            '2222400041240011',
+            '340316193809364',
+            '6011000990139424',
+        ];
+
+        foreach ($valid as $value) {
+            isSame('', $rule->test($value), $value);
+        }
+
+        $rule = $this->create(false);
+        isSame(null, $rule->validate(' 1'));
+    }
+
+    public function testNegative(): void
+    {
+        $rule = $this->create(true);
+
+        $invalid = [
+            ';',
+            ' ',
+            '2222400041240021',
+            '222240004124001.1',
+            '2222400041240021',
+            'aBc 123',
+            'aBc-123',
+        ];
+
+        foreach ($invalid as $value) {
+            isSame(
+                "The value \"{$value}\" is not a valid Luhn number.",
+                $rule->test($value),
+                $value,
+            );
+        }
+    }
+}

--- a/tests/schemas/todo.yml
+++ b/tests/schemas/todo.yml
@@ -61,7 +61,6 @@ columns:
       is_hetu: true
       is_imei: true
       is_isbn: true
-      is_luhn: true
       is_nfe_access_key: true
       is_nif: true
       is_nip: true


### PR DESCRIPTION
A new validation rule has been added to the schema for credit card numbers using the Luhn algorithm. This will ensure that only valid credit card numbers pass the validation. This change improves the robustness of the data validation rules.