### PR TITLE
Init. Add `create:schema` command to suggest schema based on CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![Static Badge](https://img.shields.io/badge/Rules-125-green?label=Cell%20rules&labelColor=blue&color=gray)](src/Rules/Cell)
 [![Static Badge](https://img.shields.io/badge/Rules-206-green?label=Aggregate%20rules&labelColor=blue&color=gray)](src/Rules/Aggregate)
 [![Static Badge](https://img.shields.io/badge/Rules-8-green?label=Extra%20checks&labelColor=blue&color=gray)](#extra-checks)
-[![Static Badge](https://img.shields.io/badge/Rules-18/11/20-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
+[![Static Badge](https://img.shields.io/badge/Rules-21/11/20-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
 <!-- auto-update:/rules-counter -->
 
 A console utility designed for validating CSV files against a strictly defined schema and validation rules outlined

--- a/README.md
+++ b/README.md
@@ -1195,28 +1195,19 @@ columns:
 
 <!-- auto-update:preset-usage-real-yml -->
 ```yml
+# Schema file ./schema-examples/preset_usage.yml
 name: 'Schema uses presets and add new columns + specific rules.'
 description: 'This schema uses presets. Also, it demonstrates how to override preset values.'
 presets:
   users: ./schema-examples/preset_users.yml
   db: ./schema-examples/preset_database.yml
-filename_pattern: ''
 csv:
-  header: true
   delimiter: ;
-  quote_char: \
   enclosure: '|'
-  encoding: utf-8
-  bom: false
-structural_rules:
-  strict_column_order: true
-  allow_extra_columns: false
 columns:
-  -
-    name: id
+  - name: id
     description: 'Unique identifier, usually used to denote a primary key in databases.'
     example: 12345
-    required: true
     rules:
       not_empty: true
       is_trimmed: true
@@ -1227,11 +1218,10 @@ columns:
       sorted:
         - asc
         - numeric
-  -
-    name: status
+
+  - name: status
     description: 'Status in database'
     example: active
-    required: true
     rules:
       not_empty: true
       allow_values:
@@ -1239,12 +1229,10 @@ columns:
         - inactive
         - pending
         - deleted
-    aggregate_rules: []
-  -
-    name: login
+
+  - name: login
     description: "User's login name"
     example: johndoe
-    required: true
     rules:
       not_empty: true
       is_trimmed: true
@@ -1255,11 +1243,10 @@ columns:
       is_alnum: true
     aggregate_rules:
       is_unique: true
-  -
-    name: email
+
+  - name: email
     description: "User's email address"
     example: user@example.com
-    required: true
     rules:
       not_empty: true
       is_trimmed: true
@@ -1267,11 +1254,10 @@ columns:
       is_lowercase: true
     aggregate_rules:
       is_unique: true
-  -
-    name: full_name
+
+  - name: full_name
     description: "User's full name"
     example: 'John Doe Smith'
-    required: true
     rules:
       not_empty: true
       is_trimmed: true
@@ -1282,11 +1268,10 @@ columns:
       is_capitalize: true
     aggregate_rules:
       is_unique: true
-  -
-    name: birthday
+
+  - name: birthday
     description: "Validates the user's birthday."
     example: '1990-01-01'
-    required: true
     rules:
       not_empty: true
       is_trimmed: true
@@ -1295,23 +1280,19 @@ columns:
       date_age_greater: 0
       date_age_less: 150
       date_max: now
-    aggregate_rules: []
-  -
-    name: phone
+
+  - name: phone
     description: "User's phone number in US"
     example: '+1 650 253 00 00'
-    required: true
     rules:
       not_empty: true
       is_trimmed: true
       starts_with: '+1'
       phone: US
-    aggregate_rules: []
-  -
-    name: password
+
+  - name: password
     description: "User's password"
     example: 9RfzENKD
-    required: true
     rules:
       not_empty: true
       is_trimmed: true
@@ -1325,12 +1306,9 @@ columns:
       charset: UTF-8
       length_min: 10
       length_max: 20
-    aggregate_rules: []
-  -
-    name: admin_note
+
+  - name: admin_note
     description: 'Admin note'
-    example: ~
-    required: true
     rules:
       not_empty: true
       length_min: 1
@@ -1482,14 +1460,14 @@ Options:
                                    - no|n|0: Apply only schemas with not empty `filename_pattern` and match the CSV files.
                                    Note. If specify the option `--apply-all` without value, it will be treated as "yes".
                                     [default: "auto"]
-  -r, --report=REPORT              Determines the report's output format.
-                                   Available options: text, table, github, gitlab, teamcity, junit
-                                    [default: "table"]
   -Q, --quick[=QUICK]              Stops the validation process upon encountering the first error,
                                    accelerating the check but limiting error visibility.
                                    Returns a non-zero exit code if any error is detected.
                                    Enable by setting to any non-empty value or "yes".
                                     [default: "no"]
+  -r, --report=REPORT              Determines the report's output format.
+                                   Available options: text, table, github, gitlab, teamcity, junit
+                                    [default: "table"]
       --dump-schema                Dumps the schema of the CSV file if you want to see the final schema after inheritance.
       --debug                      Intended solely for debugging and advanced profiling purposes.
                                    Activating this option provides detailed process insights,
@@ -1542,14 +1520,14 @@ Options:
                                  Similar to CSV paths, you can direct to specific files or search directories with glob patterns.
                                  Examples: /full/path/name.yml; p/file.yml; p/*.yml; p/**/*.yml; p/**/name-*.yml; **/*.yml
                                   (multiple values allowed)
-  -r, --report=REPORT            Determines the report's output format.
-                                 Available options: text, table, github, gitlab, teamcity, junit
-                                  [default: "table"]
   -Q, --quick[=QUICK]            Stops the validation process upon encountering the first error,
                                  accelerating the check but limiting error visibility.
                                  Returns a non-zero exit code if any error is detected.
                                  Enable by setting to any non-empty value or "yes".
                                   [default: "no"]
+  -r, --report=REPORT            Determines the report's output format.
+                                 Available options: text, table, github, gitlab, teamcity, junit
+                                  [default: "table"]
       --dump-schema              Dumps the schema of the CSV file if you want to see the final schema after inheritance.
       --debug                    Intended solely for debugging and advanced profiling purposes.
                                  Activating this option provides detailed process insights,

--- a/README.md
+++ b/README.md
@@ -1195,7 +1195,7 @@ columns:
 
 <!-- auto-update:preset-usage-real-yml -->
 ```yml
-# Schema file ./schema-examples/preset_usage.yml
+# Schema file is "./schema-examples/preset_usage.yml"
 name: 'Schema uses presets and add new columns + specific rules.'
 description: 'This schema uses presets. Also, it demonstrates how to override preset values.'
 presets:

--- a/src/Analyze/Analyzer.php
+++ b/src/Analyze/Analyzer.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace JBZoo\CsvBlueprint\Analyze;
 
 use JBZoo\CsvBlueprint\Csv\CsvFile;
-use JBZoo\CsvBlueprint\Rules\AbstractRule;
+use JBZoo\CsvBlueprint\Schema;
 use JBZoo\CsvBlueprint\Utils;
 use Symfony\Component\Finder\Finder;
 
@@ -28,68 +28,162 @@ final class Analyzer
     ) {
     }
 
-    public function analyzeCsv(bool $isHeader = true, int $lineLimit = 100): void
+    /**
+     * Analyzes a CSV file and suggests parameters for parsing and creating a schema.
+     *
+     * @param null|bool $forceHeader Whether to force the presence of a header row. Null to auto-detect.
+     * @param int       $lineLimit   Number of lines to read when detecting parameters. Default is 1000.
+     *
+     * @return Schema the suggested schema for the CSV file
+     */
+    public function analyzeCsv(?bool $forceHeader = null, int $lineLimit = 1000): Schema
     {
-        $csv = new CsvFile($this->csvFilename);
+        $suggestedSchema = [
+            'name'        => 'Schema for ' . \basename($this->csvFilename),
+            'description' => \implode("\n", [
+                'CSV file ' . Utils::cutPath($this->csvFilename),
+                "Suggested schema based on the first {$lineLimit} lines.",
+                'Please review it before using.',
+            ]),
+            'filename_pattern' => self::suggestFilenamePattern($this->csvFilename),
+            'csv'              => $this->autoDetectCsvParams($forceHeader, $lineLimit),
+            'columns'          => [],
+        ];
 
-        $analyzeResults = [];
-
-        $columns = $isHeader ? $csv->getHeader() : $csv->getRealColumNumber();
+        $csv = new CsvFile($this->csvFilename, ['csv' => $suggestedSchema['csv']]);
+        $hasHeader = $csv->getSchema()->csvHasHeader();
+        $columns = $hasHeader ? $csv->getHeader() : \range(0, $csv->getRealColumNumber() - 1);
 
         foreach ($columns as $columnId => $column) {
             $columnValues = [];
+            $example = null;
 
-            foreach ($csv->getRecords() as $line => $record) {
+            foreach ($csv->getRecords((int)$columnId) as $line => $recordValue) {
                 if ($line >= $lineLimit) {
                     break;
                 }
 
-                if ($isHeader && $line === 0) {
+                if ($hasHeader && $line === 0) {
                     continue;
                 }
 
-                $columnValues[] = $record[$columnId] ?? '';
+                if ($example === null && $recordValue !== '' && $recordValue !== null) {
+                    $example = $recordValue;
+                }
+
+                $columnValues[] = $recordValue ?? '';
             }
 
-            $analyzeResults[$columnId] =
-                \array_merge(['name' => $column], $this->analyzeColumn($columnValues));
+            $base = [];
+            if ($hasHeader) {
+                $base['name'] = $column;
+            }
+
+            if ($example !== null) {
+                $base['example'] = $example;
+            }
+
+            $suggestedSchema['columns'][$columnId] = \array_merge($base, self::analyzeColumn($columnValues));
         }
 
-        dump($analyzeResults);
+        return new Schema($suggestedSchema);
     }
 
-    private function analyzeColumn(array $columnValues): array
+    /**
+     * Automatically detects the parameters for parsing a CSV file.
+     *
+     * @param null|bool $forceHeader Whether to force the presence of a header row. Null to auto-detect.
+     * @param int       $linesLimit  number of lines to read when detecting parameters
+     *
+     * @return array the suggested parameters for parsing the CSV file
+     */
+    private function autoDetectCsvParams(?bool $forceHeader, int $linesLimit): array
+    {
+        $file = new \SplFileObject($this->csvFilename, 'r');
+        $file->setFlags(\SplFileObject::READ_CSV);
+
+        $delimiters = [',', ';', "\t", '|'];
+        $delimiterCounts = \array_fill_keys($delimiters, 0);
+        $lineCount = 0;
+        $headerChecked = false;
+        $detectedHeaderFlag = true;
+
+        // Read up to first lines to detect the delimiter
+        while (!$file->eof() && $lineCount < $linesLimit) {
+            $line = $file->fgets();
+
+            /** @phpstan-ignore-next-line */
+            $line = empty($line) ? '' : $line;
+
+            if ($lineCount === 0) {
+                foreach ($delimiters as $delimiter) {
+                    $delimiterCounts[$delimiter] += \substr_count($line, $delimiter);
+                }
+            }
+
+            if (!$headerChecked && $lineCount === 0) {
+                $detectedHeaderFlag = self::checkHeader($line, self::detectPopularDelimiter($delimiterCounts));
+                $headerChecked = true;
+            }
+
+            $lineCount++;
+        }
+
+        // Choose the delimiter with the maximum count in the first line
+        $popularDelimiter = self::detectPopularDelimiter($delimiterCounts);
+
+        // Default quote character and enclosure. We don't detect them for now. We can add this feature later.
+        // For now, we use the default values because they are the most common.
+        $quoteChar = '\\';
+        $enclosure = '"';
+
+        // Check for BOM
+        $file->rewind();
+        $bom = $file->fread(3) === "\xEF\xBB\xBF";
+
+        // Reset and check encoding
+        $file->rewind();
+        $data = (string)$file->fread(10240); // Read more bytes for better encoding detection. 10kb should be enough.
+        $encoding = \strtolower((string)\mb_detect_encoding($data, 'UTF-8, UTF-16, UTF-32', true));
+
+        return Utils::removeDefaultSettings([
+            'header'     => $forceHeader === null ? $detectedHeaderFlag : $forceHeader,
+            'delimiter'  => $popularDelimiter,
+            'quote_char' => $quoteChar,
+            'enclosure'  => $enclosure,
+            'encoding'   => $encoding,
+            'bom'        => $bom,
+        ], (new Schema())->getCsvParams());
+    }
+
+    private static function analyzeColumn(array $columnValues): array
     {
         $validRules = [
             'rules'           => [],
             'aggregate_rules' => [],
         ];
 
-        /** @var class-string<AbstractRule>[] $ruleClassnames */
-        foreach ($this->getCellRuleClasses() as $ruleType => $ruleClassnames) {
-            /** @var class-string<AbstractRule> $ruleClassname */
+        foreach (self::getCellRuleClasses() as $ruleType => $ruleClassnames) {
             foreach ($ruleClassnames as $ruleName => $ruleClassname) {
-                if ($ruleClassname::testValues($columnValues)) {
+                $checkResult = $ruleClassname::testValues($columnValues);
+                if ($checkResult === true) {
                     $validRules[$ruleType][$ruleName] = true;
                 }
             }
-        }
-
-        if (\count($validRules['rules']) === 0) {
-            unset($validRules['rules']);
-        }
-
-        if (\count($validRules['aggregate_rules']) === 0) {
-            unset($validRules['aggregate_rules']);
         }
 
         return $validRules;
     }
 
     /**
-     * @return class-string<AbstractRule>[]
+     * Returns the available rule classes for cell and aggregate rules.
+     * @suppress PhanUnextractableAnnotationSuffix
+     * @return array{
+     *     aggregate_rules: array<string, class-string<\JBZoo\CsvBlueprint\Rules\AbstractRule>>,
+     *     rules: array<string, class-string<\JBZoo\CsvBlueprint\Rules\AbstractRule>>
+     * }
      */
-    private function getCellRuleClasses(): array
+    private static function getCellRuleClasses(): array
     {
         static $availableRules = null; // Memoization to avoid multiple file system scans
 
@@ -113,7 +207,7 @@ final class Analyzer
                     $filename = $file->getFilenameWithoutExtension();
                     $ruleName = Utils::camelToKebabCase($filename);
 
-                    /** @var class-string<AbstractRule> $ruleClassname */
+                    /** @var class-string<\JBZoo\CsvBlueprint\Rules\AbstractRule> $ruleClassname */
                     $ruleClassname = "JBZoo\\CsvBlueprint\\Rules\\{$dir}\\{$filename}";
 
                     if (\class_exists($ruleClassname)) {
@@ -126,10 +220,7 @@ final class Analyzer
 
                             $key = $dir === 'Cell' ? 'rules' : 'aggregate_rules';
                             $availableRules[$key][$ruleName] = $ruleClassname;
-                        } catch (\Exception $exception) {
-                            if (Utils::getDebugMode()) {
-                                throw $exception;
-                            }
+                        } catch (\ReflectionException) {
                             continue;
                         }
                     }
@@ -138,5 +229,53 @@ final class Analyzer
         }
 
         return $availableRules;
+    }
+
+    /**
+     * Detects the most popular delimiter from the given delimiter counts.
+     *
+     * @param non-empty-array<array-key, int> $delimiterCounts the counts of occurrences for each delimiter
+     *
+     * @return string the most popular delimiter found
+     */
+    private static function detectPopularDelimiter(array $delimiterCounts): string
+    {
+        return (string)\array_search(\max($delimiterCounts), $delimiterCounts, true);
+    }
+
+    /**
+     * Checks if the header row in the CSV file is valid.
+     *
+     * @param string $line      the header row line from the CSV file
+     * @param string $delimiter the delimiter used in the CSV file
+     *
+     * @return bool true if the header row is valid, false otherwise
+     */
+    private static function checkHeader(string $line, string $delimiter): bool
+    {
+        if ($delimiter === '') {
+            return false;
+        }
+
+        $fields = \explode($delimiter, $line);
+
+        foreach ($fields as $field) {
+            if (\preg_match('/^[a-z0-9_]+$/i', \trim($field)) === 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Suggest a filename pattern based on the CSV filename.
+     *
+     * @param  string $csvFilename the CSV filename
+     * @return string the suggested filename pattern
+     */
+    private static function suggestFilenamePattern(string $csvFilename): string
+    {
+        return '/' . \preg_quote(\basename($csvFilename), '/') . '/';
     }
 }

--- a/src/Analyze/Analyzer.php
+++ b/src/Analyze/Analyzer.php
@@ -34,7 +34,9 @@ final class Analyzer
 
         $analyzeResults = [];
 
-        for ($i = 0; $i < $csv->getRealColumNumber(); $i++) {
+        $columns = $isHeader ? $csv->getHeader() : $csv->getRealColumNumber();
+
+        foreach ($columns as $columnId => $column) {
             $columnValues = [];
 
             foreach ($csv->getRecords() as $line => $record) {
@@ -46,9 +48,11 @@ final class Analyzer
                     continue;
                 }
 
-                $columnValues[] = $record[$i] ?? '';
+                $columnValues[] = $record[$columnId] ?? '';
             }
-            $analyzeResults[$i] = $this->analyzeColumn($columnValues);
+
+            $analyzeResults[$columnId] =
+                \array_merge(['name' => $column], $this->analyzeColumn($columnValues));
         }
 
         dump($analyzeResults);

--- a/src/Analyze/Analyzer.php
+++ b/src/Analyze/Analyzer.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace JBZoo\CsvBlueprint\Analyze;
 
 use JBZoo\CsvBlueprint\Csv\CsvFile;
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use JBZoo\CsvBlueprint\Utils;
 use Symfony\Component\Finder\Finder;
 
@@ -65,9 +65,9 @@ final class Analyzer
             'aggregate_rules' => [],
         ];
 
-        /** @var class-string<AbstarctRule>[] $ruleClassnames */
+        /** @var class-string<AbstractRule>[] $ruleClassnames */
         foreach ($this->getCellRuleClasses() as $ruleType => $ruleClassnames) {
-            /** @var class-string<AbstarctRule> $ruleClassname */
+            /** @var class-string<AbstractRule> $ruleClassname */
             foreach ($ruleClassnames as $ruleName => $ruleClassname) {
                 if ($ruleClassname::testValues($columnValues)) {
                     $validRules[$ruleType][$ruleName] = true;
@@ -87,7 +87,7 @@ final class Analyzer
     }
 
     /**
-     * @return class-string<AbstarctRule>[]
+     * @return class-string<AbstractRule>[]
      */
     private function getCellRuleClasses(): array
     {
@@ -113,7 +113,7 @@ final class Analyzer
                     $filename = $file->getFilenameWithoutExtension();
                     $ruleName = Utils::camelToKebabCase($filename);
 
-                    /** @var class-string<AbstarctRule> $ruleClassname */
+                    /** @var class-string<AbstractRule> $ruleClassname */
                     $ruleClassname = "JBZoo\\CsvBlueprint\\Rules\\{$dir}\\{$filename}";
 
                     if (\class_exists($ruleClassname)) {

--- a/src/Analyze/Analyzer.php
+++ b/src/Analyze/Analyzer.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Analyze;
+
+use JBZoo\CsvBlueprint\Csv\CsvFile;
+use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Utils;
+use Symfony\Component\Finder\Finder;
+
+final class Analyzer
+{
+    public function __construct(
+        private string $csvFilename,
+    ) {
+    }
+
+    public function analyzeCsv(bool $isHeader = true, int $lineLimit = 100): void
+    {
+        $csv = new CsvFile($this->csvFilename);
+
+        $analyzeResults = [];
+
+        for ($i = 0; $i < $csv->getRealColumNumber(); $i++) {
+            $columnValues = [];
+
+            foreach ($csv->getRecords() as $line => $record) {
+                if ($line >= $lineLimit) {
+                    break;
+                }
+
+                if ($isHeader && $line === 0) {
+                    continue;
+                }
+
+                $columnValues[] = $record[$i] ?? '';
+            }
+            $analyzeResults[$i] = $this->analyzeColumn($columnValues);
+        }
+
+        dump($analyzeResults);
+    }
+
+    private function analyzeColumn(array $columnValues): array
+    {
+        $validRules = [
+            'rules'           => [],
+            'aggregate_rules' => [],
+        ];
+
+        /** @var class-string<AbstarctRule>[] $ruleClassnames */
+        foreach ($this->getCellRuleClasses() as $ruleType => $ruleClassnames) {
+            /** @var class-string<AbstarctRule> $ruleClassname */
+            foreach ($ruleClassnames as $ruleName => $ruleClassname) {
+                if ($ruleClassname::testValues($columnValues)) {
+                    $validRules[$ruleType][$ruleName] = true;
+                }
+            }
+        }
+
+        if (\count($validRules['rules']) === 0) {
+            unset($validRules['rules']);
+        }
+
+        if (\count($validRules['aggregate_rules']) === 0) {
+            unset($validRules['aggregate_rules']);
+        }
+
+        return $validRules;
+    }
+
+    /**
+     * @return class-string<AbstarctRule>[]
+     */
+    private function getCellRuleClasses(): array
+    {
+        static $availableRules = null; // Memoization to avoid multiple file system scans
+
+        if ($availableRules === null) {
+            $dirs = ['Cell', 'Aggregate'];
+
+            $availableRules = [
+                'rules'           => [],
+                'aggregate_rules' => [],
+            ];
+
+            foreach ($dirs as $dir) {
+                $finder = (new Finder())
+                    ->in(__DIR__ . "/../Rules/{$dir}")
+                    ->ignoreDotFiles(false)
+                    ->ignoreVCS(true)
+                    ->name('/\\.php$/')
+                    ->files();
+
+                foreach ($finder as $file) {
+                    $filename = $file->getFilenameWithoutExtension();
+                    $ruleName = Utils::camelToKebabCase($filename);
+
+                    /** @var class-string<AbstarctRule> $ruleClassname */
+                    $ruleClassname = "JBZoo\\CsvBlueprint\\Rules\\{$dir}\\{$filename}";
+
+                    if (\class_exists($ruleClassname)) {
+                        try {
+                            $methodName = $dir === 'Cell' ? 'testValue' : 'testValues';
+                            $origClassOfMethod = (new \ReflectionClass($ruleClassname))->getMethod($methodName)->class;
+                            if ($ruleClassname !== $origClassOfMethod) {
+                                continue;
+                            }
+
+                            $key = $dir === 'Cell' ? 'rules' : 'aggregate_rules';
+                            $availableRules[$key][$ruleName] = $ruleClassname;
+                        } catch (\Exception $exception) {
+                            if (Utils::getDebugMode()) {
+                                throw $exception;
+                            }
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
+
+        return $availableRules;
+    }
+}

--- a/src/Analyze/Exception.php
+++ b/src/Analyze/Exception.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Analyze;
+
+final class Exception extends \JBZoo\CsvBlueprint\Exception
+{
+}

--- a/src/Commands/CreateSchema.php
+++ b/src/Commands/CreateSchema.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Commands;
+
+use JBZoo\CsvBlueprint\Analyze\Analyzer;
+use JBZoo\CsvBlueprint\Utils;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+final class CreateSchema extends AbstractValidate
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('create:schema')
+            ->setDescription('Analyze CSV files and suggest a schema based on the data found.')
+            ->addOption(
+                'csv',
+                'c',
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                \implode("\n", [
+                    'Specify the path(s) to the CSV files you want to analyze.',
+                    'This can include a direct path to a file or a directory to search with a maximum depth of ' .
+                    Utils::MAX_DIRECTORY_DEPTH . ' levels.',
+                    'Examples: <info>' . \implode('</info>; <info>', [
+                        'p/file.csv',
+                        'p/*.csv',
+                        'p/**/*.csv',
+                        'p/**/name-*.csv',
+                        '**/*.csv',
+                    ]) . '</info>',
+                    '',
+                ]),
+            );
+
+        parent::configure();
+    }
+
+    protected function executeAction(): int
+    {
+        $this->preparation();
+
+        $csvFilenames = $this->findFiles('csv', true);
+
+        foreach ($csvFilenames as $csvFilename) {
+            (new Analyzer($csvFilename->getRealPath()))->analyzeCsv();
+        }
+
+        self::dumpPreloader(); // Experimental feature
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Commands/CreateSchema.php
+++ b/src/Commands/CreateSchema.php
@@ -94,6 +94,10 @@ final class CreateSchema extends AbstractValidate
         return self::SUCCESS;
     }
 
+    /**
+     * Retrieves the value of the header option.
+     * @return null|bool The value of the header option. Returns null if the header is set to 'auto'.
+     */
     private function getHeaderOption(): ?bool
     {
         $header = \strtolower($this->getOptString('header'));
@@ -104,6 +108,10 @@ final class CreateSchema extends AbstractValidate
         return $header === '' || bool($header);
     }
 
+    /**
+     * Retrieves the lines option.
+     * @return int The value of the lines option. If the option is not set or is less than 1, it returns 1.
+     */
     private function getLinesOption(): int
     {
         return \max(1, $this->getOptInt('lines'));

--- a/src/Commands/ValidateCsv.php
+++ b/src/Commands/ValidateCsv.php
@@ -99,6 +99,19 @@ final class ValidateCsv extends AbstractValidate
                     '',
                 ]),
                 'auto',
+            )
+            ->addOption(
+                'quick',
+                'Q',
+                InputOption::VALUE_OPTIONAL,
+                \implode("\n", [
+                    'Stops the validation process upon encountering the first error,',
+                    'accelerating the check but limiting error visibility.',
+                    'Returns a non-zero exit code if any error is detected.',
+                    'Enable by setting to any non-empty value or "yes".',
+                    '',
+                ]),
+                'no',
             );
 
         parent::configure();

--- a/src/Commands/ValidateSchema.php
+++ b/src/Commands/ValidateSchema.php
@@ -49,6 +49,19 @@ final class ValidateSchema extends AbstractValidate
                     ]) . '</info>',
                     '',
                 ]),
+            )
+            ->addOption(
+                'quick',
+                'Q',
+                InputOption::VALUE_OPTIONAL,
+                \implode("\n", [
+                    'Stops the validation process upon encountering the first error,',
+                    'accelerating the check but limiting error visibility.',
+                    'Returns a non-zero exit code if any error is detected.',
+                    'Enable by setting to any non-empty value or "yes".',
+                    '',
+                ]),
+                'no',
             );
 
         parent::configure();

--- a/src/ExceptionNotImplemented.php
+++ b/src/ExceptionNotImplemented.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint;
+
+class ExceptionNotImplemented extends \RuntimeException
+{
+}

--- a/src/Rules/AbstarctRule.php
+++ b/src/Rules/AbstarctRule.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules;
 
+use JBZoo\CsvBlueprint\Rules\Cell\Exception;
 use JBZoo\CsvBlueprint\Utils;
 use JBZoo\CsvBlueprint\Validators\Error;
 use JBZoo\CsvBlueprint\Validators\ValidatorColumn;
@@ -109,6 +110,22 @@ abstract class AbstarctRule
     public function getInputType(): int
     {
         return static::INPUT_TYPE;
+    }
+
+    public static function testValues(array $columnValues, null|array|bool|float|int|string $options = null): array|bool
+    {
+        foreach ($columnValues as $cellValue) {
+            if (!static::testValue($cellValue, $options)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static function testValue(string $cellValue, null|array|bool|float|int|string $options = null): bool
+    {
+        throw new Exception('Not implemented yet. Please override this method in the child class.');
     }
 
     protected function getOptionAsBool(): bool

--- a/src/Rules/AbstractRule.php
+++ b/src/Rules/AbstractRule.php
@@ -112,10 +112,10 @@ abstract class AbstractRule
         return static::INPUT_TYPE;
     }
 
-    public static function testValues(array $columnValues, null|array|bool|float|int|string $options = null): array|bool
+    public static function testValues(array $columnValues): bool
     {
         foreach ($columnValues as $cellValue) {
-            if (!static::testValue($cellValue, $options)) {
+            if (!static::testValue($cellValue)) {
                 return false;
             }
         }
@@ -123,7 +123,11 @@ abstract class AbstractRule
         return true;
     }
 
-    public static function testValue(string $cellValue, null|array|bool|float|int|string $options = null): bool
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @phan-suppress PhanUnusedPublicMethodParameter
+     */
+    public static function testValue(string $cellValue): bool
     {
         throw new Exception('Not implemented yet. Please override this method in the child class.');
     }

--- a/src/Rules/AbstractRule.php
+++ b/src/Rules/AbstractRule.php
@@ -112,6 +112,11 @@ abstract class AbstractRule
         return static::INPUT_TYPE;
     }
 
+    /**
+     * Test if all values in the given column pass the testValue check.
+     * @param  array $columnValues the values of the column to test
+     * @return bool  true if all values pass the testValue check, false otherwise
+     */
     public static function testValues(array $columnValues): bool
     {
         foreach ($columnValues as $cellValue) {
@@ -124,6 +129,11 @@ abstract class AbstractRule
     }
 
     /**
+     * Checks if the given cell value is valid.
+     * @param  string    $cellValue the value to test
+     * @return bool      true if the cell value is valid, false otherwise
+     * @throws Exception when the method is not implemented in the child class
+     *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @phan-suppress PhanUnusedPublicMethodParameter
      */

--- a/src/Rules/Aggregate/IsUnique.php
+++ b/src/Rules/Aggregate/IsUnique.php
@@ -47,7 +47,7 @@ final class IsUnique extends AbstractAggregateRule
         return null;
     }
 
-    public static function testValues(array $columnValues, null|array|bool|float|int|string $options = null): bool
+    public static function testValues(array $columnValues): bool
     {
         $uValuesCount = \count(\array_unique($columnValues));
         $valuesCount = \count($columnValues);

--- a/src/Rules/Aggregate/IsUnique.php
+++ b/src/Rules/Aggregate/IsUnique.php
@@ -39,11 +39,19 @@ final class IsUnique extends AbstractAggregateRule
         $uValuesCount = \count(\array_unique($columnValues));
         $valuesCount = \count($columnValues);
 
-        if ($uValuesCount !== $valuesCount) {
+        if (self::testValues($columnValues)) {
             return 'Column has non-unique values. ' .
                 "Unique: <c>{$uValuesCount}</c>, total: <green>{$valuesCount}</green>";
         }
 
         return null;
+    }
+
+    public static function testValues(array $columnValues, null|array|bool|float|int|string $options = null): bool
+    {
+        $uValuesCount = \count(\array_unique($columnValues));
+        $valuesCount = \count($columnValues);
+
+        return $uValuesCount !== $valuesCount;
     }
 }

--- a/src/Rules/Cell/IsFloat.php
+++ b/src/Rules/Cell/IsFloat.php
@@ -43,7 +43,7 @@ class IsFloat extends AbstractCellRule
         return null;
     }
 
-    public static function testValue(string $cellValue, null|array|bool|float|int|string $options = null): bool
+    public static function testValue(string $cellValue): bool
     {
         return Validator::floatVal()->validate($cellValue);
     }

--- a/src/Rules/Cell/IsFloat.php
+++ b/src/Rules/Cell/IsFloat.php
@@ -36,7 +36,7 @@ class IsFloat extends AbstractCellRule
             return null;
         }
 
-        if (!self::testValue($cellValue)) {
+        if (!static::testValue($cellValue)) {
             return "Value \"<c>{$cellValue}</c>\" is not a float number";
         }
 

--- a/src/Rules/Cell/IsFloat.php
+++ b/src/Rules/Cell/IsFloat.php
@@ -36,10 +36,15 @@ class IsFloat extends AbstractCellRule
             return null;
         }
 
-        if (!Validator::floatVal()->validate($cellValue)) {
+        if (!self::testValue($cellValue)) {
             return "Value \"<c>{$cellValue}</c>\" is not a float number";
         }
 
         return null;
+    }
+
+    public static function testValue(string $cellValue, null|array|bool|float|int|string $options = null): bool
+    {
+        return Validator::floatVal()->validate($cellValue);
     }
 }

--- a/src/Rules/Cell/IsInt.php
+++ b/src/Rules/Cell/IsInt.php
@@ -36,10 +36,15 @@ final class IsInt extends AbstractCellRule
             return null;
         }
 
-        if (!Validator::intVal()->validate($cellValue)) {
+        if (!self::testValue($cellValue)) {
             return "Value \"<c>{$cellValue}</c>\" is not an integer";
         }
 
         return null;
+    }
+
+    public static function testValue(string $cellValue, null|array|bool|float|int|string $options = null): bool
+    {
+        return Validator::intVal()->validate($cellValue);
     }
 }

--- a/src/Rules/Cell/IsInt.php
+++ b/src/Rules/Cell/IsInt.php
@@ -43,7 +43,7 @@ final class IsInt extends AbstractCellRule
         return null;
     }
 
-    public static function testValue(string $cellValue, null|array|bool|float|int|string $options = null): bool
+    public static function testValue(string $cellValue): bool
     {
         return Validator::intVal()->validate($cellValue);
     }

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -256,6 +256,13 @@ final class Schema
         ];
     }
 
+    /**
+     * Converts the internal state to YAML string representation.
+     * @param  bool        $removeDefaultValues whether to remove default values from the dumped data
+     * @param  bool        $cliColored          whether to add color formatting for CLI output
+     * @param  null|string $basedOnCsv          the CSV file name that the data is based on
+     * @return string      the data converted to YAML string
+     */
     public function dumpAsYamlString(
         bool $removeDefaultValues = true,
         bool $cliColored = false,

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -78,16 +78,20 @@ final class Schema
             $this->data = (new SchemaDataPrep($data, $basepath))->buildData();
         } catch (\Exception $e) {
             throw new Exception(
-                "Invalid schema \"{$this->filename}\" data.\nUnexpected error: \"{$e->getMessage()}\"",
+                "Invalid schema \"{$this->getFilename(true)}\" data.\nUnexpected error: \"{$e->getMessage()}\"",
             );
         }
 
         $this->columns = $this->prepareColumns();
     }
 
-    public function getFilename(): ?string
+    public function getFilename(bool $relativePath = false): string
     {
-        return $this->filename;
+        if ($this->filename === null || $this->filename === '' || $this->filename === '_custom_array_') {
+            return 'undefined';
+        }
+
+        return $relativePath ? Utils::cutPath($this->filename) : $this->filename;
     }
 
     /**
@@ -252,10 +256,18 @@ final class Schema
         ];
     }
 
-    public function dumpAsYamlString(): string
-    {
-        return Yaml::dump(
-            $this->getData()->getArrayCopy(),
+    public function dumpAsYamlString(
+        bool $removeDefaultValues = true,
+        bool $cliColored = false,
+        ?string $basedOnCsv = null,
+    ): string {
+        $dump = $this->getData()->getArrayCopy();
+        if ($removeDefaultValues) {
+            $dump = Utils::removeDefaultSettings($dump, self::getDefaultValues(\count($dump['columns'])));
+        }
+
+        $ymlAsString = Yaml::dump(
+            $dump,
             10,
             2,
             Yaml::DUMP_NULL_AS_TILDE
@@ -264,6 +276,34 @@ final class Schema
             | Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE
             | Yaml::DUMP_EXCEPTION_ON_INVALID_TYPE,
         );
+
+        // Fix formating
+        $ymlAsString = \str_replace(
+            ["  -\n    ", "columns:\n"],
+            ["\n  - ", 'columns:'],
+            $ymlAsString,
+        );
+
+        if ($basedOnCsv !== null) {
+            $ymlAsString = "# Based on CSV \"{$basedOnCsv}\"\n{$ymlAsString}";
+        }
+
+        if ($this->getFilename(true) !== 'undefined') {
+            $ymlAsString = "# Schema file is \"{$this->getFilename(true)}\"\n{$ymlAsString}";
+        }
+
+        if ($cliColored) {
+            $ymlAsString = (string)\preg_replace('/^([ \t]*)([^:\n]+:)/m', '$1<c>$2</c>', $ymlAsString); // keys
+            $ymlAsString = (string)\preg_replace('/^(#.+)/m', '<gray>$1</gray>', $ymlAsString); // comments
+
+            $ymlAsString = \implode("\n", [
+                '<blue>```yaml</blue>',
+                $ymlAsString,
+                '<blue>```</blue>',
+            ]);
+        }
+
+        return \trim($ymlAsString) . "\n";
     }
 
     /**
@@ -280,5 +320,16 @@ final class Schema
         }
 
         return $result;
+    }
+
+    private static function getDefaultValues(int $numberOfColumns = 0): array
+    {
+        $default = (new self())->getData()->getArrayCopy();
+
+        for ($i = 0; $i < $numberOfColumns; $i++) {
+            $default['columns'][] = SchemaDataPrep::DEFAULTS['column'];
+        }
+
+        return $default;
     }
 }

--- a/src/SchemaDataPrep.php
+++ b/src/SchemaDataPrep.php
@@ -23,7 +23,7 @@ final class SchemaDataPrep
 {
     public const ALIAS_REGEX = '[a-z0-9-_]+';
 
-    private const DEFAULTS = [
+    public const DEFAULTS = [
         'name'             => '',
         'description'      => '',
         'filename_pattern' => '',

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -534,6 +534,12 @@ final class Utils
         });
     }
 
+    /**
+     * Remove default settings from an array of original settings.
+     * @param  array $original the original settings array
+     * @param  array $defaults the default settings array to compare against
+     * @return array the modified settings array with default settings removed
+     */
     public static function removeDefaultSettings(array $original, array $defaults): array
     {
         foreach ($original as $key => &$value) {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -160,8 +160,12 @@ final class Utils
         return $fileList;
     }
 
-    public static function cutPath(string $fullpath): string
+    public static function cutPath(?string $fullpath): string
     {
+        if ($fullpath === null) {
+            return '';
+        }
+
         $pwd = (string)\getcwd();
 
         if (\strlen($pwd) <= 1) {
@@ -528,6 +532,30 @@ final class Utils
             };
             throw new Exception("Unexpected {$severity}: \"{$message}\" in file \"{$file}:{$line}\"");
         });
+    }
+
+    public static function removeDefaultSettings(array $original, array $defaults): array
+    {
+        foreach ($original as $key => &$value) {
+            // Check if the key exists in defaults and values are the same
+            if (\array_key_exists($key, $defaults)) {
+                if (\is_array($value) && \is_array($defaults[$key])) {
+                    $value = self::removeDefaultSettings($value, $defaults[$key]);
+                } elseif ($value === $defaults[$key]) {
+                    unset($original[$key]);
+                }
+            }
+
+            // After processing, check if the value is an empty array and unset it
+            if (\is_array($value) && \count($value) === 0) {
+                unset($original[$key]);
+            }
+        }
+
+        // Unsetting the reference to avoid unexpected behavior later
+        unset($value);
+
+        return $original;
     }
 
     /**

--- a/src/Validators/ValidatorCsv.php
+++ b/src/Validators/ValidatorCsv.php
@@ -84,7 +84,7 @@ final class ValidatorCsv
                 $error = new Error(
                     'csv.header',
                     'Property "<c>name</c>" is not defined in schema: ' .
-                    "\"<c>{$this->schema->getFilename()}</c>\"",
+                    "\"<c>{$this->schema->getFilename(true)}</c>\"",
                     $column->getHumanName(),
                     ValidatorColumn::FALLBACK_LINE,
                 );

--- a/tests/Commands/CreateSchemaTest.php
+++ b/tests/Commands/CreateSchemaTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Commands;
+
+use JBZoo\PHPUnit\TestCase;
+use JBZoo\PHPUnit\Tools;
+
+use function JBZoo\PHPUnit\isSame;
+
+final class CreateSchemaTest extends TestCase
+{
+    public function testWithoutHeader(): void
+    {
+        [$actual, $exitCode] = Tools::virtualExecution('create:schema', [
+            'csv' => './tests/fixtures/demo.csv',
+        ]);
+
+        $expected = <<<'TXT'
+            # Schema file undefined
+            # Based on CSV ./tests/fixtures/demo.csv
+            name: 'Schema for demo.csv'
+            description: |-
+              CSV file ./tests/fixtures/demo.csv
+              Suggested schema based on the first 1000 lines.
+              Please review it before using.
+            filename_pattern: /demo\.csv/
+            csv:
+              header: false
+            columns:
+              - example: Name
+            
+              - example: City
+                aggregate_rules:
+                  is_unique: true
+            
+              - example: Float
+            
+              - example: Birthday
+                aggregate_rules:
+                  is_unique: true
+            
+              - example: 'Favorite color'
+                aggregate_rules:
+                  is_unique: true
+            
+            
+            TXT;
+
+        isSame($expected, $actual);
+        isSame(0, $exitCode, $actual);
+    }
+
+    public function testWitHeader(): void
+    {
+        [$actual, $exitCode] = Tools::virtualExecution('create:schema', [
+            'csv'    => './tests/fixtures/demo.csv',
+            'header' => 'true',
+        ]);
+
+        $expected = <<<'TXT'
+            # Schema file undefined
+            # Based on CSV ./tests/fixtures/demo.csv
+            name: 'Schema for demo.csv'
+            description: |-
+              CSV file ./tests/fixtures/demo.csv
+              Suggested schema based on the first 1000 lines.
+              Please review it before using.
+            filename_pattern: /demo\.csv/
+            columns:
+              - name: Name
+                example: Clyde
+            
+              - name: City
+                example: Rivsikgo
+                aggregate_rules:
+                  is_unique: true
+            
+              - name: Float
+                example: '4825.185'
+                rules:
+                  is_float: true
+            
+              - name: Birthday
+                example: '2000-01-01'
+                aggregate_rules:
+                  is_unique: true
+            
+              - name: 'Favorite color'
+                example: green
+                aggregate_rules:
+                  is_unique: true
+            
+            
+            TXT;
+
+        isSame($expected, $actual);
+        isSame(0, $exitCode, $actual);
+    }
+}

--- a/tests/Commands/CreateSchemaTest.php
+++ b/tests/Commands/CreateSchemaTest.php
@@ -30,8 +30,7 @@ final class CreateSchemaTest extends TestCase
         ]);
 
         $expected = <<<'TXT'
-            # Schema file undefined
-            # Based on CSV ./tests/fixtures/demo.csv
+            # Based on CSV "./tests/fixtures/demo.csv"
             name: 'Schema for demo.csv'
             description: |-
               CSV file ./tests/fixtures/demo.csv
@@ -72,8 +71,7 @@ final class CreateSchemaTest extends TestCase
         ]);
 
         $expected = <<<'TXT'
-            # Schema file undefined
-            # Based on CSV ./tests/fixtures/demo.csv
+            # Based on CSV "./tests/fixtures/demo.csv"
             name: 'Schema for demo.csv'
             description: |-
               CSV file ./tests/fixtures/demo.csv

--- a/tests/Commands/ValidateSchemaTest.php
+++ b/tests/Commands/ValidateSchemaTest.php
@@ -110,8 +110,8 @@ final class ValidateSchemaTest extends TestCase
               +-------+-----------+--------+----------------------------------+
               | undef | meta      | schema | Unknown key: .unknow_root_option |
               +-------+-----------+--------+----------------------------------+
-            ```yaml
             # File: ./tests/schemas/broken/invalid_schema.yml
+            # Schema file ./tests/schemas/broken/invalid_schema.yml
             name: ''
             description: ''
             presets: []
@@ -129,17 +129,14 @@ final class ValidateSchemaTest extends TestCase
             columns: []
             unknow_root_option: true
             
-            ```
             (2/2) 1 issue in ./tests/schemas/broken/syntax.yml
               +------+-----------+---------------+---------------------------------------------------+
               | Line | id:Column | Rule          | Message                                           |
               +------+-----------+---------------+---------------------------------------------------+
               |   15 |           | schema.syntax | Unable to parse at line 15 (near "(*$#)@(@$*)("). |
               +------+-----------+---------------+---------------------------------------------------+
-            ```yaml
             # File: ./tests/schemas/broken/syntax.yml
             Unable to parse schema file: Unable to parse at line 15 (near "(*$#)@(@$*)(").
-            ```
             
             TXT;
 

--- a/tests/Commands/ValidateSchemaTest.php
+++ b/tests/Commands/ValidateSchemaTest.php
@@ -111,7 +111,7 @@ final class ValidateSchemaTest extends TestCase
               | undef | meta      | schema | Unknown key: .unknow_root_option |
               +-------+-----------+--------+----------------------------------+
             # File: ./tests/schemas/broken/invalid_schema.yml
-            # Schema file ./tests/schemas/broken/invalid_schema.yml
+            # Schema file is "./tests/schemas/broken/invalid_schema.yml"
             name: ''
             description: ''
             presets: []

--- a/tests/SchemaPresetTest.php
+++ b/tests/SchemaPresetTest.php
@@ -749,7 +749,7 @@ final class SchemaPresetTest extends TestCase
     public function testInvalidPresetFile(): void
     {
         $this->expectExceptionMessage(
-            "Invalid schema \"_custom_array_\" data.\n" .
+            "Invalid schema \"undefined\" data.\n" .
             'Unexpected error: "Unknown included file: "invalid.yml""',
         );
 

--- a/tests/Tools.php
+++ b/tests/Tools.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace JBZoo\PHPUnit;
 
 use JBZoo\Cli\CliApplication;
+use JBZoo\CsvBlueprint\Commands\CreateSchema;
 use JBZoo\CsvBlueprint\Commands\ValidateCsv;
 use JBZoo\CsvBlueprint\Commands\ValidateSchema;
 use JBZoo\Utils\Cli;
@@ -57,6 +58,7 @@ final class Tools
         $application = new CliApplication();
         $application->add(new ValidateCsv());
         $application->add(new ValidateSchema());
+        $application->add(new CreateSchema());
         $command = $application->find($action);
 
         $buffer = new BufferedOutput();

--- a/tests/Validators/CsvValidatorTest.php
+++ b/tests/Validators/CsvValidatorTest.php
@@ -116,7 +116,7 @@ final class CsvValidatorTest extends TestCase
     {
         $csv = new CsvFile(Tools::CSV_COMPLEX, Tools::getRule(null, 'not_empty', true));
         isSame(
-            '"csv.header" at line 1, column "0:". Property "name" is not defined in schema: "_custom_array_".',
+            '"csv.header" at line 1, column "0:". Property "name" is not defined in schema: "undefined".',
             $csv->validate()->render(cleanOutput: true),
         );
     }

--- a/tests/schemas/todo.yml
+++ b/tests/schemas/todo.yml
@@ -15,7 +15,7 @@
 
 csv: # How to parse file before validation
   auto_detect: false                  # If true, then the control chars will be detected automatically.
-  empty_values:                       # List of values that will be treated as empty
+  empty_values: # List of values that will be treated as empty
     - ""                              # By default, only empty string is treated as empty (string length = 0).
     - null
     - none
@@ -33,7 +33,7 @@ structural_rules:
 
 
 columns:
-  - empty_values: ['']                # Override csv.empty_values. List of values that will be treated as empty.
+  - empty_values: [ '' ]                # Override csv.empty_values. List of values that will be treated as empty.
 
     # Multi prop
     multiple: true
@@ -43,6 +43,11 @@ columns:
     rules:
       is_null: true                   # see csv.empty_values and column.empty_values
       _list: true                     # Example: starts_with_list: [ 'a', 'b', 'c' ]
+
+      # File system
+      is_filename: true
+      is_dirname: true
+      is_realtive_path: true
 
       # identifier
       is_bsn: true                    # Validates a Dutch citizen service number (BSN).
@@ -125,13 +130,139 @@ complex_rules:
 
     # Logical OR for group of rules. If one of the rules is true, then the column is valid.
   - group_or:
-    - count_by_group:
-        group_column: City
-        value: New York
-        count: 10
-    - sum_by_group:
-        group_column: City
-        sum_column: population
-        sums:
-          - [ New York, 10000 ]
-          - [ Los Angeles, 20000 ]
+      - count_by_group:
+          group_column: City
+          value: New York
+          count: 10
+      - sum_by_group:
+          group_column: City
+          sum_column: population
+          sums:
+            - [ New York, 10000 ]
+            - [ Los Angeles, 20000 ]
+
+analyser:
+  name: 'Based on file ...'
+  description: 'Based on file ...'
+  csv:
+    header: true
+    delimiter: ,
+    quote_char: \
+    enclosure: '"'
+    encoding: utf-8
+    bom: false
+  structural_rules:
+    strict_column_order: true
+    allow_extra_columns: false
+  rules:
+    strings:
+      - not_empty
+      - exact_value
+      - allow_values # 2<= x <= 10 values
+      - length_min
+      - length
+      - length_max
+      - is_trimmed
+      - is_lowercase
+      - is_uppercase
+      - is_capitalize
+      - word_count_min
+      - word_count
+      - word_count_max
+
+    is_int|is_float:
+      - num_min
+      - num
+      - num_max
+      - precision_min
+      - precision
+      - precision_max
+
+    is_date:
+      - date_min
+      - date
+      - date_max
+      - date_format
+      - is_timezone
+      - is_timezone_offset
+      - is_time
+      - is_leap_year
+      - date_age_min
+      - date_age
+      - date_age_max
+
+    is_ip:
+      - is_ip_v4
+      - is_ip_v6
+      - is_ip_private
+      - is_ip_reserved
+
+    other:
+      - is_mac_address
+      - is_bool
+      - is_binary
+      - is_octal
+      - is_hex
+      - is_uuid
+      - is_slug
+      - is_currency_code
+      - is_base64
+      - is_angle
+      - is_domain
+      - is_public_domain_suffix
+      - is_url
+      - is_email
+      - is_json
+      - is_latitude
+      - is_longitude
+      - is_geohash
+      - is_cardinal_direction
+      - is_usa_market_name
+      - country_code:
+          - alpha-2
+          - alpha-3
+          - numeric
+      - language_code:
+          - alpha-2
+          - alpha-3
+      - phone:
+          - all
+          - by_country
+      - postal_code:
+          - all
+          - by_country
+      - is_fibonacci
+      - is_prime_number
+      - is_even
+      - is_odd
+      - is_roman
+      - is_luhn
+      - is_iban
+      - is_bic
+      - is_imei
+      - is_isbn
+      - is_version
+      - is_punct
+      - is_vowel
+      - is_consonant
+      - is_alnum
+      - is_alpha
+      - is_hex_rgb_color
+      - hash:
+          - all
+          - by_algo
+      - credit_card:
+          - all
+          - by_brand
+
+  aggregate_rules:
+    - is_unique
+    - sorted:
+        - "[ asc, natural ]"
+        - "[ desc, natural ]"
+        - "[ asc, regular ]"
+        - "[ desc, regular ]"
+        - "[ asc, numeric ]"
+        - "[ desc, numeric ]"
+        - "[ asc, string ]"
+        - "[ desc, string ]"


### PR DESCRIPTION
Introduced a new command 'create:schema' which is capable of analyzing CSV files and suggests a schema based on the data. The file provides options to specify exactly which CSV files should be analyzed. This improvement enhances application's ability to validate data and schema interactions effectively.