### PR TITLE
Fix typos in class references

### DIFF
--- a/src/Rules/AbstractRule.php
+++ b/src/Rules/AbstractRule.php
@@ -22,7 +22,7 @@ use JBZoo\CsvBlueprint\Validators\ValidatorColumn;
 
 use function JBZoo\Utils\bool;
 
-abstract class AbstarctRule
+abstract class AbstractRule
 {
     public const INPUT_TYPE = self::INPUT_TYPE_UNDEF;
 

--- a/src/Rules/AbstractRuleCombo.php
+++ b/src/Rules/AbstractRuleCombo.php
@@ -21,7 +21,7 @@ use JBZoo\CsvBlueprint\Rules\Cell\AbstractCellRuleCombo;
 use JBZoo\CsvBlueprint\Validators\Error;
 use JBZoo\CsvBlueprint\Validators\ValidatorColumn;
 
-abstract class AbstarctRuleCombo extends AbstarctRule
+abstract class AbstractRuleCombo extends AbstractRule
 {
     protected const NAME = 'UNDEFINED';
 

--- a/src/Rules/Aggregate/AbstractAggregateRule.php
+++ b/src/Rules/Aggregate/AbstractAggregateRule.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
-abstract class AbstractAggregateRule extends AbstarctRule
+abstract class AbstractAggregateRule extends AbstractRule
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_STRINGS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_STRINGS;
 
     /**
      * Validate the rule.

--- a/src/Rules/Aggregate/AbstractAggregateRuleCombo.php
+++ b/src/Rules/Aggregate/AbstractAggregateRuleCombo.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
-use JBZoo\CsvBlueprint\Rules\AbstarctRuleCombo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRuleCombo;
 
-abstract class AbstractAggregateRuleCombo extends AbstarctRuleCombo
+abstract class AbstractAggregateRuleCombo extends AbstractRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_STRINGS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_STRINGS;
 
     abstract protected function getActualAggregate(array $colValues): ?float;
 
@@ -54,11 +54,11 @@ abstract class AbstractAggregateRuleCombo extends AbstarctRuleCombo
 
         try {
             // TODO: Think about the performance optimization here
-            if (static::INPUT_TYPE === AbstarctRule::INPUT_TYPE_FLOATS) {
+            if (static::INPUT_TYPE === AbstractRule::INPUT_TYPE_FLOATS) {
                 $colValues = \array_map('floatval', $colValues);
             }
 
-            if (static::INPUT_TYPE === AbstarctRule::INPUT_TYPE_INTS) {
+            if (static::INPUT_TYPE === AbstractRule::INPUT_TYPE_INTS) {
                 $colValues = \array_map('intval', $colValues);
             }
 

--- a/src/Rules/Aggregate/ComboAverage.php
+++ b/src/Rules/Aggregate/ComboAverage.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use MathPHP\Statistics\Average;
 
 final class ComboAverage extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'average';
 

--- a/src/Rules/Aggregate/ComboCoefOfVar.php
+++ b/src/Rules/Aggregate/ComboCoefOfVar.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use MathPHP\Statistics\Descriptive;
 
 final class ComboCoefOfVar extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'Coefficient of variation';
 

--- a/src/Rules/Aggregate/ComboContraharmonicMean.php
+++ b/src/Rules/Aggregate/ComboContraharmonicMean.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use MathPHP\Statistics\Average;
 
 final class ComboContraharmonicMean extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'contraharmonic mean';
 

--- a/src/Rules/Aggregate/ComboCount.php
+++ b/src/Rules/Aggregate/ComboCount.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
 final class ComboCount extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_COUNTER;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_COUNTER;
 
     protected const NAME = 'number of rows';
 

--- a/src/Rules/Aggregate/ComboCountDistinct.php
+++ b/src/Rules/Aggregate/ComboCountDistinct.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
 final class ComboCountDistinct extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_STRINGS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_STRINGS;
 
     protected const NAME = 'number of unique values';
 

--- a/src/Rules/Aggregate/ComboCountEmpty.php
+++ b/src/Rules/Aggregate/ComboCountEmpty.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
 final class ComboCountEmpty extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_STRINGS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_STRINGS;
 
     protected const NAME = 'number of empty rows';
 

--- a/src/Rules/Aggregate/ComboCountEven.php
+++ b/src/Rules/Aggregate/ComboCountEven.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
 final class ComboCountEven extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_INTS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_INTS;
 
     protected const NAME = 'number of even values';
 

--- a/src/Rules/Aggregate/ComboCountNegative.php
+++ b/src/Rules/Aggregate/ComboCountNegative.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
 final class ComboCountNegative extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_INTS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_INTS;
 
     protected const NAME = 'number of negative values';
 

--- a/src/Rules/Aggregate/ComboCountNotEmpty.php
+++ b/src/Rules/Aggregate/ComboCountNotEmpty.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
 final class ComboCountNotEmpty extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_STRINGS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_STRINGS;
 
     protected const NAME = 'number of not empty rows';
 

--- a/src/Rules/Aggregate/ComboCountOdd.php
+++ b/src/Rules/Aggregate/ComboCountOdd.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
 final class ComboCountOdd extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_INTS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_INTS;
 
     protected const NAME = 'number of odd values';
 

--- a/src/Rules/Aggregate/ComboCountPositive.php
+++ b/src/Rules/Aggregate/ComboCountPositive.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
 final class ComboCountPositive extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_INTS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_INTS;
 
     protected const NAME = 'number of positive values';
 

--- a/src/Rules/Aggregate/ComboCountPrime.php
+++ b/src/Rules/Aggregate/ComboCountPrime.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use Respect\Validation\Validator;
 
 final class ComboCountPrime extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_INTS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_INTS;
 
     protected const NAME = 'number of prime values';
 

--- a/src/Rules/Aggregate/ComboCountZero.php
+++ b/src/Rules/Aggregate/ComboCountZero.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
 final class ComboCountZero extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_INTS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_INTS;
 
     protected const NAME = 'number of zero values';
 

--- a/src/Rules/Aggregate/ComboCubicMean.php
+++ b/src/Rules/Aggregate/ComboCubicMean.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use MathPHP\Statistics\Average;
 
 final class ComboCubicMean extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'cubic mean';
 

--- a/src/Rules/Aggregate/ComboFirstNum.php
+++ b/src/Rules/Aggregate/ComboFirstNum.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
 final class ComboFirstNum extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'first value';
 

--- a/src/Rules/Aggregate/ComboGeometricMean.php
+++ b/src/Rules/Aggregate/ComboGeometricMean.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use MathPHP\Statistics\Average;
 
 final class ComboGeometricMean extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'geometric mean';
 

--- a/src/Rules/Aggregate/ComboHarmonicMean.php
+++ b/src/Rules/Aggregate/ComboHarmonicMean.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use MathPHP\Statistics\Average;
 
 final class ComboHarmonicMean extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'harmonic mean';
 

--- a/src/Rules/Aggregate/ComboInterquartileMean.php
+++ b/src/Rules/Aggregate/ComboInterquartileMean.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use MathPHP\Statistics\Average;
 
 final class ComboInterquartileMean extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'interquartile mean (IQM)';
 

--- a/src/Rules/Aggregate/ComboLastNum.php
+++ b/src/Rules/Aggregate/ComboLastNum.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
 final class ComboLastNum extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'last value';
 

--- a/src/Rules/Aggregate/ComboMeanAbsDev.php
+++ b/src/Rules/Aggregate/ComboMeanAbsDev.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use MathPHP\Statistics\Descriptive;
 
 final class ComboMeanAbsDev extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'MAD';
 

--- a/src/Rules/Aggregate/ComboMedian.php
+++ b/src/Rules/Aggregate/ComboMedian.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use MathPHP\Statistics\Average;
 
 final class ComboMedian extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'median';
 

--- a/src/Rules/Aggregate/ComboMedianAbsDev.php
+++ b/src/Rules/Aggregate/ComboMedianAbsDev.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use MathPHP\Statistics\Descriptive;
 
 final class ComboMedianAbsDev extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'MAD';
 

--- a/src/Rules/Aggregate/ComboMidhinge.php
+++ b/src/Rules/Aggregate/ComboMidhinge.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use MathPHP\Statistics\Descriptive;
 
 final class ComboMidhinge extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'midhinge';
 

--- a/src/Rules/Aggregate/ComboNthNum.php
+++ b/src/Rules/Aggregate/ComboNthNum.php
@@ -16,13 +16,13 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
 use function JBZoo\Utils\float;
 
 final class ComboNthNum extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'N-th value';
 

--- a/src/Rules/Aggregate/ComboPercentile.php
+++ b/src/Rules/Aggregate/ComboPercentile.php
@@ -16,14 +16,14 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use MathPHP\Statistics\Descriptive;
 
 use function JBZoo\Utils\float;
 
 final class ComboPercentile extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'percentile';
 

--- a/src/Rules/Aggregate/ComboPopulationVariance.php
+++ b/src/Rules/Aggregate/ComboPopulationVariance.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use MathPHP\Statistics\Descriptive;
 
 final class ComboPopulationVariance extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'population variance';
 

--- a/src/Rules/Aggregate/ComboQuartiles.php
+++ b/src/Rules/Aggregate/ComboQuartiles.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use JBZoo\CsvBlueprint\Utils;
 use MathPHP\Statistics\Descriptive;
 
@@ -24,7 +24,7 @@ use function JBZoo\Utils\float;
 
 final class ComboQuartiles extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'quartile';
 

--- a/src/Rules/Aggregate/ComboRootMeanSquare.php
+++ b/src/Rules/Aggregate/ComboRootMeanSquare.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use MathPHP\Statistics\Average;
 
 final class ComboRootMeanSquare extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'root mean square (quadratic mean)';
 

--- a/src/Rules/Aggregate/ComboSampleVariance.php
+++ b/src/Rules/Aggregate/ComboSampleVariance.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use MathPHP\Statistics\Descriptive;
 
 final class ComboSampleVariance extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'population variance';
 

--- a/src/Rules/Aggregate/ComboStddev.php
+++ b/src/Rules/Aggregate/ComboStddev.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use MathPHP\Statistics\Descriptive;
 
 final class ComboStddev extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'StdDev';
 

--- a/src/Rules/Aggregate/ComboStddevPop.php
+++ b/src/Rules/Aggregate/ComboStddevPop.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use MathPHP\Statistics\Descriptive;
 
 final class ComboStddevPop extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'standard deviation (SD+)';
 

--- a/src/Rules/Aggregate/ComboSum.php
+++ b/src/Rules/Aggregate/ComboSum.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
 final class ComboSum extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'sum of numbers';
 

--- a/src/Rules/Aggregate/ComboTrimean.php
+++ b/src/Rules/Aggregate/ComboTrimean.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use MathPHP\Statistics\Average;
 
 final class ComboTrimean extends AbstractAggregateRuleCombo
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_FLOATS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_FLOATS;
 
     protected const NAME = 'trimean';
 

--- a/src/Rules/Aggregate/First.php
+++ b/src/Rules/Aggregate/First.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
 final class First extends AbstractAggregateRule
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_STRINGS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_STRINGS;
 
     public function getHelpMeta(): array
     {

--- a/src/Rules/Aggregate/FirstNot.php
+++ b/src/Rules/Aggregate/FirstNot.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
 final class FirstNot extends AbstractAggregateRule
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_STRINGS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_STRINGS;
 
     public function getHelpMeta(): array
     {

--- a/src/Rules/Aggregate/IsUnique.php
+++ b/src/Rules/Aggregate/IsUnique.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
 final class IsUnique extends AbstractAggregateRule
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_STRINGS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_STRINGS;
 
     public function getHelpMeta(): array
     {

--- a/src/Rules/Aggregate/Last.php
+++ b/src/Rules/Aggregate/Last.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
 final class Last extends AbstractAggregateRule
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_STRINGS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_STRINGS;
 
     public function getHelpMeta(): array
     {

--- a/src/Rules/Aggregate/LastNot.php
+++ b/src/Rules/Aggregate/LastNot.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
 final class LastNot extends AbstractAggregateRule
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_STRINGS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_STRINGS;
 
     public function getHelpMeta(): array
     {

--- a/src/Rules/Aggregate/Nth.php
+++ b/src/Rules/Aggregate/Nth.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
 final class Nth extends AbstractAggregateRule
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_STRINGS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_STRINGS;
 
     private const ARGS = 2;
     private const NTH = 0;

--- a/src/Rules/Aggregate/NthNot.php
+++ b/src/Rules/Aggregate/NthNot.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
 final class NthNot extends AbstractAggregateRule
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_STRINGS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_STRINGS;
 
     private const ARGS = 2;
     private const NTH = 0;

--- a/src/Rules/Aggregate/Sorted.php
+++ b/src/Rules/Aggregate/Sorted.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use JBZoo\CsvBlueprint\Utils;
 
 final class Sorted extends AbstractAggregateRule
 {
-    public const INPUT_TYPE = AbstarctRule::INPUT_TYPE_STRINGS;
+    public const INPUT_TYPE = AbstractRule::INPUT_TYPE_STRINGS;
 
     private const ARGS = 2;
     private const DIR = 0;

--- a/src/Rules/Cell/AbstractCellRule.php
+++ b/src/Rules/Cell/AbstractCellRule.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Cell;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 
 /**
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  */
-abstract class AbstractCellRule extends AbstarctRule
+abstract class AbstractCellRule extends AbstractRule
 {
     /**
      * Validate the rule.

--- a/src/Rules/Cell/AbstractCellRuleCombo.php
+++ b/src/Rules/Cell/AbstractCellRuleCombo.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules\Cell;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRuleCombo;
+use JBZoo\CsvBlueprint\Rules\AbstractRuleCombo;
 
-abstract class AbstractCellRuleCombo extends AbstarctRuleCombo
+abstract class AbstractCellRuleCombo extends AbstractRuleCombo
 {
     abstract protected function getActualCell(string $cellValue): float;
 

--- a/src/Rules/DocBuilder.php
+++ b/src/Rules/DocBuilder.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Rules;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Rule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Rule;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboCount;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboCountDistinct;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboCountEmpty;
@@ -103,7 +103,7 @@ final class DocBuilder
             $topComment = "{$leftPad}# " . \implode("\n{$leftPad}# ", $this->topHelp);
         }
 
-        if ($this->rule instanceof AbstarctRuleCombo) {
+        if ($this->rule instanceof AbstractRuleCombo) {
             return \implode("\n", [
                 $topComment,
                 self::renderLine($this->ymlRuleCode, $this->options[Rule::MIN], Rule::MIN),

--- a/src/Rules/Ruleset.php
+++ b/src/Rules/Ruleset.php
@@ -22,7 +22,7 @@ use JBZoo\CsvBlueprint\Validators\ErrorSuite;
 
 final class Ruleset
 {
-    /** @var AbstarctRule[] */
+    /** @var AbstractRule[] */
     private array  $rules;
     private string $columnNameId;
 
@@ -66,7 +66,7 @@ final class Ruleset
     public function ruleDiscovery(
         string $origRuleName,
         null|array|bool|float|int|string $options = null,
-    ): ?AbstarctRule {
+    ): ?AbstractRule {
         $mode = AbstractCellRuleCombo::parseMode($origRuleName);
         $noCombo = \preg_replace("/(_{$mode})\$/", '', $origRuleName);
 
@@ -98,7 +98,7 @@ final class Ruleset
     public function getAggregationInputType(): int
     {
         if (\count($this->intputTypes) === 0) {
-            return AbstarctRule::INPUT_TYPE_UNDEF;
+            return AbstractRule::INPUT_TYPE_UNDEF;
         }
 
         return \max($this->intputTypes);
@@ -112,7 +112,7 @@ final class Ruleset
         string $posibleClassName,
         null|array|bool|float|int|string $options,
         string $mode,
-    ): ?AbstarctRule {
+    ): ?AbstractRule {
         if (\class_exists($posibleClassName)) {
             // @phpstan-ignore-next-line
             return new $posibleClassName($this->columnNameId, $options, $mode);

--- a/src/Validators/ValidatorColumn.php
+++ b/src/Validators/ValidatorColumn.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace JBZoo\CsvBlueprint\Validators;
 
 use JBZoo\CsvBlueprint\Csv\Column;
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use JBZoo\CsvBlueprint\Rules\Ruleset;
 
 final class ValidatorColumn
@@ -55,15 +55,15 @@ final class ValidatorColumn
      */
     public static function prepareValue(string $cellValue, int $aggInputType): null|float|int|string
     {
-        if ($aggInputType === AbstarctRule::INPUT_TYPE_COUNTER) {
+        if ($aggInputType === AbstractRule::INPUT_TYPE_COUNTER) {
             return null;
         }
 
-        if ($aggInputType === AbstarctRule::INPUT_TYPE_INTS) {
+        if ($aggInputType === AbstractRule::INPUT_TYPE_INTS) {
             return (int)$cellValue;
         }
 
-        if ($aggInputType === AbstarctRule::INPUT_TYPE_FLOATS) {
+        if ($aggInputType === AbstractRule::INPUT_TYPE_FLOATS) {
             return (float)$cellValue;
         }
 

--- a/src/Validators/ValidatorCsv.php
+++ b/src/Validators/ValidatorCsv.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace JBZoo\CsvBlueprint\Validators;
 
 use JBZoo\CsvBlueprint\Csv\CsvFile;
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
 use JBZoo\CsvBlueprint\Schema;
 use JBZoo\CsvBlueprint\Utils;
 
@@ -147,7 +147,7 @@ final class ValidatorCsv
                 $aggInputType = $colValidator->getAggregationInputType();
                 Utils::debug("{$messPrefix} Aggregation Flag: {$aggInputType}");
             } else {
-                $aggInputType = AbstarctRule::INPUT_TYPE_UNDEF;
+                $aggInputType = AbstractRule::INPUT_TYPE_UNDEF;
             }
 
             if (!$isAggRules && !$isRules) { // Time optimization

--- a/tests/Rules/Aggregate/ComboAverageTest.php
+++ b/tests/Rules/Aggregate/ComboAverageTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboAverage;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboCoefOfVarTest.php
+++ b/tests/Rules/Aggregate/ComboCoefOfVarTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboCoefOfVar;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboContraharmonicMeanTest.php
+++ b/tests/Rules/Aggregate/ComboContraharmonicMeanTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboContraharmonicMean;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboCountDistinctTest.php
+++ b/tests/Rules/Aggregate/ComboCountDistinctTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboCountDistinct;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboCountEmptyTest.php
+++ b/tests/Rules/Aggregate/ComboCountEmptyTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboCountEmpty;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboCountEvenTest.php
+++ b/tests/Rules/Aggregate/ComboCountEvenTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboCountEven;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboCountNegativeTest.php
+++ b/tests/Rules/Aggregate/ComboCountNegativeTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboCountNegative;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboCountNotEmptyTest.php
+++ b/tests/Rules/Aggregate/ComboCountNotEmptyTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboCountNotEmpty;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboCountOddTest.php
+++ b/tests/Rules/Aggregate/ComboCountOddTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboCountOdd;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboCountPositiveTest.php
+++ b/tests/Rules/Aggregate/ComboCountPositiveTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboCountPositive;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboCountPrimeTest.php
+++ b/tests/Rules/Aggregate/ComboCountPrimeTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboCountPrime;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 use JBZoo\PHPUnit\Tools;

--- a/tests/Rules/Aggregate/ComboCountTest.php
+++ b/tests/Rules/Aggregate/ComboCountTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboCount;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboCountZeroTest.php
+++ b/tests/Rules/Aggregate/ComboCountZeroTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboCountZero;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboCubicMeanTest.php
+++ b/tests/Rules/Aggregate/ComboCubicMeanTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboCubicMean;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboFirstNumTest.php
+++ b/tests/Rules/Aggregate/ComboFirstNumTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboFirstNum;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboGeometricMeanTest.php
+++ b/tests/Rules/Aggregate/ComboGeometricMeanTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboGeometricMean;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboHarmonicMeanTest.php
+++ b/tests/Rules/Aggregate/ComboHarmonicMeanTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboHarmonicMean;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboInterquartileMeanTest.php
+++ b/tests/Rules/Aggregate/ComboInterquartileMeanTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboInterquartileMean;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboLastNumTest.php
+++ b/tests/Rules/Aggregate/ComboLastNumTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboLastNum;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboMeanAbsDevTest.php
+++ b/tests/Rules/Aggregate/ComboMeanAbsDevTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboMeanAbsDev;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboMedianAbsDevTest.php
+++ b/tests/Rules/Aggregate/ComboMedianAbsDevTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboMedianAbsDev;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboMedianTest.php
+++ b/tests/Rules/Aggregate/ComboMedianTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboMedian;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 use JBZoo\PHPUnit\Tools;

--- a/tests/Rules/Aggregate/ComboMidhingeTest.php
+++ b/tests/Rules/Aggregate/ComboMidhingeTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboMidhinge;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 use JBZoo\PHPUnit\Tools;

--- a/tests/Rules/Aggregate/ComboNthNumTest.php
+++ b/tests/Rules/Aggregate/ComboNthNumTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboNthNum;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboPercentileTest.php
+++ b/tests/Rules/Aggregate/ComboPercentileTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboPercentile;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 use JBZoo\PHPUnit\Tools;

--- a/tests/Rules/Aggregate/ComboPopulationVarianceTest.php
+++ b/tests/Rules/Aggregate/ComboPopulationVarianceTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboPopulationVariance;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboQuartilesTest.php
+++ b/tests/Rules/Aggregate/ComboQuartilesTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboQuartiles;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 use JBZoo\PHPUnit\Tools;

--- a/tests/Rules/Aggregate/ComboRootMeanSquareTest.php
+++ b/tests/Rules/Aggregate/ComboRootMeanSquareTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboRootMeanSquare;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboSampleVarianceTest.php
+++ b/tests/Rules/Aggregate/ComboSampleVarianceTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboSampleVariance;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboStdDevTest.php
+++ b/tests/Rules/Aggregate/ComboStdDevTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboStddev;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboStddevPopTest.php
+++ b/tests/Rules/Aggregate/ComboStddevPopTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboStddevPop;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboSumTest.php
+++ b/tests/Rules/Aggregate/ComboSumTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboSum;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Aggregate/ComboTrimeanTest.php
+++ b/tests/Rules/Aggregate/ComboTrimeanTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Aggregate;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Aggregate\ComboTrimean;
 use JBZoo\PHPUnit\Rules\TestAbstractAggregateRuleCombo;
 

--- a/tests/Rules/Cell/ComboDateAgeTest.php
+++ b/tests/Rules/Cell/ComboDateAgeTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Cell;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Cell\ComboDateAge;
 use JBZoo\PHPUnit\Rules\TestAbstractCellRuleCombo;
 

--- a/tests/Rules/Cell/ComboDateIntervalTest.php
+++ b/tests/Rules/Cell/ComboDateIntervalTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Cell;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Cell\ComboDateInterval;
 use JBZoo\PHPUnit\Rules\TestAbstractCellRuleCombo;
 

--- a/tests/Rules/Cell/ComboDateTest.php
+++ b/tests/Rules/Cell/ComboDateTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Cell;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Cell\ComboDate;
 use JBZoo\PHPUnit\Rules\TestAbstractCellRuleCombo;
 

--- a/tests/Rules/Cell/ComboLengthTest.php
+++ b/tests/Rules/Cell/ComboLengthTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Cell;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Cell\ComboLength;
 use JBZoo\PHPUnit\Rules\TestAbstractCellRuleCombo;
 

--- a/tests/Rules/Cell/ComboNumTest.php
+++ b/tests/Rules/Cell/ComboNumTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Cell;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Cell\ComboNum;
 use JBZoo\PHPUnit\Rules\TestAbstractCellRuleCombo;
 

--- a/tests/Rules/Cell/ComboPasswordStrengthTest.php
+++ b/tests/Rules/Cell/ComboPasswordStrengthTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Cell;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Cell\ComboPasswordStrength;
 use JBZoo\PHPUnit\Rules\TestAbstractCellRuleCombo;
 

--- a/tests/Rules/Cell/ComboPrecisionTest.php
+++ b/tests/Rules/Cell/ComboPrecisionTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Cell;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Cell\ComboPrecision;
 use JBZoo\PHPUnit\Rules\TestAbstractCellRuleCombo;
 

--- a/tests/Rules/Cell/ComboTest.php
+++ b/tests/Rules/Cell/ComboTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Cell;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Cell\ComboNum;
 use JBZoo\PHPUnit\Rules\TestAbstractCellRuleCombo;
 

--- a/tests/Rules/Cell/ComboWordCountTest.php
+++ b/tests/Rules/Cell/ComboWordCountTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules\Cell;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\CsvBlueprint\Rules\Cell\ComboWordCount;
 use JBZoo\PHPUnit\Rules\TestAbstractCellRuleCombo;
 

--- a/tests/Rules/TestAbstractAggregateRule.php
+++ b/tests/Rules/TestAbstractAggregateRule.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule;
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\PHPUnit\TestCase;
 use JBZoo\PHPUnit\Tools;
 use JBZoo\Utils\Str;
@@ -46,7 +46,7 @@ abstract class TestAbstractAggregateRule extends TestCase
 
     public function testInputType(): void
     {
-        isNotSame(AbstarctRule::INPUT_TYPE_UNDEF, $this->create(true)->getInputType());
+        isNotSame(AbstractRule::INPUT_TYPE_UNDEF, $this->create(true)->getInputType());
     }
 
     public function testBoolenOptionFlag(): void

--- a/tests/Rules/TestAbstractAggregateRuleCombo.php
+++ b/tests/Rules/TestAbstractAggregateRuleCombo.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\PHPUnit\TestCase;
 use JBZoo\PHPUnit\Tools;
 use JBZoo\Utils\Str;

--- a/tests/Rules/TestAbstractCellRuleCombo.php
+++ b/tests/Rules/TestAbstractCellRuleCombo.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\PHPUnit\Rules;
 
-use JBZoo\CsvBlueprint\Rules\AbstarctRule as Combo;
+use JBZoo\CsvBlueprint\Rules\AbstractRule as Combo;
 use JBZoo\PHPUnit\TestCase;
 use JBZoo\PHPUnit\Tools;
 


### PR DESCRIPTION
This commit corrects spelling mistakes which were present in class references throughout the codebase. The typing error `AbstarctRule` has been replaced with `AbstractRule`. Stupid typo... :(