### PR TITLE
Add 'is_imei' validation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 <!-- auto-update:/top-badges -->
 
 <!-- auto-update:rules-counter -->
-[![Static Badge](https://img.shields.io/badge/Rules-329-green?label=Total%20number%20of%20rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)
-[![Static Badge](https://img.shields.io/badge/Rules-115-green?label=Cell%20rules&labelColor=blue&color=gray)](src/Rules/Cell)
+[![Static Badge](https://img.shields.io/badge/Rules-330-green?label=Total%20number%20of%20rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)
+[![Static Badge](https://img.shields.io/badge/Rules-116-green?label=Cell%20rules&labelColor=blue&color=gray)](src/Rules/Cell)
 [![Static Badge](https://img.shields.io/badge/Rules-206-green?label=Aggregate%20rules&labelColor=blue&color=gray)](src/Rules/Aggregate)
 [![Static Badge](https://img.shields.io/badge/Rules-8-green?label=Extra%20checks&labelColor=blue&color=gray)](#extra-checks)
-[![Static Badge](https://img.shields.io/badge/Rules-20/54/9-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
+[![Static Badge](https://img.shields.io/badge/Rules-18/54/9-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
 <!-- auto-update:/rules-counter -->
 
 A console utility designed for validating CSV files against a strictly defined schema and validation rules outlined
@@ -528,6 +528,7 @@ columns:
       is_iban: true                     # IBAN - International Bank Account Number. See: https://en.wikipedia.org/wiki/International_Bank_Account_Number
       is_bic: true                      # Validates a Bank Identifier Code (BIC) according to ISO 9362 standards. See: https://en.wikipedia.org/wiki/ISO_9362
       postal_code: US                   # Validate postal code by country code (alpha-2). Example: "02179". Extracted from https://www.geonames.org
+      is_imei: true                     # Validates an International Mobile Equipment Identity (IMEI). See: https://en.wikipedia.org/wiki/International_Mobile_Station_Equipment_Identity
 
       # Misc
       is_version: true                  # Validates the string as version numbers using Semantic Versioning. Example: "1.2.3".

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -150,6 +150,7 @@
                 "is_iban"                 : true,
                 "is_bic"                  : true,
                 "postal_code"             : "US",
+                "is_imei"                 : true,
 
                 "is_version"              : true,
                 "is_punct"                : true,

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -170,6 +170,7 @@ This example serves as a comprehensive guide for creating robust CSV file valida
                 'is_iban'     => true,
                 'is_bic'      => true,
                 'postal_code' => 'US',
+                'is_imei'     => true,
 
                 'is_version'   => true,
                 'is_punct'     => true,

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -231,6 +231,7 @@ columns:
       is_iban: true                     # IBAN - International Bank Account Number. See: https://en.wikipedia.org/wiki/International_Bank_Account_Number
       is_bic: true                      # Validates a Bank Identifier Code (BIC) according to ISO 9362 standards. See: https://en.wikipedia.org/wiki/ISO_9362
       postal_code: US                   # Validate postal code by country code (alpha-2). Example: "02179". Extracted from https://www.geonames.org
+      is_imei: true                     # Validates an International Mobile Equipment Identity (IMEI). See: https://en.wikipedia.org/wiki/International_Mobile_Station_Equipment_Identity
 
       # Misc
       is_version: true                  # Validates the string as version numbers using Semantic Versioning. Example: "1.2.3".

--- a/schema-examples/full_clean.yml
+++ b/schema-examples/full_clean.yml
@@ -178,6 +178,7 @@ columns:
       is_iban: true
       is_bic: true
       postal_code: US
+      is_imei: true
 
       is_version: true
       is_punct: true

--- a/src/Rules/Cell/IsImei.php
+++ b/src/Rules/Cell/IsImei.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Rules\Cell;
+
+use Respect\Validation\Validator;
+
+final class IsImei extends AbstractCellRule
+{
+    public function getHelpMeta(): array
+    {
+        return [
+            [],
+            [
+                self::DEFAULT => [
+                    'true',
+                    'Validates an International Mobile Equipment Identity (IMEI). ' .
+                    'See: https://en.wikipedia.org/wiki/International_Mobile_Station_Equipment_Identity',
+                ],
+            ],
+        ];
+    }
+
+    public function validateRule(string $cellValue): ?string
+    {
+        if ($cellValue === '') {
+            return null;
+        }
+
+        if (!Validator::imei()->validate($cellValue)) {
+            return "Value \"<c>{$cellValue}</c>\" is not a valid IMEI number.";
+        }
+
+        return null;
+    }
+}

--- a/tests/Rules/Cell/IsImeiTest.php
+++ b/tests/Rules/Cell/IsImeiTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Rules\Cell;
+
+use JBZoo\CsvBlueprint\Rules\Cell\IsImei;
+use JBZoo\PHPUnit\Rules\TestAbstractCellRule;
+
+use function JBZoo\PHPUnit\isSame;
+
+final class IsImeiTest extends TestAbstractCellRule
+{
+    protected string $ruleClass = IsImei::class;
+
+    public function testPositive(): void
+    {
+        $rule = $this->create(true);
+        isSame(null, $rule->validate(''));
+
+        $valid = [
+            '',
+            '35-209900-176148-1',
+            '490154203237518',
+            '35-007752-323751-3',
+            '35-209900-176148-1',
+            '350077523237513',
+            '356938035643809',
+            '490154203237518',
+        ];
+
+        foreach ($valid as $value) {
+            isSame('', $rule->test($value), "\"{$value}\"");
+        }
+
+        $rule = $this->create(false);
+        isSame(null, $rule->validate(' 1'));
+    }
+
+    public function testNegative(): void
+    {
+        $rule = $this->create(true);
+
+        $invalid = [
+            ';',
+            '!@#$%^&*()',
+            'aBc 123',
+            'aBc-123',
+            '490154203237512',
+            '4901542032375125',
+        ];
+
+        foreach ($invalid as $value) {
+            isSame(
+                "Value \"{$value}\" is not a valid IMEI number.",
+                $rule->test($value),
+                $value,
+            );
+        }
+    }
+}

--- a/tests/schemas/todo.yml
+++ b/tests/schemas/todo.yml
@@ -42,7 +42,7 @@ columns:
     # Multi prop
     multiple: true
     multiple_separator: "|"           # Separator for multiple values
-    faker: [faker_method arg1 arg2]   # Faker method with arguments
+    faker: [ faker_method arg1 arg2 ]   # Faker method with arguments
 
     rules:
       # https://github.com/Respect/Validation/blob/main/docs/08-list-of-rules-by-category.md
@@ -53,20 +53,19 @@ columns:
       subdivision_code: [ ]           # https://github.com/Respect/Validation/blob/main/docs/rules/SubdivisionCode.md
 
       # ids
-      is_bsn: true
-      is_cnh: true
-      is_cnpj: true
-      is_cpf: true
-      is_hetu: true
-      is_imei: true
-      is_isbn: true
-      is_nfe_access_key: true
-      is_nif: true
-      is_nip: true
-      is_pesel: true
-      is_pis: true
-      is_polish_id_card: true
-      is_portuguese_nif: true
+      is_isbn: true                   # Validates an International Standard Book Number (ISBN).
+
+      is_bsn: true                    # Validates a Dutch citizen service number (BSN).
+      is_cnh: true                    # Validates a Brazilian national health card number (CNH).
+      is_cnpj: true                   # Validates a Brazilian company identifier (CNPJ).
+      is_cpf: true                    # Validates a Brazilian individual taxpayer identifier (CPF).
+      is_nfe_access_key: true         # Validates a Brazilian Nota Fiscal Eletronica (NFe) access key.
+      is_pis: true                    # Validates a Brazilian individual social security number (PIS).
+      is_hetu: true                   # Validates a Finnish personal identity code (HETU).
+      is_nip: true                    # Validates a Polish taxpayer identification number (NIP).
+      is_pesel: true                  # Validates a Polish national identification number (PESEL).
+      is_polish_id_card: true         # Validates a Polish identity card number.
+      is_portuguese_nif: true         # Validates a Portuguese taxpayer number (NIF).
 
       # Strings
       is_hex_rgb_color: true


### PR DESCRIPTION
A new cell validation rule named `is_imei` has been added to check if a value is a valid International Mobile Equipment Identity (IMEI). This rule has been implemented in the schema-examples. Additionally, updated the documentation and "Plan to add" badge in README.md to reflect this new rule.