### PR TITLE
Adjust Docker build platforms in Github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -233,7 +233,6 @@ jobs:
         with:
           context: .
           push: false
-          platforms: linux/amd64,linux/arm64
           tags: jbzoo/csv-blueprint:local
 
       - name: 🎨 Test help and logo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -233,6 +233,7 @@ jobs:
         with:
           context: .
           push: false
+          platforms: linux/amd64,linux/arm64
           tags: jbzoo/csv-blueprint:local
 
       - name: 🎨 Test help and logo

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,7 +76,7 @@ jobs:
           tags: |
             jbzoo/csv-blueprint:latest
             jbzoo/csv-blueprint:${{ github.event.release.tag_name }}
-          platforms: linux/amd64,linux/arm64/v8,linux/386
+          platforms: linux/amd64,linux/arm64
           build-args: |
             VERSION=${{ github.event.release.tag_name }}
 


### PR DESCRIPTION
This commit updates the listed platforms for Docker builds in two Github action workflow files: 'main.yml' and 'publish.yml'. It specifies now to run the builds on both 'linux/amd64' and 'linux/arm64' platforms.