### PR TITLE
Remove redundant properties from sonar-project configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![CI](https://github.com/JBZoo/Csv-Blueprint/actions/workflows/demo.yml/badge.svg)](https://github.com/JBZoo/Csv-Blueprint/actions/workflows/demo.yml)
 [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Csv-Blueprint/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Csv-Blueprint?branch=master)
 [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Csv-Blueprint/coverage.svg)](https://shepherd.dev/github/JBZoo/Csv-Blueprint)
-[![GitHub Release](https://img.shields.io/github/v/release/jbzoo/csv-blueprint?label=Latest)](https://github.com/jbzoo/csv-blueprint/releases)
-[![Total Downloads](https://poser.pugx.org/jbzoo/csv-blueprint/downloads)](https://packagist.org/packages/jbzoo/csv-blueprint/stats)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=JBZoo_Csv-Blueprint&metric=alert_status)](https://sonarcloud.io/summary/overall?id=JBZoo_Csv-Blueprint)
 [![Docker Pulls](https://img.shields.io/docker/pulls/jbzoo/csv-blueprint.svg)](https://hub.docker.com/r/jbzoo/csv-blueprint/tags)
+[![GitHub Release](https://img.shields.io/github/v/release/jbzoo/csv-blueprint?label=Latest)](https://github.com/jbzoo/csv-blueprint/releases)
 <!-- auto-update:/top-badges -->
 
 <!-- auto-update:rules-counter -->

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,4 +2,6 @@ sonar.projectKey=JBZoo_Csv-Blueprint
 sonar.organization=jbzoo
 sonar.projectName=CSV Blueprint
 
+sonar.tests=tests
+
 sonar.php.coverage.reportPaths=build/coverage_xml/main.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,4 @@ sonar.projectKey=JBZoo_Csv-Blueprint
 sonar.organization=jbzoo
 sonar.projectName=CSV Blueprint
 
-sonar.sources=src
-sonar.tests=tests
-
 sonar.php.coverage.reportPaths=build/coverage_xml/main.xml

--- a/tests/PackageTest.php
+++ b/tests/PackageTest.php
@@ -60,6 +60,7 @@ final class PackageTest extends \JBZoo\Codestyle\PHPUnit\AbstractPackageTest
         'sonarcloud'     => true,
         'coveralls'      => true,
         'circle_ci'      => true,
+        'sonar_qube'     => true,
     ];
 
     protected array $badgesTemplate = [
@@ -67,9 +68,10 @@ final class PackageTest extends \JBZoo\Codestyle\PHPUnit\AbstractPackageTest
         'github_actions_demo',
         'coveralls',
         'psalm_coverage',
-        'github_latest_release',
-        'packagist_downloads_total',
+        'sonar_qube',
+        //'packagist_downloads_total',
         'docker_pulls',
+        'github_latest_release',
     ];
 
     protected function setUp(): void
@@ -171,6 +173,17 @@ final class PackageTest extends \JBZoo\Codestyle\PHPUnit\AbstractPackageTest
                 'GitHub Release',
                 'https://img.shields.io/github/v/release/jbzoo/csv-blueprint?label=Latest',
                 'https://github.com/__VENDOR__/__PACKAGE__/releases',
+            ),
+        );
+    }
+
+    protected function checkBadgeSonarQube(): ?string
+    {
+        return $this->getPreparedBadge(
+            $this->getBadge(
+                'Quality Gate Status',
+                'https://sonarcloud.io/api/project_badges/measure?project=JBZoo_Csv-Blueprint&metric=alert_status',
+                'https://sonarcloud.io/summary/overall?id=JBZoo_Csv-Blueprint',
             ),
         );
     }

--- a/tests/PackageTest.php
+++ b/tests/PackageTest.php
@@ -69,7 +69,7 @@ final class PackageTest extends \JBZoo\Codestyle\PHPUnit\AbstractPackageTest
         'coveralls',
         'psalm_coverage',
         'sonar_qube',
-        //'packagist_downloads_total',
+        // 'packagist_downloads_total',
         'docker_pulls',
         'github_latest_release',
     ];


### PR DESCRIPTION
The commit removes superfluous properties from 'sonar-project.properties'. The dimensions 'sonar.sources' and 'sonar.tests' were deleted to improve the configuration management of the project, focusing on the essential parameters only. New configuration should streamline the project configuration and management process.