### PR TITLE
Fix code smells in SonarQube

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![CI](https://github.com/JBZoo/Csv-Blueprint/actions/workflows/demo.yml/badge.svg)](https://github.com/JBZoo/Csv-Blueprint/actions/workflows/demo.yml)
 [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Csv-Blueprint/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Csv-Blueprint?branch=master)
 [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Csv-Blueprint/coverage.svg)](https://shepherd.dev/github/JBZoo/Csv-Blueprint)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=JBZoo_Csv-Blueprint&metric=alert_status)](https://sonarcloud.io/summary/overall?id=JBZoo_Csv-Blueprint)
+[![Sonar - Bugs](https://sonarcloud.io/api/project_badges/measure?project=JBZoo_Csv-Blueprint&metric=bugs)](https://sonarcloud.io/summary/overall?id=JBZoo_Csv-Blueprint)
+[![Sonar - Code smells](https://sonarcloud.io/api/project_badges/measure?project=JBZoo_Csv-Blueprint&metric=code_smells)](https://sonarcloud.io/summary/overall?id=JBZoo_Csv-Blueprint)
 [![Docker Pulls](https://img.shields.io/docker/pulls/jbzoo/csv-blueprint.svg)](https://hub.docker.com/r/jbzoo/csv-blueprint/tags)
-[![GitHub Release](https://img.shields.io/github/v/release/jbzoo/csv-blueprint?label=Latest)](https://github.com/jbzoo/csv-blueprint/releases)
 <!-- auto-update:/top-badges -->
 
 <!-- auto-update:rules-counter -->

--- a/docker/build-preloader.php
+++ b/docker/build-preloader.php
@@ -20,7 +20,8 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 (new PreloadBuilder(enableOpcacheCompiler: false))
     ->setExcludes([
-        '/app/csv-blueprint',
+        \dirname(__DIR__) . '/csv-blueprint',
+        \dirname(__DIR__) . '/csv-blueprint.php',
     ])
     ->setFiles(
         \file_exists(__DIR__ . '/included_files.php')

--- a/docker/build-preloader.php
+++ b/docker/build-preloader.php
@@ -14,38 +14,18 @@
 
 declare(strict_types=1);
 
-$files = include_once __DIR__ . '/included_files.php';
+use JBZoo\CsvBlueprint\Tools\PreloadBuilder;
 
-$header = <<<'TEXT'
-    <?php
-    
-    // if (!\function_exists('opcache_compile_file') ||
-    //     !\ini_get('opcache.enable') ||
-    //     !\ini_get('opcache.enable_cli')
-    // ) {
-    //     echo 'Opcache is not available.';
-    //     die(1);
-    // }
-    
-    TEXT;
+require_once __DIR__ . '/../vendor/autoload.php';
 
-$result = [$header];
-
-$excludes = [
-    '/app/csv-blueprint',
-    '/app/csv-blueprint.php',
-];
-
-foreach ($files as $path) {
-    foreach ($excludes as $exclude) {
-        if ($path === $exclude) {
-            continue 2;
-        }
-    }
-
-    // $result[] = "\\opcache_compile_file('{$path}');";
-    $result[] = "require_once '{$path}';";
-}
-
-echo 'Included classes:' . (\count($result) - 1) . \PHP_EOL;
-\file_put_contents(__DIR__ . '/preload.php', \implode(\PHP_EOL, $result) . \PHP_EOL);
+(new PreloadBuilder(isCompiler: true))
+    ->setExcludes([
+        '/app/csv-blueprint',
+        '/app/csv-blueprint.php',
+    ])
+    ->setFiles(
+        \file_exists(__DIR__ . '/included_files.php')
+            ? include_once __DIR__ . '/included_files.php'
+            : \array_values(include_once __DIR__ . '/../vendor/composer/autoload_classmap.php'),
+    )
+    ->saveToFile(__DIR__ . '/preload.php', true);

--- a/docker/build-preloader.php
+++ b/docker/build-preloader.php
@@ -21,7 +21,6 @@ require_once __DIR__ . '/../vendor/autoload.php';
 (new PreloadBuilder(enableOpcacheCompiler: false))
     ->setExcludes([
         '/app/csv-blueprint',
-        '/app/csv-blueprint.php',
     ])
     ->setFiles(
         \file_exists(__DIR__ . '/included_files.php')

--- a/docker/build-preloader.php
+++ b/docker/build-preloader.php
@@ -18,7 +18,7 @@ use JBZoo\CsvBlueprint\Tools\PreloadBuilder;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-(new PreloadBuilder(isCompiler: true))
+(new PreloadBuilder(enableOpcacheCompiler: false))
     ->setExcludes([
         '/app/csv-blueprint',
         '/app/csv-blueprint.php',

--- a/docker/random-csv.php
+++ b/docker/random-csv.php
@@ -14,39 +14,15 @@
 
 declare(strict_types=1);
 
-final class CsvGenerator
-{
-    public function __construct(
-        private int $rows,
-        private string $filePath,
-        private array $columns,
-    ) {
-    }
+use JBZoo\CsvBlueprint\Tools\RandomCsvGenerator;
+use JBZoo\Utils\Cli;
 
-    public function generateCsv(): void
-    {
-        $fileHandle = \fopen($this->filePath, 'w');
+require_once __DIR__ . '/../vendor/autoload.php';
 
-        \fputcsv($fileHandle, $this->columns);
-
-        for ($i = 0; $i < $this->rows; $i++) {
-            $rowData = [];
-
-            foreach (\array_keys($this->columns) as $columnIndex) {
-                $rowData[$columnIndex] = \random_int(1, 10000);
-            }
-
-            \fputcsv($fileHandle, $rowData);
-        }
-
-        \fclose($fileHandle);
-
-        echo "CSV file created: {$this->filePath}.\n";
-    }
-}
-
-(new CsvGenerator(
+(new RandomCsvGenerator(
     1000,
     __DIR__ . '/random_data.csv',
     ['Column Name (header)', 'another_column', 'inherited_column_login', 'inherited_column_full_name'],
 ))->generateCsv();
+
+Cli::out('Random CSV file with 1000 lines created: ' . __DIR__ . '/random_data.csv');

--- a/src/Rules/Cell/ComboPasswordStrength.php
+++ b/src/Rules/Cell/ComboPasswordStrength.php
@@ -49,12 +49,12 @@ final class ComboPasswordStrength extends AbstractCellRuleCombo
         $score += \min(5, \strlen($password) / 2);
 
         // Uppercase letters: +1 point if at least one
-        if (\preg_match('/[A-Z]/', $password) !== 0) {
+        if (\preg_match('/[A-Z]/', $password) !== 0) { // NOSONAR
             $score++;
         }
 
         // Lowercase letters: +1 point if at least one
-        if (\preg_match('/[a-z]/', $password) !== 0) {
+        if (\preg_match('/[a-z]/', $password) !== 0) { // NOSONAR
             $score++;
         }
 
@@ -64,7 +64,7 @@ final class ComboPasswordStrength extends AbstractCellRuleCombo
         }
 
         // Special characters: +1 point if at least one
-        if (\preg_match('/[^a-zA-Z0-9]/', $password) !== 0) {
+        if (\preg_match('/[^a-zA-Z0-9]/', $password) !== 0) { // NOSONAR
             $score++;
         }
 

--- a/src/Tools/Exception.php
+++ b/src/Tools/Exception.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Tools;
+
+class Exception extends \RuntimeException
+{
+}

--- a/src/Tools/PreloadBuilder.php
+++ b/src/Tools/PreloadBuilder.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Tools;
+
+use JBZoo\Utils\Cli;
+
+final class PreloadBuilder
+{
+    private array $files = [];
+    private array $excludes = [];
+
+    public function __construct(
+        private bool $isCompiler = false,
+    ) {
+    }
+
+    public function saveToFile(string $filename, bool $showInfo = false): void
+    {
+        $classes = $this->buildClassList();
+        $lines = $this->buildHeader() + $classes;
+
+        \file_put_contents($filename, \implode(\PHP_EOL, $lines) . \PHP_EOL);
+
+        if ($showInfo) {
+            Cli::out('Included classes: ' . \count($classes));
+        }
+    }
+
+    public function setExcludes(array $excludes): self
+    {
+        $this->excludes = $excludes;
+        return $this;
+    }
+
+    public function setFiles(array $files): self
+    {
+        $this->files = $files;
+        return $this;
+    }
+
+    private function buildClassList(): array
+    {
+        $classes = [];
+
+        foreach ($this->files as $path) {
+            if ($this->isExcluded($path)) {
+                continue;
+            }
+
+            $classes[] = $this->isCompiler
+                ? "\\opcache_compile_file('{$path}');"
+                : "require_once '{$path}';";
+        }
+
+        return $classes;
+    }
+
+    private function isExcluded(string $path): bool
+    {
+        return \in_array($path, $this->excludes, true);
+    }
+
+    private function buildHeader(): array
+    {
+        $header = [
+            '<?php declare(strict_types=1);',
+            '',
+        ];
+
+        if ($this->isCompiler) {
+            $header = \array_merge($header, [
+                "if (!\\function_exists('opcache_compile_file') ||",
+                "    !\\ini_get('opcache.enable') ||",
+                "    !\\ini_get('opcache.enable_cli')",
+                ') {',
+                "    echo 'Opcache is not available.';",
+                '    die(1);',
+                '}',
+                '',
+            ]);
+        }
+
+        return $header;
+    }
+}

--- a/src/Tools/PreloadBuilder.php
+++ b/src/Tools/PreloadBuilder.php
@@ -69,7 +69,7 @@ final class PreloadBuilder
                 : "require_once '{$path}';";
         }
 
-        return $files;
+        return \array_unique($files);
     }
 
     private function isExcluded(string $path): bool

--- a/src/Tools/PreloadBuilder.php
+++ b/src/Tools/PreloadBuilder.php
@@ -24,7 +24,7 @@ final class PreloadBuilder
     private array $excludes = [];
 
     public function __construct(
-        private bool $isCompiler = false,
+        private bool $enableOpcacheCompiler = false,
     ) {
     }
 
@@ -61,7 +61,7 @@ final class PreloadBuilder
                 continue;
             }
 
-            $classes[] = $this->isCompiler
+            $classes[] = $this->enableOpcacheCompiler
                 ? "\\opcache_compile_file('{$path}');"
                 : "require_once '{$path}';";
         }
@@ -81,7 +81,7 @@ final class PreloadBuilder
             '',
         ];
 
-        if ($this->isCompiler) {
+        if ($this->enableOpcacheCompiler) {
             $header = \array_merge($header, [
                 "if (!\\function_exists('opcache_compile_file') ||",
                 "    !\\ini_get('opcache.enable') ||",

--- a/src/Tools/PreloadBuilder.php
+++ b/src/Tools/PreloadBuilder.php
@@ -30,13 +30,13 @@ final class PreloadBuilder
 
     public function saveToFile(string $filename, bool $showInfo = false): void
     {
-        $classes = $this->buildClassList();
-        $lines = $this->buildHeader() + $classes;
+        $files = $this->buildFilelist();
+        $lines = \array_merge($this->buildHeader(), $files);
 
         \file_put_contents($filename, \implode(\PHP_EOL, $lines) . \PHP_EOL);
 
         if ($showInfo) {
-            Cli::out('Included classes: ' . \count($classes));
+            Cli::out('Included files: ' . \count($files));
         }
     }
 
@@ -52,21 +52,24 @@ final class PreloadBuilder
         return $this;
     }
 
-    private function buildClassList(): array
+    private function buildFilelist(): array
     {
-        $classes = [];
+        $files = [];
+        $fillList = \array_merge([
+            \dirname(__DIR__, 2) . '/vendor/autoload.php',
+        ], $this->files);
 
-        foreach ($this->files as $path) {
+        foreach ($fillList as $path) {
             if ($this->isExcluded($path)) {
                 continue;
             }
 
-            $classes[] = $this->enableOpcacheCompiler
+            $files[] = $this->enableOpcacheCompiler
                 ? "\\opcache_compile_file('{$path}');"
                 : "require_once '{$path}';";
         }
 
-        return $classes;
+        return $files;
     }
 
     private function isExcluded(string $path): bool

--- a/src/Tools/RandomCsvGenerator.php
+++ b/src/Tools/RandomCsvGenerator.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Tools;
+
+final class RandomCsvGenerator
+{
+    private const MIN = 1;
+    private const MAX = 10_000;
+
+    public function __construct(
+        private int $rows,
+        private string $filePath,
+        private array $columns,
+    ) {
+    }
+
+    public function generateCsv(): void
+    {
+        $fileHandle = \fopen($this->filePath, 'w');
+        if ($fileHandle === false) {
+            throw new Exception("Can't open file: {$this->filePath}");
+        }
+
+        \fputcsv($fileHandle, $this->columns);
+
+        for ($i = 0; $i < $this->rows; $i++) {
+            $rowData = [];
+
+            foreach (\array_keys($this->columns) as $columnIndex) {
+                $rowData[$columnIndex] = \random_int(self::MIN, self::MAX);
+            }
+
+            \fputcsv($fileHandle, $rowData);
+        }
+
+        \fclose($fileHandle);
+    }
+}

--- a/tests/PackageTest.php
+++ b/tests/PackageTest.php
@@ -60,7 +60,9 @@ final class PackageTest extends \JBZoo\Codestyle\PHPUnit\AbstractPackageTest
         'sonarcloud'     => true,
         'coveralls'      => true,
         'circle_ci'      => true,
-        'sonar_qube'     => true,
+
+        'sonar_qube_bugs'   => true,
+        'sonar_qube_smells' => true,
     ];
 
     protected array $badgesTemplate = [
@@ -68,10 +70,9 @@ final class PackageTest extends \JBZoo\Codestyle\PHPUnit\AbstractPackageTest
         'github_actions_demo',
         'coveralls',
         'psalm_coverage',
-        'sonar_qube',
-        // 'packagist_downloads_total',
+        'sonar_qube_bugs',
+        'sonar_qube_smells',
         'docker_pulls',
-        'github_latest_release',
     ];
 
     protected function setUp(): void
@@ -177,12 +178,23 @@ final class PackageTest extends \JBZoo\Codestyle\PHPUnit\AbstractPackageTest
         );
     }
 
-    protected function checkBadgeSonarQube(): ?string
+    protected function checkBadgeSonarQubeBugs(): ?string
     {
         return $this->getPreparedBadge(
             $this->getBadge(
-                'Quality Gate Status',
-                'https://sonarcloud.io/api/project_badges/measure?project=JBZoo_Csv-Blueprint&metric=alert_status',
+                'Sonar - Bugs',
+                'https://sonarcloud.io/api/project_badges/measure?project=JBZoo_Csv-Blueprint&metric=bugs',
+                'https://sonarcloud.io/summary/overall?id=JBZoo_Csv-Blueprint',
+            ),
+        );
+    }
+
+    protected function checkBadgeSonarQubeSmells(): ?string
+    {
+        return $this->getPreparedBadge(
+            $this->getBadge(
+                'Sonar - Code smells',
+                'https://sonarcloud.io/api/project_badges/measure?project=JBZoo_Csv-Blueprint&metric=code_smells',
                 'https://sonarcloud.io/summary/overall?id=JBZoo_Csv-Blueprint',
             ),
         );

--- a/tests/Tools/PreloadBuilderTest.php
+++ b/tests/Tools/PreloadBuilderTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Tools;
+
+use JBZoo\CsvBlueprint\Tools\PreloadBuilder;
+use JBZoo\PHPUnit\TestCase;
+
+use function JBZoo\PHPUnit\isNotContain;
+
+class PreloadBuilderTest extends TestCase
+{
+    public function testPreloader(): void
+    {
+        (new PreloadBuilder(isCompiler: false))
+            ->setExcludes([
+                __FILE__,
+            ])
+            ->setFiles(\get_included_files())
+            ->saveToFile(PROJECT_BUILD . '/preload.php');
+
+        self::assertFileExists(PROJECT_BUILD . '/preload.php');
+
+        $content = \file_get_contents(PROJECT_BUILD . '/preload.php');
+        isNotContain(__FILE__, $content);
+    }
+}

--- a/tests/Tools/PreloadBuilderTest.php
+++ b/tests/Tools/PreloadBuilderTest.php
@@ -38,6 +38,7 @@ class PreloadBuilderTest extends TestCase
         $content = \file_get_contents(PROJECT_BUILD . '/preload.php');
         isNotContain(__FILE__, $content);
         isContain('PreloadBuilder.php', $content);
+        isContain('vendor/autoload.php', $content);
 
         isNotContain('function_exists', $content);
         isNotContain('opcache_compile_file', $content);
@@ -58,6 +59,7 @@ class PreloadBuilderTest extends TestCase
         $content = \file_get_contents(PROJECT_BUILD . '/preload.php');
         isNotContain(__FILE__, $content);
         isContain('PreloadBuilder.php', $content);
+        isContain('vendor/autoload.php', $content);
 
         isContain('function_exists', $content);
         isContain('opcache_compile_file', $content);

--- a/tests/Tools/PreloadBuilderTest.php
+++ b/tests/Tools/PreloadBuilderTest.php
@@ -19,11 +19,12 @@ namespace JBZoo\PHPUnit\Tools;
 use JBZoo\CsvBlueprint\Tools\PreloadBuilder;
 use JBZoo\PHPUnit\TestCase;
 
+use function JBZoo\PHPUnit\isContain;
 use function JBZoo\PHPUnit\isNotContain;
 
 class PreloadBuilderTest extends TestCase
 {
-    public function testPreloader(): void
+    public function testPreloaderWithoutCompiling(): void
     {
         (new PreloadBuilder(enableOpcacheCompiler: false))
             ->setExcludes([
@@ -36,5 +37,30 @@ class PreloadBuilderTest extends TestCase
 
         $content = \file_get_contents(PROJECT_BUILD . '/preload.php');
         isNotContain(__FILE__, $content);
+        isContain('PreloadBuilder.php', $content);
+
+        isNotContain('function_exists', $content);
+        isNotContain('opcache_compile_file', $content);
+        isContain('require_once', $content);
+    }
+
+    public function testPreloaderWithCompiling(): void
+    {
+        (new PreloadBuilder(enableOpcacheCompiler: true))
+            ->setExcludes([
+                __FILE__,
+            ])
+            ->setFiles(\get_included_files())
+            ->saveToFile(PROJECT_BUILD . '/preload.php');
+
+        self::assertFileExists(PROJECT_BUILD . '/preload.php');
+
+        $content = \file_get_contents(PROJECT_BUILD . '/preload.php');
+        isNotContain(__FILE__, $content);
+        isContain('PreloadBuilder.php', $content);
+
+        isContain('function_exists', $content);
+        isContain('opcache_compile_file', $content);
+        isNotContain('require_once', $content);
     }
 }

--- a/tests/Tools/PreloadBuilderTest.php
+++ b/tests/Tools/PreloadBuilderTest.php
@@ -25,7 +25,7 @@ class PreloadBuilderTest extends TestCase
 {
     public function testPreloader(): void
     {
-        (new PreloadBuilder(isCompiler: false))
+        (new PreloadBuilder(enableOpcacheCompiler: false))
             ->setExcludes([
                 __FILE__,
             ])

--- a/tests/Tools/RandomCsvGeneratorTest.php
+++ b/tests/Tools/RandomCsvGeneratorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Tools;
+
+use JBZoo\CsvBlueprint\Tools\RandomCsvGenerator;
+use JBZoo\PHPUnit\TestCase;
+
+class RandomCsvGeneratorTest extends TestCase
+{
+    public function testGenerator(): void
+    {
+        $outputFile = PROJECT_BUILD . '/random_data.csv';
+        (new RandomCsvGenerator(
+            10,
+            $outputFile,
+            ['col 1', 'col 2', 'col 3', 'col 4'],
+        ))->generateCsv();
+
+        self::assertFileExists($outputFile);
+
+        $content = \file_get_contents($outputFile);
+        self::assertStringContainsString("\"col 1\",\"col 2\",\"col 3\",\"col 4\"\n", $content);
+    }
+}


### PR DESCRIPTION
The PHP scripts (`build-preloader.php` and `random-csv.php`) used in Docker have been refactored to use new CSV tool classes instead of self-contained solutions. New `PreloadBuilder` and `RandomCsvGenerator` classes are introduced for better reusability and tests for these new classes have been added. Also, minor adjustments on SonarQube regex checks and the project readme were made.