### PR TITLE
Add BIC validation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 <!-- auto-update:/top-badges -->
 
 <!-- auto-update:rules-counter -->
-[![Static Badge](https://img.shields.io/badge/Rules-327-green?label=Total%20number%20of%20rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)
-[![Static Badge](https://img.shields.io/badge/Rules-113-green?label=Cell%20rules&labelColor=blue&color=gray)](src/Rules/Cell)
+[![Static Badge](https://img.shields.io/badge/Rules-328-green?label=Total%20number%20of%20rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)
+[![Static Badge](https://img.shields.io/badge/Rules-114-green?label=Cell%20rules&labelColor=blue&color=gray)](src/Rules/Cell)
 [![Static Badge](https://img.shields.io/badge/Rules-206-green?label=Aggregate%20rules&labelColor=blue&color=gray)](src/Rules/Aggregate)
 [![Static Badge](https://img.shields.io/badge/Rules-8-green?label=Extra%20checks&labelColor=blue&color=gray)](#extra-checks)
-[![Static Badge](https://img.shields.io/badge/Rules-22/54/9-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
+[![Static Badge](https://img.shields.io/badge/Rules-21/54/9-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
 <!-- auto-update:/rules-counter -->
 
 A console utility designed for validating CSV files against a strictly defined schema and validation rules outlined
@@ -521,11 +521,12 @@ columns:
       is_even: true                     # Check if the value is an even number. Example: "2", "4", "6".
       is_odd: true                      # Check if the value is an odd number. Example: "1", "7", "11".
       is_roman: true                    # Validates if the input is a Roman numeral. Example: "I", "IV", "XX".
-      is_luhn: true                     # Luhn algorithm. See https://en.wikipedia.org/wiki/Luhn_algorithm
+      is_luhn: true                     # Luhn algorithm. See: https://en.wikipedia.org/wiki/Luhn_algorithm
 
       # Identifications
       phone: ALL                        # Validates if the input is a phone number. Specify the country code to validate the phone number for a specific country. Example: "ALL", "US", "BR".".
       is_iban: true                     # IBAN - International Bank Account Number. See: https://en.wikipedia.org/wiki/International_Bank_Account_Number
+      is_bic: true                      # Validates a Bank Identifier Code (BIC) according to ISO 9362 standards. See: https://en.wikipedia.org/wiki/ISO_9362
 
       # Misc
       is_version: true                  # Validates the string as version numbers using Semantic Versioning. Example: "1.2.3".

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -148,6 +148,7 @@
 
                 "phone"                   : "ALL",
                 "is_iban"                 : true,
+                "is_bic"                  : true,
 
                 "is_version"              : true,
                 "is_punct"                : true,

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -168,6 +168,7 @@ This example serves as a comprehensive guide for creating robust CSV file valida
 
                 'phone'   => 'ALL',
                 'is_iban' => true,
+                'is_bic'  => true,
 
                 'is_version'   => true,
                 'is_punct'     => true,

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -224,11 +224,12 @@ columns:
       is_even: true                     # Check if the value is an even number. Example: "2", "4", "6".
       is_odd: true                      # Check if the value is an odd number. Example: "1", "7", "11".
       is_roman: true                    # Validates if the input is a Roman numeral. Example: "I", "IV", "XX".
-      is_luhn: true                     # Luhn algorithm. See https://en.wikipedia.org/wiki/Luhn_algorithm
+      is_luhn: true                     # Luhn algorithm. See: https://en.wikipedia.org/wiki/Luhn_algorithm
 
       # Identifications
       phone: ALL                        # Validates if the input is a phone number. Specify the country code to validate the phone number for a specific country. Example: "ALL", "US", "BR".".
       is_iban: true                     # IBAN - International Bank Account Number. See: https://en.wikipedia.org/wiki/International_Bank_Account_Number
+      is_bic: true                      # Validates a Bank Identifier Code (BIC) according to ISO 9362 standards. See: https://en.wikipedia.org/wiki/ISO_9362
 
       # Misc
       is_version: true                  # Validates the string as version numbers using Semantic Versioning. Example: "1.2.3".

--- a/schema-examples/full_clean.yml
+++ b/schema-examples/full_clean.yml
@@ -176,6 +176,7 @@ columns:
 
       phone: ALL
       is_iban: true
+      is_bic: true
 
       is_version: true
       is_punct: true

--- a/src/Rules/Cell/IsBic.php
+++ b/src/Rules/Cell/IsBic.php
@@ -16,9 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Cell;
 
-use Respect\Validation\Validator;
-
-final class IsLuhn extends AbstractCellRule
+final class IsBic extends AbstractCellRule
 {
     public function getHelpMeta(): array
     {
@@ -27,7 +25,8 @@ final class IsLuhn extends AbstractCellRule
             [
                 self::DEFAULT => [
                     'true',
-                    'Luhn algorithm. See: https://en.wikipedia.org/wiki/Luhn_algorithm',
+                    'Validates a Bank Identifier Code (BIC) according to ISO 9362 standards. ' .
+                    'See: https://en.wikipedia.org/wiki/ISO_9362',
                 ],
             ],
         ];
@@ -39,8 +38,8 @@ final class IsLuhn extends AbstractCellRule
             return null;
         }
 
-        if (!Validator::luhn()->validate($cellValue)) {
-            return "The value \"<c>{$cellValue}</c>\" is not a valid Luhn number.";
+        if (\preg_match('/^[A-Za-z]{4}[A-Za-z]{2}[A-Za-z0-9]{2}([A-Za-z0-9]{3})?$/', $cellValue) === 0) {
+            return "The value \"<c>{$cellValue}</c>\" is not a valid BIC number (ISO 9362).";
         }
 
         return null;

--- a/tests/Rules/Cell/IsBicTest.php
+++ b/tests/Rules/Cell/IsBicTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Rules\Cell;
+
+use JBZoo\CsvBlueprint\Rules\Cell\IsBic;
+use JBZoo\PHPUnit\Rules\TestAbstractCellRule;
+
+use function JBZoo\PHPUnit\isSame;
+
+final class IsBicTest extends TestAbstractCellRule
+{
+    protected string $ruleClass = IsBic::class;
+
+    public function testPositive(): void
+    {
+        $rule = $this->create(true);
+        isSame(null, $rule->validate(''));
+
+        $valid = [
+            '',
+            'DEUTDEFF',        // Deutsche Bank primary office, Frankfurt, Germany
+            'NEDSZAJJXXX',     // Nedbank in Johannesburg, South Africa, with primary office code
+            'BNPAFRPP',        // BNP Paribas primary office, Paris, France
+            'CHASUS33',        // JPMorgan Chase Bank, New York, USA
+            'HSBCGB2L',        // HSBC Bank, London, UK
+            'UNCRIT2B912',     // UniCredit Bank, Milan, Italy, specific branch
+            'DABADKKK',        // Danske Bank, Copenhagen, Denmark
+            'NORDEAHH',        // Nordea, Helsinki, Finland
+            'AIBKIE2D',        // AIB Bank, Dublin, Ireland
+            'CTBAAU2S',        // Commonwealth Bank of Australia, Sydney, Australia
+        ];
+
+        foreach ($valid as $value) {
+            isSame('', $rule->test($value), $value);
+        }
+
+        $rule = $this->create(false);
+        isSame(null, $rule->validate(' 1'));
+    }
+
+    public function testNegative(): void
+    {
+        $rule = $this->create(true);
+
+        $invalid = [
+            ';',
+            ' ',
+            'ZZ32 5000 5880 7742',
+            '123456789',
+            'aBc 123',
+            'aBc-123',
+        ];
+
+        foreach ($invalid as $value) {
+            isSame(
+                "The value \"{$value}\" is not a valid BIC number (ISO 9362).",
+                $rule->test($value),
+                $value,
+            );
+        }
+    }
+}

--- a/tests/schemas/todo.yml
+++ b/tests/schemas/todo.yml
@@ -68,7 +68,6 @@ columns:
       is_pis: true
       is_polish_id_card: true
       is_portuguese_nif: true
-      is_bic: true
 
       # Strings
       is_hex_rgb_color: true


### PR DESCRIPTION
Added the 'is_bic' check to the validation rules. This enhancement ensures validation of Bank Identifier Codes (BIC), enforcing data accuracy for banking codes. Also updated schema examples and unit tests.