### PR TITLE
Replace \ErrorException with Exception and specify Alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 # @see        https://github.com/JBZoo/Csv-Blueprint
 #
 
-FROM alpine:latest as preparatory
+FROM alpine:3.9 AS preparatory
 RUN apk add --no-cache make git
 WORKDIR /tmp
 COPY . /tmp

--- a/csv-blueprint.php
+++ b/csv-blueprint.php
@@ -37,9 +37,6 @@ $_SERVER['argc'] = \count($_SERVER['argv']);
     throw new Exception($message, 0, $severity, $file, $line);
 });
 
-$cliApp = (new CliApplication('CSV Blueprint', Utils::getVersion(true)));
-$cliApp->setVersion(Utils::getVersion(false));
-
-$cliApp
+(new CliApplication('CSV Blueprint', Utils::getVersion(true)))
     ->registerCommandsByPath(PATH_ROOT . '/src/Commands', __NAMESPACE__)
     ->run();

--- a/csv-blueprint.php
+++ b/csv-blueprint.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint;
 
-if ('cli' !== \PHP_SAPI) {
-    throw new \RuntimeException('This script must be run from the command line.');
-}
-
 \define('PATH_ROOT', __DIR__);
 require_once __DIR__ . '/vendor/autoload.php';
+
+if ('cli' !== \PHP_SAPI) {
+    throw new Exception('This script must be run from the command line.');
+}
 
 // Fix for GitHub actions. See action.yml
 $_SERVER['argv'] = Utils::fixArgv($_SERVER['argv'] ?? []);
@@ -34,7 +34,7 @@ $_SERVER['argc'] = \count($_SERVER['argv']);
 // We have to do it becase tool uses 3rd-party libraries, and we can't trust them.
 // So, we need to catch all errors and handle them.
 \set_error_handler(static function ($severity, $message, $file, $line): void {
-    throw new \ErrorException($message, 0, $severity, $file, $line);
+    throw new Exception($message, 0, $severity, $file, $line);
 });
 
 $cliApp = (new CliApplication('CSV Blueprint', Utils::getVersion(true)));


### PR DESCRIPTION
The \ErrorException instances in `csv-blueprint.php` script have been replaced with standard Exception to simplify error handling. Additionally, the Dockerfile has been updated to pull from Alpine version 3.9 specifically, ensuring a more predictable build environment.