### PR TITLE
Remove character length limit in IsFloat and IsInt test functions

### DIFF
--- a/src/Rules/Cell/IsFloat.php
+++ b/src/Rules/Cell/IsFloat.php
@@ -45,11 +45,6 @@ final class IsFloat extends AbstractCellRule
 
     public static function testValue(string $cellValue): bool
     {
-        $maxLimit = 18;
-        if (\strlen($cellValue) > $maxLimit) {
-            return false;
-        }
-
         return Validator::floatVal()->validate($cellValue);
     }
 }

--- a/src/Rules/Cell/IsInt.php
+++ b/src/Rules/Cell/IsInt.php
@@ -45,11 +45,6 @@ final class IsInt extends AbstractCellRule
 
     public static function testValue(string $cellValue): bool
     {
-        $maxLimit = 19;
-        if (\strlen($cellValue) > $maxLimit) {
-            return false;
-        }
-
         return Validator::intVal()->validate($cellValue);
     }
 }


### PR DESCRIPTION
The character length constraints previously set on the testValue method in the IsFloat and IsInt classes have been removed. This change ensures that the functions can validate floats and integers of any length.