### PR TITLE
Rename `apply-global` option to `apply-all`

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,10 @@ You can find launch examples in the [workflow demo](https://github.com/JBZoo/Csv
     # Required: true
     report: 'table'
 
-    # Apply global schemas (without `filename_pattern`) to all CSV files found.
+    # Apply all schemas (also without `filename_pattern`) to all CSV files found.
     # Default value: 'no'
     # Required: true
-    apply-global: 'no'
+    apply-all: 'no'
 
     # Quick mode. It will not validate all rows. It will stop after the first error.
     # Default value: 'no'
@@ -1435,50 +1435,50 @@ Usage:
   validate:csv [options]
 
 Options:
-  -c, --csv=CSV                      Specify the path(s) to the CSV files you want to validate.
-                                     This can include a direct path to a file or a directory to search with a maximum depth of 10 levels.
-                                     Examples: /full/path/name.csv; p/file.csv; p/*.csv; p/**/*.csv; p/**/name-*.csv; **/*.csv
-                                      (multiple values allowed)
-  -s, --schema=SCHEMA                Specify the path(s) to the schema file(s), supporting YAML, JSON, or PHP formats.
-                                     Similar to CSV paths, you can direct to specific files or search directories with glob patterns.
-                                     Examples: /full/path/name.yml; p/file.yml; p/*.yml; p/**/*.yml; p/**/name-*.yml; **/*.yml
-                                      (multiple values allowed)
-  -S, --skip-schema[=SKIP-SCHEMA]    Skips schema validation for quicker checks when the schema's correctness is certain.
-                                     Use any non-empty value or "yes" to activate
-                                      [default: "no"]
-  -G, --apply-global[=APPLY-GLOBAL]  Apply global schemas (without `filename_pattern`) to all CSV files found. [default: "no"]
-  -r, --report=REPORT                Determines the report's output format.
-                                     Available options: text, table, github, gitlab, teamcity, junit
-                                      [default: "table"]
-  -Q, --quick[=QUICK]                Stops the validation process upon encountering the first error,
-                                     accelerating the check but limiting error visibility.
-                                     Returns a non-zero exit code if any error is detected.
-                                     Enable by setting to any non-empty value or "yes".
-                                      [default: "no"]
-      --dump-schema                  Dumps the schema of the CSV file if you want to see the final schema after inheritance.
-      --debug                        Intended solely for debugging and advanced profiling purposes.
-                                     Activating this option provides detailed process insights,
-                                     useful for troubleshooting and performance analysis.
-      --no-progress                  Disable progress bar animation for logs. It will be used only for text output format.
-      --mute-errors                  Mute any sort of errors. So exit code will be always "0" (if it's possible).
-                                     It has major priority then --non-zero-on-error. It's on your own risk!
-      --stdout-only                  For any errors messages application will use StdOut instead of StdErr. It's on your own risk!
-      --non-zero-on-error            None-zero exit code on any StdErr message.
-      --timestamp                    Show timestamp at the beginning of each message.It will be used only for text output format.
-      --profile                      Display timing and memory usage information.
-      --output-mode=OUTPUT-MODE      Output format. Available options:
-                                     text - Default text output format, userfriendly and easy to read.
-                                     cron - Shortcut for crontab. It's basically focused on human-readable logs output.
-                                     It's combination of --timestamp --profile --stdout-only --no-progress -vv.
-                                     logstash - Logstash output format, for integration with ELK stack.
-                                      [default: "text"]
-      --cron                         Alias for --output-mode=cron. Deprecated!
-  -h, --help                         Display help for the given command. When no command is given display help for the list command
-  -q, --quiet                        Do not output any message
-  -V, --version                      Display this application version
-      --ansi|--no-ansi               Force (or disable --no-ansi) ANSI output
-  -n, --no-interaction               Do not ask any interactive question
-  -v|vv|vvv, --verbose               Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+  -c, --csv=CSV                    Specify the path(s) to the CSV files you want to validate.
+                                   This can include a direct path to a file or a directory to search with a maximum depth of 10 levels.
+                                   Examples: /full/path/name.csv; p/file.csv; p/*.csv; p/**/*.csv; p/**/name-*.csv; **/*.csv
+                                    (multiple values allowed)
+  -s, --schema=SCHEMA              Specify the path(s) to the schema file(s), supporting YAML, JSON, or PHP formats.
+                                   Similar to CSV paths, you can direct to specific files or search directories with glob patterns.
+                                   Examples: /full/path/name.yml; p/file.yml; p/*.yml; p/**/*.yml; p/**/name-*.yml; **/*.yml
+                                    (multiple values allowed)
+  -S, --skip-schema[=SKIP-SCHEMA]  Skips schema validation for quicker checks when the schema's correctness is certain.
+                                   Use any non-empty value or "yes" to activate
+                                    [default: "no"]
+  -a, --apply-all[=APPLY-ALL]      Apply global schemas (also without `filename_pattern`) to all CSV files found. [default: "no"]
+  -r, --report=REPORT              Determines the report's output format.
+                                   Available options: text, table, github, gitlab, teamcity, junit
+                                    [default: "table"]
+  -Q, --quick[=QUICK]              Stops the validation process upon encountering the first error,
+                                   accelerating the check but limiting error visibility.
+                                   Returns a non-zero exit code if any error is detected.
+                                   Enable by setting to any non-empty value or "yes".
+                                    [default: "no"]
+      --dump-schema                Dumps the schema of the CSV file if you want to see the final schema after inheritance.
+      --debug                      Intended solely for debugging and advanced profiling purposes.
+                                   Activating this option provides detailed process insights,
+                                   useful for troubleshooting and performance analysis.
+      --no-progress                Disable progress bar animation for logs. It will be used only for text output format.
+      --mute-errors                Mute any sort of errors. So exit code will be always "0" (if it's possible).
+                                   It has major priority then --non-zero-on-error. It's on your own risk!
+      --stdout-only                For any errors messages application will use StdOut instead of StdErr. It's on your own risk!
+      --non-zero-on-error          None-zero exit code on any StdErr message.
+      --timestamp                  Show timestamp at the beginning of each message.It will be used only for text output format.
+      --profile                    Display timing and memory usage information.
+      --output-mode=OUTPUT-MODE    Output format. Available options:
+                                   text - Default text output format, userfriendly and easy to read.
+                                   cron - Shortcut for crontab. It's basically focused on human-readable logs output.
+                                   It's combination of --timestamp --profile --stdout-only --no-progress -vv.
+                                   logstash - Logstash output format, for integration with ELK stack.
+                                    [default: "text"]
+      --cron                       Alias for --output-mode=cron. Deprecated!
+  -h, --help                       Display help for the given command. When no command is given display help for the list command
+  -q, --quiet                      Do not output any message
+  -V, --version                    Display this application version
+      --ansi|--no-ansi             Force (or disable --no-ansi) ANSI output
+  -n, --no-interaction             Do not ask any interactive question
+  -v|vv|vvv, --verbose             Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 ```
 <!-- auto-update:/validate-csv-help -->
 

--- a/action.yml
+++ b/action.yml
@@ -35,8 +35,8 @@ inputs:
     description: 'Report format. Available options: text, table, github, gitlab, teamcity, junit.'
     default: table
     required: true
-  apply-global:
-    description: 'Apply global schemas (without `filename_pattern`) to all CSV files found.'
+  apply-all:
+    description: 'Apply all schemas (also without `filename_pattern`) to all CSV files found.'
     default: no
     required: true
   quick:
@@ -71,8 +71,8 @@ runs:
     - ${{ inputs.schema }}
     - '--report'
     - ${{ inputs.report }}
-    - '--apply-global'
-    - ${{ inputs.apply-global }}
+    - '--apply-all'
+    - ${{ inputs.apply-all }}
     - '--quick'
     - ${{ inputs.quick }}
     - '--skip-schema'

--- a/src/Commands/ValidateCsv.php
+++ b/src/Commands/ValidateCsv.php
@@ -85,10 +85,10 @@ final class ValidateCsv extends AbstractValidate
                 'no',
             )
             ->addOption(
-                'apply-global',
-                'G',
+                'apply-all',
+                'a',
                 InputOption::VALUE_OPTIONAL,
-                'Apply global schemas (without `filename_pattern`) to all CSV files found.',
+                'Apply global schemas (also without `filename_pattern`) to all CSV files found.',
                 'no',
             );
 
@@ -121,7 +121,7 @@ final class ValidateCsv extends AbstractValidate
 
     protected function isApplyGlobal(): bool
     {
-        $value = $this->getOptString('apply-global');
+        $value = $this->getOptString('apply-all');
         return $value === '' || bool($value);
     }
 

--- a/tests/Commands/ValidateCsvBasicTest.php
+++ b/tests/Commands/ValidateCsvBasicTest.php
@@ -250,9 +250,9 @@ final class ValidateCsvBasicTest extends TestCase
     public function testValidateOneCsvNoHeaderNegative(): void
     {
         [$actual, $exitCode] = Tools::virtualExecution('validate:csv', [
-            'csv'          => Tools::DEMO_CSV,
-            'schema'       => './tests/schemas/simple_no_header.yml',
-            'apply-global' => 'yes',
+            'csv'       => Tools::DEMO_CSV,
+            'schema'    => './tests/schemas/simple_no_header.yml',
+            'apply-all' => 'yes',
         ]);
 
         $expected = <<<'TXT'

--- a/tests/Commands/ValidateCsvBatchSchemaTest.php
+++ b/tests/Commands/ValidateCsvBatchSchemaTest.php
@@ -143,9 +143,9 @@ final class ValidateCsvBatchSchemaTest extends TestCase
     public function testNoPatternApplyGlobal(): void
     {
         $optionsAsString = Tools::arrayToOptionString([
-            'csv'          => './tests/fixtures/demo.csv',
-            'schema'       => [Tools::DEMO_YML_VALID, './tests/schemas/demo_invalid_no_pattern.yml'],
-            'apply-global' => 'yes',
+            'csv'       => './tests/fixtures/demo.csv',
+            'schema'    => [Tools::DEMO_YML_VALID, './tests/schemas/demo_invalid_no_pattern.yml'],
+            'apply-all' => 'yes',
         ]);
 
         [$actual, $exitCode] = Tools::virtualExecution('validate:csv', $optionsAsString);

--- a/tests/GithubActionsTest.php
+++ b/tests/GithubActionsTest.php
@@ -49,13 +49,13 @@ final class GithubActionsTest extends TestCase
     {
         $inputs = yml(PROJECT_ROOT . '/action.yml')->findArray('inputs');
         $examples = [
-            'csv'          => './tests/**/*.csv',
-            'schema'       => './tests/**/*.yml',
-            'report'       => "'" . ErrorSuite::REPORT_DEFAULT . "'",
-            'apply-global' => "'no'",
-            'quick'        => "'no'",
-            'skip-schema'  => "'no'",
-            'extra'        => "'options: --ansi'",
+            'csv'         => './tests/**/*.csv',
+            'schema'      => './tests/**/*.yml',
+            'report'      => "'" . ErrorSuite::REPORT_DEFAULT . "'",
+            'apply-all'   => "'no'",
+            'quick'       => "'no'",
+            'skip-schema' => "'no'",
+            'extra'       => "'options: --ansi'",
         ];
 
         $expectedMessage = [


### PR DESCRIPTION
Renamed the `apply-global` command option to `apply-all` in CSV validation, and adjusted all related usage within the documentation, test, and action files. This change aims to improve clarity and simplicity of command usage.