### PR TITLE
Missed PHP setup step in benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -39,6 +39,11 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch || github.ref }}
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+
       # We need it to build benchmark tool. See ./tests/Benchmarks
       - name: Build project
         run: make build --no-print-directory
@@ -77,6 +82,11 @@ jobs:
 #        with:
 #          fetch-depth: 0
 #          ref: ${{ github.event.inputs.branch || github.ref }}
+#
+#      - name: Setup PHP
+#        uses: shivammathur/setup-php@v2
+#        with:
+#          php-version: 8.3
 #
 #      - name: Setup PHP
 #        uses: shivammathur/setup-php@v2


### PR DESCRIPTION
Integration of step to setup PHP version 8.3 in the benchmark workflow process has been added. This setup step ensures correct PHP version is used before running benchmarks. This modification has been implemented in both active and commented sections of the GitHub workflow.