### PR TITLE
Add 'is_isbn' validation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 <!-- auto-update:/top-badges -->
 
 <!-- auto-update:rules-counter -->
-[![Static Badge](https://img.shields.io/badge/Rules-330-green?label=Total%20number%20of%20rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)
-[![Static Badge](https://img.shields.io/badge/Rules-116-green?label=Cell%20rules&labelColor=blue&color=gray)](src/Rules/Cell)
+[![Static Badge](https://img.shields.io/badge/Rules-331-green?label=Total%20number%20of%20rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)
+[![Static Badge](https://img.shields.io/badge/Rules-117-green?label=Cell%20rules&labelColor=blue&color=gray)](src/Rules/Cell)
 [![Static Badge](https://img.shields.io/badge/Rules-206-green?label=Aggregate%20rules&labelColor=blue&color=gray)](src/Rules/Aggregate)
 [![Static Badge](https://img.shields.io/badge/Rules-8-green?label=Extra%20checks&labelColor=blue&color=gray)](#extra-checks)
-[![Static Badge](https://img.shields.io/badge/Rules-18/54/9-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
+[![Static Badge](https://img.shields.io/badge/Rules-17/54/10-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
 <!-- auto-update:/rules-counter -->
 
 A console utility designed for validating CSV files against a strictly defined schema and validation rules outlined
@@ -529,6 +529,7 @@ columns:
       is_bic: true                      # Validates a Bank Identifier Code (BIC) according to ISO 9362 standards. See: https://en.wikipedia.org/wiki/ISO_9362
       postal_code: US                   # Validate postal code by country code (alpha-2). Example: "02179". Extracted from https://www.geonames.org
       is_imei: true                     # Validates an International Mobile Equipment Identity (IMEI). See: https://en.wikipedia.org/wiki/International_Mobile_Station_Equipment_Identity
+      is_isbn: true                     # Validates an International Standard Book Number (ISBN). See: https://www.isbn-international.org/content/what-isbn
 
       # Misc
       is_version: true                  # Validates the string as version numbers using Semantic Versioning. Example: "1.2.3".

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -151,6 +151,7 @@
                 "is_bic"                  : true,
                 "postal_code"             : "US",
                 "is_imei"                 : true,
+                "is_isbn"                 : true,
 
                 "is_version"              : true,
                 "is_punct"                : true,

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -171,6 +171,7 @@ This example serves as a comprehensive guide for creating robust CSV file valida
                 'is_bic'      => true,
                 'postal_code' => 'US',
                 'is_imei'     => true,
+                'is_isbn'     => true,
 
                 'is_version'   => true,
                 'is_punct'     => true,

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -232,6 +232,7 @@ columns:
       is_bic: true                      # Validates a Bank Identifier Code (BIC) according to ISO 9362 standards. See: https://en.wikipedia.org/wiki/ISO_9362
       postal_code: US                   # Validate postal code by country code (alpha-2). Example: "02179". Extracted from https://www.geonames.org
       is_imei: true                     # Validates an International Mobile Equipment Identity (IMEI). See: https://en.wikipedia.org/wiki/International_Mobile_Station_Equipment_Identity
+      is_isbn: true                     # Validates an International Standard Book Number (ISBN). See: https://www.isbn-international.org/content/what-isbn
 
       # Misc
       is_version: true                  # Validates the string as version numbers using Semantic Versioning. Example: "1.2.3".

--- a/schema-examples/full_clean.yml
+++ b/schema-examples/full_clean.yml
@@ -179,6 +179,7 @@ columns:
       is_bic: true
       postal_code: US
       is_imei: true
+      is_isbn: true
 
       is_version: true
       is_punct: true

--- a/src/Rules/Cell/IsIsbn.php
+++ b/src/Rules/Cell/IsIsbn.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Rules\Cell;
+
+use Respect\Validation\Validator;
+
+final class IsIsbn extends AbstractCellRule
+{
+    public function getHelpMeta(): array
+    {
+        return [
+            [],
+            [
+                self::DEFAULT => [
+                    'true',
+                    'Validates an International Standard Book Number (ISBN). ' .
+                    'See: https://www.isbn-international.org/content/what-isbn',
+                ],
+            ],
+        ];
+    }
+
+    public function validateRule(string $cellValue): ?string
+    {
+        if ($cellValue === '') {
+            return null;
+        }
+
+        if (!Validator::isbn()->validate($cellValue)) {
+            return "Value \"<c>{$cellValue}</c>\" is not a valid ISBN number.";
+        }
+
+        return null;
+    }
+}

--- a/tests/Rules/Cell/IsIsbnTest.php
+++ b/tests/Rules/Cell/IsIsbnTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Rules\Cell;
+
+use JBZoo\CsvBlueprint\Rules\Cell\IsIsbn;
+use JBZoo\PHPUnit\Rules\TestAbstractCellRule;
+
+use function JBZoo\PHPUnit\isSame;
+
+final class IsIsbnTest extends TestAbstractCellRule
+{
+    protected string $ruleClass = IsIsbn::class;
+
+    public function testPositive(): void
+    {
+        $rule = $this->create(true);
+        isSame(null, $rule->validate(''));
+
+        $valid = [
+            '',
+            'ISBN-13: 978-0-596-52068-7',
+            '978 0 596 52068 7',
+            '9780596520687',
+            '0-596-52068-9',
+            '0 512 52068 9',
+            'ISBN-10 0-596-52068-9',
+            'ISBN-10: 0-596-52068-9',
+        ];
+
+        foreach ($valid as $value) {
+            isSame('', $rule->test($value), "\"{$value}\"");
+        }
+
+        $rule = $this->create(false);
+        isSame(null, $rule->validate(' 1'));
+    }
+
+    public function testNegative(): void
+    {
+        $rule = $this->create(true);
+
+        $invalid = [
+            ';',
+            '!@#$%^&*()',
+            'ISBN 11978-0-596-52068-7',
+            'ISBN-12: 978-0-596-52068-7',
+            '978 10 596 52068 7',
+            '119780596520687',
+            '0-5961-52068-9',
+            '11 5122 52068 9',
+            'ISBN-11 0-596-52068-9',
+            'ISBN-10- 0-596-52068-9',
+            'Defiatly no ISBN',
+            'Neither ISBN-13: 978-0-596-52068-7',
+        ];
+
+        foreach ($invalid as $value) {
+            isSame(
+                "Value \"{$value}\" is not a valid ISBN number.",
+                $rule->test($value),
+                $value,
+            );
+        }
+    }
+}

--- a/tests/schemas/todo.yml
+++ b/tests/schemas/todo.yml
@@ -30,6 +30,7 @@ structural_rules:
   columns_count: 5                    # Exact number of columns in the file. By default, it is equal to the number of columns in the schema.
   columns_count_max: 5                # Minimum number of columns in the file. By default, it is equal to the number of columns in the schema.
   ignore_duplicate_rows: false        # If true, then duplicate rows will be ignored. Duplicate rows are rows that have the same values in all columns - 100% match.
+  ends_with_newline: false            # If true, then the file must end with a newline character (\n).
 
 
 columns:
@@ -53,8 +54,6 @@ columns:
       subdivision_code: [ ]           # https://github.com/Respect/Validation/blob/main/docs/rules/SubdivisionCode.md
 
       # ids
-      is_isbn: true                   # Validates an International Standard Book Number (ISBN).
-
       is_bsn: true                    # Validates a Dutch citizen service number (BSN).
       is_cnh: true                    # Validates a Brazilian national health card number (CNH).
       is_cnpj: true                   # Validates a Brazilian company identifier (CNPJ).


### PR DESCRIPTION
Introduced a new cell validation rule named `is_isbn` to validate if a value is a valid International Standard Book Number (ISBN). The rule has been added to the schema-examples and implemented in a new class file. The README.md file and relevant test files have been updated to reflect this change.