### PR TITLE
Add `--apply-global` option for CSV validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ You can find launch examples in the [workflow demo](https://github.com/JBZoo/Csv
     # Required: true
     report: 'table'
 
+    # Apply global schemas (without `filename_pattern`) to all CSV files found.
+    # Default value: 'no'
+    # Required: true
+    apply-global: 'no'
+
     # Quick mode. It will not validate all rows. It will stop after the first error.
     # Default value: 'no'
     # Required: true
@@ -1430,49 +1435,50 @@ Usage:
   validate:csv [options]
 
 Options:
-  -c, --csv=CSV                    Specify the path(s) to the CSV files you want to validate.
-                                   This can include a direct path to a file or a directory to search with a maximum depth of 10 levels.
-                                   Examples: /full/path/name.csv; p/file.csv; p/*.csv; p/**/*.csv; p/**/name-*.csv; **/*.csv
-                                    (multiple values allowed)
-  -s, --schema=SCHEMA              Specify the path(s) to the schema file(s), supporting YAML, JSON, or PHP formats.
-                                   Similar to CSV paths, you can direct to specific files or search directories with glob patterns.
-                                   Examples: /full/path/name.yml; p/file.yml; p/*.yml; p/**/*.yml; p/**/name-*.yml; **/*.yml
-                                    (multiple values allowed)
-  -S, --skip-schema[=SKIP-SCHEMA]  Skips schema validation for quicker checks when the schema's correctness is certain.
-                                   Use any non-empty value or "yes" to activate
-                                    [default: "no"]
-  -r, --report=REPORT              Determines the report's output format.
-                                   Available options: text, table, github, gitlab, teamcity, junit
-                                    [default: "table"]
-  -Q, --quick[=QUICK]              Stops the validation process upon encountering the first error,
-                                   accelerating the check but limiting error visibility.
-                                   Returns a non-zero exit code if any error is detected.
-                                   Enable by setting to any non-empty value or "yes".
-                                    [default: "no"]
-      --dump-schema                Dumps the schema of the CSV file if you want to see the final schema after inheritance.
-      --debug                      Intended solely for debugging and advanced profiling purposes.
-                                   Activating this option provides detailed process insights,
-                                   useful for troubleshooting and performance analysis.
-      --no-progress                Disable progress bar animation for logs. It will be used only for text output format.
-      --mute-errors                Mute any sort of errors. So exit code will be always "0" (if it's possible).
-                                   It has major priority then --non-zero-on-error. It's on your own risk!
-      --stdout-only                For any errors messages application will use StdOut instead of StdErr. It's on your own risk!
-      --non-zero-on-error          None-zero exit code on any StdErr message.
-      --timestamp                  Show timestamp at the beginning of each message.It will be used only for text output format.
-      --profile                    Display timing and memory usage information.
-      --output-mode=OUTPUT-MODE    Output format. Available options:
-                                   text - Default text output format, userfriendly and easy to read.
-                                   cron - Shortcut for crontab. It's basically focused on human-readable logs output.
-                                   It's combination of --timestamp --profile --stdout-only --no-progress -vv.
-                                   logstash - Logstash output format, for integration with ELK stack.
-                                    [default: "text"]
-      --cron                       Alias for --output-mode=cron. Deprecated!
-  -h, --help                       Display help for the given command. When no command is given display help for the list command
-  -q, --quiet                      Do not output any message
-  -V, --version                    Display this application version
-      --ansi|--no-ansi             Force (or disable --no-ansi) ANSI output
-  -n, --no-interaction             Do not ask any interactive question
-  -v|vv|vvv, --verbose             Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+  -c, --csv=CSV                      Specify the path(s) to the CSV files you want to validate.
+                                     This can include a direct path to a file or a directory to search with a maximum depth of 10 levels.
+                                     Examples: /full/path/name.csv; p/file.csv; p/*.csv; p/**/*.csv; p/**/name-*.csv; **/*.csv
+                                      (multiple values allowed)
+  -s, --schema=SCHEMA                Specify the path(s) to the schema file(s), supporting YAML, JSON, or PHP formats.
+                                     Similar to CSV paths, you can direct to specific files or search directories with glob patterns.
+                                     Examples: /full/path/name.yml; p/file.yml; p/*.yml; p/**/*.yml; p/**/name-*.yml; **/*.yml
+                                      (multiple values allowed)
+  -S, --skip-schema[=SKIP-SCHEMA]    Skips schema validation for quicker checks when the schema's correctness is certain.
+                                     Use any non-empty value or "yes" to activate
+                                      [default: "no"]
+  -G, --apply-global[=APPLY-GLOBAL]  Apply global schemas (without `filename_pattern`) to all CSV files found. [default: "no"]
+  -r, --report=REPORT                Determines the report's output format.
+                                     Available options: text, table, github, gitlab, teamcity, junit
+                                      [default: "table"]
+  -Q, --quick[=QUICK]                Stops the validation process upon encountering the first error,
+                                     accelerating the check but limiting error visibility.
+                                     Returns a non-zero exit code if any error is detected.
+                                     Enable by setting to any non-empty value or "yes".
+                                      [default: "no"]
+      --dump-schema                  Dumps the schema of the CSV file if you want to see the final schema after inheritance.
+      --debug                        Intended solely for debugging and advanced profiling purposes.
+                                     Activating this option provides detailed process insights,
+                                     useful for troubleshooting and performance analysis.
+      --no-progress                  Disable progress bar animation for logs. It will be used only for text output format.
+      --mute-errors                  Mute any sort of errors. So exit code will be always "0" (if it's possible).
+                                     It has major priority then --non-zero-on-error. It's on your own risk!
+      --stdout-only                  For any errors messages application will use StdOut instead of StdErr. It's on your own risk!
+      --non-zero-on-error            None-zero exit code on any StdErr message.
+      --timestamp                    Show timestamp at the beginning of each message.It will be used only for text output format.
+      --profile                      Display timing and memory usage information.
+      --output-mode=OUTPUT-MODE      Output format. Available options:
+                                     text - Default text output format, userfriendly and easy to read.
+                                     cron - Shortcut for crontab. It's basically focused on human-readable logs output.
+                                     It's combination of --timestamp --profile --stdout-only --no-progress -vv.
+                                     logstash - Logstash output format, for integration with ELK stack.
+                                      [default: "text"]
+      --cron                         Alias for --output-mode=cron. Deprecated!
+  -h, --help                         Display help for the given command. When no command is given display help for the list command
+  -q, --quiet                        Do not output any message
+  -V, --version                      Display this application version
+      --ansi|--no-ansi               Force (or disable --no-ansi) ANSI output
+  -n, --no-interaction               Do not ask any interactive question
+  -v|vv|vvv, --verbose               Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 ```
 <!-- auto-update:/validate-csv-help -->
 
@@ -1873,7 +1879,6 @@ It's random ideas and plans. No promises and deadlines. Feel free to [help me!](
 
 * **Batch processing**
     * If option `--csv` is not specified, then the STDIN is used. To build a pipeline in Unix-like systems.
-    * Flag to ignore file name pattern. It's useful when you have a lot of files, and you don't want to validate the file name.
 
 * **Validation**
     * Multi `filename_pattern`. Support list of regexs.
@@ -1914,11 +1919,11 @@ It's random ideas and plans. No promises and deadlines. Feel free to [help me!](
     * Warnings about deprecated options and features.
     * Add option `--recomendation` to show a list of recommended rules for the schema or potential issues in the CSV file or schema. It's useful when you are not sure what rules to use.
     * Add option `--error=[level]` to show only errors with a specific level. It's useful when you have a lot of warnings and you want to see only errors.
-    * S3 Storage support. Validate files in the S3 bucket? Hmm... Why not? But...
     * More examples and documentation.
 
 PS. [There is a file](tests/schemas/todo.yml) with my ideas and imagination. It's not valid schema file, just a draft.
 I'm not sure if I will implement all of them. But I will try to do my best.
+
 </details>
 
 ## Contributing

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: 'Report format. Available options: text, table, github, gitlab, teamcity, junit.'
     default: table
     required: true
+  apply-global:
+    description: 'Apply global schemas (without `filename_pattern`) to all CSV files found.'
+    default: no
+    required: true
   quick:
     description: 'Quick mode. It will not validate all rows. It will stop after the first error.'
     default: no
@@ -67,6 +71,8 @@ runs:
     - ${{ inputs.schema }}
     - '--report'
     - ${{ inputs.report }}
+    - '--apply-global'
+    - ${{ inputs.apply-global }}
     - '--quick'
     - ${{ inputs.quick }}
     - '--skip-schema'

--- a/src/Commands/ValidateCsv.php
+++ b/src/Commands/ValidateCsv.php
@@ -83,6 +83,13 @@ final class ValidateCsv extends AbstractValidate
                     '',
                 ]),
                 'no',
+            )
+            ->addOption(
+                'apply-global',
+                'G',
+                InputOption::VALUE_OPTIONAL,
+                'Apply global schemas (without `filename_pattern`) to all CSV files found.',
+                'no',
             );
 
         parent::configure();
@@ -94,7 +101,7 @@ final class ValidateCsv extends AbstractValidate
 
         $csvFilenames = $this->findFiles('csv', false);
         $schemaFilenames = $this->findFiles('schema', false);
-        $matchedFiles = Utils::matchSchemaAndCsvFiles($csvFilenames, $schemaFilenames);
+        $matchedFiles = Utils::matchSchemaAndCsvFiles($csvFilenames, $schemaFilenames, $this->isApplyGlobal());
 
         $this->printHeaderInfo($csvFilenames, $schemaFilenames, $matchedFiles);
 
@@ -110,6 +117,12 @@ final class ValidateCsv extends AbstractValidate
             $errorInSchemaCounter,
             $matchedFiles,
         );
+    }
+
+    protected function isApplyGlobal(): bool
+    {
+        $value = $this->getOptString('apply-global');
+        return $value === '' || bool($value);
     }
 
     private function isCheckingSchema(): bool

--- a/tests/Commands/ValidateCsvBasicTest.php
+++ b/tests/Commands/ValidateCsvBasicTest.php
@@ -250,8 +250,9 @@ final class ValidateCsvBasicTest extends TestCase
     public function testValidateOneCsvNoHeaderNegative(): void
     {
         [$actual, $exitCode] = Tools::virtualExecution('validate:csv', [
-            'csv'    => Tools::DEMO_CSV,
-            'schema' => './tests/schemas/simple_no_header.yml',
+            'csv'          => Tools::DEMO_CSV,
+            'schema'       => './tests/schemas/simple_no_header.yml',
+            'apply-global' => 'yes',
         ]);
 
         $expected = <<<'TXT'

--- a/tests/Commands/ValidateCsvBatchSchemaTest.php
+++ b/tests/Commands/ValidateCsvBatchSchemaTest.php
@@ -103,14 +103,49 @@ final class ValidateCsvBatchSchemaTest extends TestCase
         isSame($expected, $actual);
     }
 
-    public function testNoPattern(): void
+    public function testNoPatternNoApplyGlobal(): void
     {
         $optionsAsString = Tools::arrayToOptionString([
             'csv'    => './tests/fixtures/demo.csv',
-            'schema' => [
-                Tools::DEMO_YML_VALID,
-                './tests/schemas/demo_invalid_no_pattern.yml',
-            ],
+            'schema' => [Tools::DEMO_YML_VALID, './tests/schemas/demo_invalid_no_pattern.yml'],
+        ]);
+
+        [$actual, $exitCode] = Tools::virtualExecution('validate:csv', $optionsAsString);
+
+        $expected = <<<'TXT'
+            CSV Blueprint: Unknown version (PhpUnit)
+            Found Schemas   : 2
+            Found CSV files : 1
+            Pairs by pattern: 1
+            
+            Check schema syntax: 2
+              (1/2) OK ./tests/schemas/demo_invalid_no_pattern.yml
+              (2/2) OK ./tests/schemas/demo_valid.yml
+            
+            CSV file validation: 1
+            Schema: ./tests/schemas/demo_valid.yml
+              OK ./tests/fixtures/demo.csv; Size: 123.34 MB
+            
+            Summary:
+              1 pairs (schema to csv) were found based on `filename_pattern`.
+              No issues in 2 schemas.
+              No issues in 1 CSV files.
+              Not used schemas:
+                * ./tests/schemas/demo_invalid_no_pattern.yml
+            
+            
+            TXT;
+
+        isSame(1, $exitCode, $actual);
+        isSame($expected, $actual);
+    }
+
+    public function testNoPatternApplyGlobal(): void
+    {
+        $optionsAsString = Tools::arrayToOptionString([
+            'csv'          => './tests/fixtures/demo.csv',
+            'schema'       => [Tools::DEMO_YML_VALID, './tests/schemas/demo_invalid_no_pattern.yml'],
+            'apply-global' => 'yes',
         ]);
 
         [$actual, $exitCode] = Tools::virtualExecution('validate:csv', $optionsAsString);

--- a/tests/GithubActionsTest.php
+++ b/tests/GithubActionsTest.php
@@ -49,12 +49,13 @@ final class GithubActionsTest extends TestCase
     {
         $inputs = yml(PROJECT_ROOT . '/action.yml')->findArray('inputs');
         $examples = [
-            'csv'         => './tests/**/*.csv',
-            'schema'      => './tests/**/*.yml',
-            'report'      => "'" . ErrorSuite::REPORT_DEFAULT . "'",
-            'quick'       => "'no'",
-            'skip-schema' => "'no'",
-            'extra'       => "'options: --ansi'",
+            'csv'          => './tests/**/*.csv',
+            'schema'       => './tests/**/*.yml',
+            'report'       => "'" . ErrorSuite::REPORT_DEFAULT . "'",
+            'apply-global' => "'no'",
+            'quick'        => "'no'",
+            'skip-schema'  => "'no'",
+            'extra'        => "'options: --ansi'",
         ];
 
         $expectedMessage = [


### PR DESCRIPTION
This update introduces a new 'apply-global' option in the CSV validation command. This flag allows global schemas, those without a 'filename_pattern', to be applied to all CSV files being analyzed. This addition increases flexibility and efficiency in the file validation process.