### PR TITLE
Remove condition in validation check for CSV files

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,13 @@ You can find launch examples in the [workflow demo](https://github.com/JBZoo/Csv
   with:
     # Specify the path(s) to the CSV files you want to validate.
     #   This can include a direct path to a file or a directory to search with a maximum depth of 10 levels.
-    #   Examples: /full/path/name.csv; p/file.csv; p/*.csv; p/**/*.csv; p/**/name-*.csv; **/*.csv
+    #   Examples: p/file.csv; p/*.csv; p/**/*.csv; p/**/name-*.csv; **/*.csv
     # Required: true
     csv: './tests/**/*.csv'
 
     # Specify the path(s) to the schema file(s), supporting YAML, JSON, or PHP formats.
     #   Similar to CSV paths, you can direct to specific files or search directories with glob patterns.
-    #   Examples: /full/path/name.yml; p/file.yml; p/*.yml; p/**/*.yml; p/**/name-*.yml; **/*.yml
+    #   Examples: p/file.yml; p/*.yml; p/**/*.yml; p/**/name-*.yml; **/*.yml
     # Required: true
     schema: './tests/**/*.yml'
 
@@ -976,6 +976,7 @@ In fact, this can be considered as partial inheritance.
  - You can make the chain of inheritance infinitely long.
    I.e. make chains of the form `grant-parent.yml` -> `parent.yml` -> `child.yml` -> `grandchild.yml` -> etc.
    Of course if you like to take risks ;).
