### PR TITLE
Adjust static calls in multiple rules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,13 +78,6 @@ jobs:
       - name: 👍 Code Quality
         run: make codestyle --no-print-directory
 
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
-        continue-on-error: true
-        with:
-          name: Tests - Current
-          path: build/
-
 
   test-lowest-versions:
     name: Tests - Lowest
@@ -117,13 +110,6 @@ jobs:
       - name: 👍 Code Quality
         run: make codestyle --no-print-directory
 
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
-        continue-on-error: true
-        with:
-          name: Tests - Lowest
-          path: build/
-
 
   test-latest-libs:
     name: Tests - Latest
@@ -155,13 +141,6 @@ jobs:
 
       - name: 👍 Code Quality
         run: make codestyle --no-print-directory
-
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
-        continue-on-error: true
-        with:
-          name: Tests - Latest
-          path: build/
 
 
   verify-php-binary:

--- a/src/Rules/Aggregate/AbstractAggregateRuleCombo.php
+++ b/src/Rules/Aggregate/AbstractAggregateRuleCombo.php
@@ -77,7 +77,7 @@ abstract class AbstractAggregateRuleCombo extends AbstarctRuleCombo
             return "<red>{$exception->getMessage()}</red>"; // TODO: Expose the error/warning message in the report?
         }
 
-        if (!self::compare($expected, $actual, $mode)) {
+        if (!static::compare($expected, $actual, $mode)) {
             return "The {$name} in the column is \"<c>{$actual}</c>\", " .
                 "which is {$verb} than the {$prefix}expected \"<green>{$expected}</green>\"";
         }

--- a/src/Rules/Cell/AbstractCellRuleCombo.php
+++ b/src/Rules/Cell/AbstractCellRuleCombo.php
@@ -49,7 +49,7 @@ abstract class AbstractCellRuleCombo extends AbstarctRuleCombo
             return null;
         }
 
-        if (!self::compare($this->getExpected(), $this->getActual($cellValue), $mode)) {
+        if (!static::compare($this->getExpected(), $this->getActual($cellValue), $mode)) {
             return $this->getErrorMessage($cellValue, $mode);
         }
 

--- a/src/Rules/Cell/IsBic.php
+++ b/src/Rules/Cell/IsBic.php
@@ -38,7 +38,7 @@ final class IsBic extends AbstractCellRule
             return null;
         }
 
-        if (\preg_match('/^[A-Za-z]{4}[A-Za-z]{2}[A-Za-z0-9]{2}([A-Za-z0-9]{3})?$/', $cellValue) === 0) {
+        if (\preg_match('/^[a-z]{4}[a-z]{2}[a-z0-9]{2}([a-z0-9]{3})?$/i', $cellValue) === 0) { // NOSONAR
             return "The value \"<c>{$cellValue}</c>\" is not a valid BIC number (ISO 9362).";
         }
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -99,7 +99,7 @@ final class Utils
 
     public static function camelToKebabCase(string $input): string
     {
-        return \strtolower((string)\preg_replace('/(?<!^)[A-Z]/', '_$0', $input));
+        return \strtolower((string)\preg_replace('/(?<!^)[A-Z]/', '_$0', $input)); // NOSONAR
     }
 
     public static function prepareRegex(?string $pattern, string $addDelimiter = '/'): ?string


### PR DESCRIPTION
This commit removes the redundant artifact upload step from the GitHub Actions workflow as it was unnecessary for the process. Also, the self::compare() calls have been replaced with static::compare() in AbstractAggregateRuleCombo, AbstractCellRuleCombo, and the pattern for BIC number verification in IsBic rule has been updated for better matching. Changes also include commenting on the NOSONAR issue where applicable.