### PR TITLE
Remove Coveralls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,17 +62,10 @@ jobs:
       - name: 🧪 PHPUnit Tests
         run: make test --no-print-directory
 
-      - name: Uploading coverage to coveralls
-        continue-on-error: true
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: make report-coveralls --no-print-directory || true
-
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: 👍 Code Quality

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 <!-- auto-update:top-badges -->
 [![CI](https://github.com/JBZoo/Csv-Blueprint/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Csv-Blueprint/actions/workflows/main.yml?query=branch%3Amaster)
 [![CI](https://github.com/JBZoo/Csv-Blueprint/actions/workflows/demo.yml/badge.svg)](https://github.com/JBZoo/Csv-Blueprint/actions/workflows/demo.yml)
-[![Coverage Status](https://coveralls.io/repos/github/JBZoo/Csv-Blueprint/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Csv-Blueprint?branch=master)
 [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Csv-Blueprint/coverage.svg)](https://shepherd.dev/github/JBZoo/Csv-Blueprint)
-[![Sonar - Bugs](https://sonarcloud.io/api/project_badges/measure?project=JBZoo_Csv-Blueprint&metric=bugs)](https://sonarcloud.io/summary/overall?id=JBZoo_Csv-Blueprint)
-[![Sonar - Code smells](https://sonarcloud.io/api/project_badges/measure?project=JBZoo_Csv-Blueprint&metric=code_smells)](https://sonarcloud.io/summary/overall?id=JBZoo_Csv-Blueprint)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=JBZoo_Csv-Blueprint&metric=coverage)](https://sonarcloud.io/code?id=JBZoo_Csv-Blueprint&selected=JBZoo_Csv-Blueprint%3Asrc)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=JBZoo_Csv-Blueprint&metric=bugs)](https://sonarcloud.io/project/issues?resolved=false&id=JBZoo_Csv-Blueprint)
+[![Code smells](https://sonarcloud.io/api/project_badges/measure?project=JBZoo_Csv-Blueprint&metric=code_smells)](https://sonarcloud.io/project/issues?resolved=false&id=JBZoo_Csv-Blueprint)
 [![Docker Pulls](https://img.shields.io/docker/pulls/jbzoo/csv-blueprint.svg)](https://hub.docker.com/r/jbzoo/csv-blueprint/tags)
 <!-- auto-update:/top-badges -->
 

--- a/tests/PackageTest.php
+++ b/tests/PackageTest.php
@@ -61,17 +61,18 @@ final class PackageTest extends \JBZoo\Codestyle\PHPUnit\AbstractPackageTest
         'coveralls'      => true,
         'circle_ci'      => true,
 
-        'sonar_qube_bugs'   => true,
-        'sonar_qube_smells' => true,
+        'sonarqube_coverage' => true,
+        'sonarqube_bugs'     => true,
+        'sonarqube_smells'   => true,
     ];
 
     protected array $badgesTemplate = [
         'github_actions',
         'github_actions_demo',
-        'coveralls',
         'psalm_coverage',
-        'sonar_qube_bugs',
-        'sonar_qube_smells',
+        'sonarqube_coverage',
+        'sonarqube_bugs',
+        'sonarqube_smells',
         'docker_pulls',
     ];
 
@@ -178,24 +179,35 @@ final class PackageTest extends \JBZoo\Codestyle\PHPUnit\AbstractPackageTest
         );
     }
 
-    protected function checkBadgeSonarQubeBugs(): ?string
+    protected function checkBadgeSonarqubeBugs(): ?string
     {
         return $this->getPreparedBadge(
             $this->getBadge(
-                'Sonar - Bugs',
+                'Bugs',
                 'https://sonarcloud.io/api/project_badges/measure?project=JBZoo_Csv-Blueprint&metric=bugs',
-                'https://sonarcloud.io/summary/overall?id=JBZoo_Csv-Blueprint',
+                'https://sonarcloud.io/project/issues?resolved=false&id=JBZoo_Csv-Blueprint',
             ),
         );
     }
 
-    protected function checkBadgeSonarQubeSmells(): ?string
+    protected function checkBadgeSonarqubeSmells(): ?string
     {
         return $this->getPreparedBadge(
             $this->getBadge(
-                'Sonar - Code smells',
+                'Code smells',
                 'https://sonarcloud.io/api/project_badges/measure?project=JBZoo_Csv-Blueprint&metric=code_smells',
-                'https://sonarcloud.io/summary/overall?id=JBZoo_Csv-Blueprint',
+                'https://sonarcloud.io/project/issues?resolved=false&id=JBZoo_Csv-Blueprint',
+            ),
+        );
+    }
+
+    protected function checkBadgeSonarqubeCoverage(): ?string
+    {
+        return $this->getPreparedBadge(
+            $this->getBadge(
+                'Coverage',
+                'https://sonarcloud.io/api/project_badges/measure?project=JBZoo_Csv-Blueprint&metric=coverage',
+                'https://sonarcloud.io/code?id=JBZoo_Csv-Blueprint&selected=JBZoo_Csv-Blueprint%3Asrc',
             ),
         );
     }


### PR DESCRIPTION
This commit removes Coveralls from the testing pipeline reflected in the GitHub workflow and the README file. It also improves the SonarCloud part in several ways, including the addition of Sonarqube coverage measure and revising the SonarQube bug and smell badges. The changes make the testing pipeline more focused, benefiting from SonarCloud's coverage reporting instead of using a separate Coveralls service.