### PR TITLE
Add 'is_iban' validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 <!-- auto-update:/top-badges -->
 
 <!-- auto-update:rules-counter -->
-[![Static Badge](https://img.shields.io/badge/Rules-326-green?label=Total%20number%20of%20rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)
-[![Static Badge](https://img.shields.io/badge/Rules-112-green?label=Cell%20rules&labelColor=blue&color=gray)](src/Rules/Cell)
+[![Static Badge](https://img.shields.io/badge/Rules-327-green?label=Total%20number%20of%20rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)
+[![Static Badge](https://img.shields.io/badge/Rules-113-green?label=Cell%20rules&labelColor=blue&color=gray)](src/Rules/Cell)
 [![Static Badge](https://img.shields.io/badge/Rules-206-green?label=Aggregate%20rules&labelColor=blue&color=gray)](src/Rules/Aggregate)
 [![Static Badge](https://img.shields.io/badge/Rules-8-green?label=Extra%20checks&labelColor=blue&color=gray)](#extra-checks)
-[![Static Badge](https://img.shields.io/badge/Rules-23/54/9-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
+[![Static Badge](https://img.shields.io/badge/Rules-22/54/9-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
 <!-- auto-update:/rules-counter -->
 
 A console utility designed for validating CSV files against a strictly defined schema and validation rules outlined
@@ -525,6 +525,7 @@ columns:
 
       # Identifications
       phone: ALL                        # Validates if the input is a phone number. Specify the country code to validate the phone number for a specific country. Example: "ALL", "US", "BR".".
+      is_iban: true                     # IBAN - International Bank Account Number. See: https://en.wikipedia.org/wiki/International_Bank_Account_Number
 
       # Misc
       is_version: true                  # Validates the string as version numbers using Semantic Versioning. Example: "1.2.3".

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -147,6 +147,7 @@
                 "is_luhn"                 : true,
 
                 "phone"                   : "ALL",
+                "is_iban"                 : true,
 
                 "is_version"              : true,
                 "is_punct"                : true,

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -167,6 +167,7 @@ This example serves as a comprehensive guide for creating robust CSV file valida
                 'is_luhn'         => true,
 
                 'phone' => 'ALL',
+                'is_iban' => true,
 
                 'is_version'   => true,
                 'is_punct'     => true,

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -166,7 +166,7 @@ This example serves as a comprehensive guide for creating robust CSV file valida
                 'is_roman'        => true,
                 'is_luhn'         => true,
 
-                'phone' => 'ALL',
+                'phone'   => 'ALL',
                 'is_iban' => true,
 
                 'is_version'   => true,

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -228,6 +228,7 @@ columns:
 
       # Identifications
       phone: ALL                        # Validates if the input is a phone number. Specify the country code to validate the phone number for a specific country. Example: "ALL", "US", "BR".".
+      is_iban: true                     # IBAN - International Bank Account Number. See: https://en.wikipedia.org/wiki/International_Bank_Account_Number
 
       # Misc
       is_version: true                  # Validates the string as version numbers using Semantic Versioning. Example: "1.2.3".

--- a/schema-examples/full_clean.yml
+++ b/schema-examples/full_clean.yml
@@ -175,6 +175,7 @@ columns:
       is_luhn: true
 
       phone: ALL
+      is_iban: true
 
       is_version: true
       is_punct: true

--- a/src/Rules/Cell/IsIban.php
+++ b/src/Rules/Cell/IsIban.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Rules\Cell;
+
+use Respect\Validation\Validator;
+
+final class IsIban extends AbstractCellRule
+{
+    public function getHelpMeta(): array
+    {
+        return [
+            [],
+            [
+                self::DEFAULT => [
+                    'true',
+                    'IBAN - International Bank Account Number. ' .
+                    'See: https://en.wikipedia.org/wiki/International_Bank_Account_Number',
+                ],
+            ],
+        ];
+    }
+
+    public function validateRule(string $cellValue): ?string
+    {
+        if ($cellValue === '') {
+            return null;
+        }
+
+        if (!Validator::iban()->validate($cellValue)) {
+            return "The value \"<c>{$cellValue}</c>\" is not a valid IBAN number.";
+        }
+
+        return null;
+    }
+}

--- a/tests/Rules/Cell/IsIbanTest.php
+++ b/tests/Rules/Cell/IsIbanTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Rules\Cell;
+
+use JBZoo\CsvBlueprint\Rules\Cell\IsIban;
+use JBZoo\PHPUnit\Rules\TestAbstractCellRule;
+
+use function JBZoo\PHPUnit\isSame;
+
+final class IsIbanTest extends TestAbstractCellRule
+{
+    protected string $ruleClass = IsIban::class;
+
+    public function testPositive(): void
+    {
+        $rule = $this->create(true);
+        isSame(null, $rule->validate(''));
+
+        $valid = [
+            '',
+            'BE71 0961 2345 6769',                  // 'Belgium'
+            'FR76 3000 6000 0112 3456 7890 189',    // 'France'
+            'DE89 3704 0044 0532 0130 00',          // 'Germany'
+            'GR96 0810 0010 0000 0123 4567 890',    // 'Greece'
+            'RO09 BCYP 0000 0012 3456 7890',        // 'Romania'
+            'SA44 2000 0001 2345 6789 1234',        // 'Saudi Arabia'
+            'ES79 2100 0813 6101 2345 6789',        // 'Spain'
+            'SE35 5000 0000 0549 1000 0003',        // 'Sweden'
+            'CH56 0483 5012 3456 7800 9',           // 'Switzerland'
+            'CH9300762011623852957',                // 'Switzerland without spaces'
+            'GB98 MIDL 0700 9312 3456 78',          // 'United Kingdom'
+        ];
+
+        foreach ($valid as $value) {
+            isSame('', $rule->test($value), $value);
+        }
+
+        $rule = $this->create(false);
+        isSame(null, $rule->validate(' 1'));
+    }
+
+    public function testNegative(): void
+    {
+        $rule = $this->create(true);
+
+        $invalid = [
+            ';',
+            ' ',
+            'ZZ32 5000 5880 7742',
+            '123456789',
+            'aBc 123',
+            'aBc-123',
+        ];
+
+        foreach ($invalid as $value) {
+            isSame(
+                "The value \"{$value}\" is not a valid IBAN number.",
+                $rule->test($value),
+                $value,
+            );
+        }
+    }
+}

--- a/tests/schemas/todo.yml
+++ b/tests/schemas/todo.yml
@@ -69,7 +69,6 @@ columns:
       is_polish_id_card: true
       is_portuguese_nif: true
       is_bic: true
-      is_iban: true
 
       # Strings
       is_hex_rgb_color: true


### PR DESCRIPTION
Added `is_iban` to the validation rules in the schema. This new rule ensures the validation of International Bank Account Numbers (IBAN). This will ensure data consistency and validation accuracy for international transactions.