+ - But be careful with circular dependencies. The tool will not be able to handle them, and it can be an infinite loop.
  - Any(!) of the schema files can be used alone or as a library. The syntax is the same.
  - Schemas with presets validate themselves and if there are any obvious issues, you will see them when you try to use
    the schema. But logical conflicts between rules are not checked (It's almost impossible from a code perspective).
@@ -1441,11 +1442,11 @@ Usage:
 Options:
   -c, --csv=CSV                    Specify the path(s) to the CSV files you want to validate.
                                    This can include a direct path to a file or a directory to search with a maximum depth of 10 levels.
-                                   Examples: /full/path/name.csv; p/file.csv; p/*.csv; p/**/*.csv; p/**/name-*.csv; **/*.csv
+                                   Examples: p/file.csv; p/*.csv; p/**/*.csv; p/**/name-*.csv; **/*.csv
                                     (multiple values allowed)
   -s, --schema=SCHEMA              Specify the path(s) to the schema file(s), supporting YAML, JSON, or PHP formats.
                                    Similar to CSV paths, you can direct to specific files or search directories with glob patterns.
-                                   Examples: /full/path/name.yml; p/file.yml; p/*.yml; p/**/*.yml; p/**/name-*.yml; **/*.yml
+                                   Examples: p/file.yml; p/*.yml; p/**/*.yml; p/**/name-*.yml; **/*.yml
                                     (multiple values allowed)
   -S, --skip-schema[=SKIP-SCHEMA]  Skips schema validation for quicker checks when the schema's correctness is certain.
                                    Use any non-empty value or "yes" to activate

--- a/action.yml
+++ b/action.yml
@@ -23,13 +23,13 @@ inputs:
     description: |
       Specify the path(s) to the CSV files you want to validate.
         This can include a direct path to a file or a directory to search with a maximum depth of 10 levels.
-        Examples: /full/path/name.csv; p/file.csv; p/*.csv; p/**/*.csv; p/**/name-*.csv; **/*.csv
+        Examples: p/file.csv; p/*.csv; p/**/*.csv; p/**/name-*.csv; **/*.csv
     required: true
   schema:
     description: |
       Specify the path(s) to the schema file(s), supporting YAML, JSON, or PHP formats.
         Similar to CSV paths, you can direct to specific files or search directories with glob patterns.
-        Examples: /full/path/name.yml; p/file.yml; p/*.yml; p/**/*.yml; p/**/name-*.yml; **/*.yml
+        Examples: p/file.yml; p/*.yml; p/**/*.yml; p/**/name-*.yml; **/*.yml
     required: true
   report:
     description: 'Report format. Available options: text, table, github, gitlab, teamcity, junit.'

--- a/src/Commands/ValidateCsv.php
+++ b/src/Commands/ValidateCsv.php
@@ -45,7 +45,6 @@ final class ValidateCsv extends AbstractValidate
                     'This can include a direct path to a file or a directory to search with a maximum depth of ' .
                     Utils::MAX_DIRECTORY_DEPTH . ' levels.',
                     'Examples: <info>' . \implode('</info>; <info>', [
-                        '/full/path/name.csv',
                         'p/file.csv',
                         'p/*.csv',
                         'p/**/*.csv',
@@ -63,7 +62,6 @@ final class ValidateCsv extends AbstractValidate
                     'Specify the path(s) to the schema file(s), supporting YAML, JSON, or PHP formats. ',
                     'Similar to CSV paths, you can direct to specific files or search directories with glob patterns.',
                     'Examples: <info>' . \implode('</info>; <info>', [
-                        '/full/path/name.yml',
                         'p/file.yml',
                         'p/*.yml',
                         'p/**/*.yml',
@@ -245,7 +243,6 @@ final class ValidateCsv extends AbstractValidate
             $totalSchemaFiles === 0
             || $errorInCsvCounter > 0
             || $errorInSchemaCounter > 0
-            || \count($matchedFiles['schema_without_csv']) > 0
             || \count($matchedFiles['csv_without_schema']) > 0
         ) {
             $exitCode = self::FAILURE;

--- a/tests/Commands/ValidateCsvApplyAllTest.php
+++ b/tests/Commands/ValidateCsvApplyAllTest.php
@@ -55,11 +55,12 @@ final class ValidateCsvApplyAllTest extends TestCase
               No issues in 1 CSV files.
               Not used schemas:
                 * ./tests/schemas/demo_invalid_no_pattern.yml
+              Looks good!
             
             
             TXT;
 
-        isSame(1, $exitCode, $actual);
+        isSame(0, $exitCode, $actual);
         isSame($expected, $actual);
     }
 

--- a/tests/Commands/ValidateCsvBasicTest.php
+++ b/tests/Commands/ValidateCsvBasicTest.php
@@ -151,8 +151,6 @@ final class ValidateCsvBasicTest extends TestCase
         isSame($expected, $actual);
     }
 
-    // ###################################################################################################################
-
     public function testInvalidSchemaNotMatched(): void
     {
         $options = [
@@ -315,6 +313,46 @@ final class ValidateCsvBasicTest extends TestCase
             TXT;
 
         isSame(1, $exitCode, $actual);
+        isSame($expected, $actual);
+    }
+
+    public function testNoSchemaWasAppliedToCsv(): void
+    {
+        $optionsAsString = Tools::arrayToOptionString([
+            'csv'    => './tests/fixtures/demo.csv',
+            'schema' => [
+                './tests/schemas/preset/child-of-child.yml',
+                './tests/schemas/demo_valid.yml',
+            ],
+        ]);
+        [$actual, $exitCode] = Tools::virtualExecution('validate:csv', $optionsAsString);
+
+        $expected = <<<'TXT'
+            CSV Blueprint: Unknown version (PhpUnit)
+            Found Schemas   : 2
+            Found CSV files : 1
+            Pairs by pattern: 1
+            
+            Check schema syntax: 2
+              (1/2) OK ./tests/schemas/demo_valid.yml
+              (2/2) OK ./tests/schemas/preset/child-of-child.yml
+            
+            CSV file validation: 1
+            Schema: ./tests/schemas/demo_valid.yml
+              OK ./tests/fixtures/demo.csv; Size: 123.34 MB
+            
+            Summary:
+              1 pairs (schema to csv) were found based on `filename_pattern`.
+              No issues in 2 schemas.
+              No issues in 1 CSV files.
+              Not used schemas:
+                * ./tests/schemas/preset/child-of-child.yml
+              Looks good!
+            
+            
+            TXT;
+
+        isSame(0, $exitCode, $actual);
         isSame($expected, $actual);
     }
 }


### PR DESCRIPTION
The commit removes a condition that checked for schema files without corresponding CSV files in the ValidateCsv script. This decision could mean that having schema files without CSVs is now acceptable in the business logic.