### PR TITLE
Add `is_usa_state` validation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 <!-- auto-update:/top-badges -->
 
 <!-- auto-update:rules-counter -->
-[![Static Badge](https://img.shields.io/badge/Rules-340-green?label=Total%20number%20of%20rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)
-[![Static Badge](https://img.shields.io/badge/Rules-126-green?label=Cell%20rules&labelColor=blue&color=gray)](src/Rules/Cell)
+[![Static Badge](https://img.shields.io/badge/Rules-341-green?label=Total%20number%20of%20rules&labelColor=darkgreen&color=gray)](schema-examples/full.yml)
+[![Static Badge](https://img.shields.io/badge/Rules-127-green?label=Cell%20rules&labelColor=blue&color=gray)](src/Rules/Cell)
 [![Static Badge](https://img.shields.io/badge/Rules-206-green?label=Aggregate%20rules&labelColor=blue&color=gray)](src/Rules/Aggregate)
 [![Static Badge](https://img.shields.io/badge/Rules-8-green?label=Extra%20checks&labelColor=blue&color=gray)](#extra-checks)
 [![Static Badge](https://img.shields.io/badge/Rules-22/11/20-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
@@ -506,6 +506,7 @@ columns:
       is_geohash: true                  # Check if the value is a valid geohash. Example: "u4pruydqqvj".
       is_cardinal_direction: true       # Valid cardinal direction. Case-insensitive. Available values: ["N", "S", "E", "W", "NE", "SE", "NW", "SW", "NONE"]
       is_usa_market_name: true          # Check if the value is a valid USA market name. Example: "New York, NY".
+      is_usa_state: true                # Name or code of USA state name. Case-insensitive. Example: "CA" or "California".
 
       # Validates whether the input is a country code in ISO 3166-1 standard.
       # Available options: "alpha-2" (Ex: "US"), "alpha-3" (Ex: "USA"), "numeric" (Ex: "840").

--- a/schema-examples/full.json
+++ b/schema-examples/full.json
@@ -148,6 +148,7 @@
                 "is_geohash"                : true,
                 "is_cardinal_direction"     : true,
                 "is_usa_market_name"        : true,
+                "is_usa_state"              : true,
 
                 "country_code"              : "alpha-2",
                 "language_code"             : "alpha-2",

--- a/schema-examples/full.php
+++ b/schema-examples/full.php
@@ -169,6 +169,7 @@ This example serves as a comprehensive guide for creating robust CSV file valida
                 'is_geohash'            => true,
                 'is_cardinal_direction' => true,
                 'is_usa_market_name'    => true,
+                'is_usa_state'          => true,
 
                 'country_code'  => 'alpha-2',
                 'language_code' => 'alpha-2',

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -231,6 +231,7 @@ columns:
       is_geohash: true                  # Check if the value is a valid geohash. Example: "u4pruydqqvj".
       is_cardinal_direction: true       # Valid cardinal direction. Case-insensitive. Available values: ["N", "S", "E", "W", "NE", "SE", "NW", "SW", "NONE"]
       is_usa_market_name: true          # Check if the value is a valid USA market name. Example: "New York, NY".
+      is_usa_state: true                # Name or code of USA state name. Case-insensitive. Example: "CA" or "California".
 
       # Validates whether the input is a country code in ISO 3166-1 standard.
       # Available options: "alpha-2" (Ex: "US"), "alpha-3" (Ex: "USA"), "numeric" (Ex: "840").

--- a/schema-examples/full_clean.yml
+++ b/schema-examples/full_clean.yml
@@ -164,6 +164,7 @@ columns:
       is_geohash: true
       is_cardinal_direction: true
       is_usa_market_name: true
+      is_usa_state: true
       country_code: alpha-2
       language_code: alpha-2
 

--- a/src/Rules/Cell/IsUsaState.php
+++ b/src/Rules/Cell/IsUsaState.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\CsvBlueprint\Rules\Cell;
+
+final class IsUsaState extends AbstractCellRule
+{
+    public function getHelpMeta(): array
+    {
+        return [
+            [],
+            [
+                self::DEFAULT => [
+                    'true',
+                    'Name or code of USA state name. Case-insensitive. ' .
+                    'Example: "CA" or "California".',
+                ],
+            ],
+        ];
+    }
+
+    public function validateRule(string $cellValue): ?string
+    {
+        if ($cellValue === '') {
+            return null;
+        }
+
+        if (!self::testValue($cellValue)) {
+            return "Value \"<c>{$cellValue}</c>\" is not a valid USA state name or code";
+        }
+
+        return null;
+    }
+
+    public static function testValue(string $cellValue): bool
+    {
+        return \in_array(\strtoupper($cellValue), self::getOptions(), true)
+            || \in_array(\strtoupper($cellValue), \array_keys(self::getOptions()), true);
+    }
+
+    private static function getOptions(): array
+    {
+        return [
+            'AL' => 'ALABAMA',
+            'AK' => 'ALASKA',
+            'AZ' => 'ARIZONA',
+            'AR' => 'ARKANSAS',
+            'CA' => 'CALIFORNIA',
+            'CO' => 'COLORADO',
+            'CT' => 'CONNECTICUT',
+            'DE' => 'DELAWARE',
+            'FL' => 'FLORIDA',
+            'GA' => 'GEORGIA',
+            'HI' => 'HAWAII',
+            'ID' => 'IDAHO',
+            'IL' => 'ILLINOIS',
+            'IN' => 'INDIANA',
+            'IA' => 'IOWA',
+            'KS' => 'KANSAS',
+            'KY' => 'KENTUCKY',
+            'LA' => 'LOUISIANA',
+            'ME' => 'MAINE',
+            'MD' => 'MARYLAND',
+            'MA' => 'MASSACHUSETTS',
+            'MI' => 'MICHIGAN',
+            'MN' => 'MINNESOTA',
+            'MS' => 'MISSISSIPPI',
+            'MO' => 'MISSOURI',
+            'MT' => 'MONTANA',
+            'NE' => 'NEBRASKA',
+            'NV' => 'NEVADA',
+            'NH' => 'NEW HAMPSHIRE',
+            'NJ' => 'NEW JERSEY',
+            'NM' => 'NEW MEXICO',
+            'NY' => 'NEW YORK',
+            'NC' => 'NORTH CAROLINA',
+            'ND' => 'NORTH DAKOTA',
+            'OH' => 'OHIO',
+            'OK' => 'OKLAHOMA',
+            'OR' => 'OREGON',
+            'PA' => 'PENNSYLVANIA',
+            'RI' => 'RHODE ISLAND',
+            'SC' => 'SOUTH CAROLINA',
+            'SD' => 'SOUTH DAKOTA',
+            'TN' => 'TENNESSEE',
+            'TX' => 'TEXAS',
+            'UT' => 'UTAH',
+            'VT' => 'VERMONT',
+            'VA' => 'VIRGINIA',
+            'WA' => 'WASHINGTON',
+            'WV' => 'WEST VIRGINIA',
+            'WI' => 'WISCONSIN',
+            'WY' => 'WYOMING',
+        ];
+    }
+}

--- a/tests/Commands/CreateSchemaTest.php
+++ b/tests/Commands/CreateSchemaTest.php
@@ -1630,6 +1630,7 @@ final class CreateSchemaTest extends TestCase
                   length: 2
                   is_trimmed: true
                   is_uppercase: true
+                  is_usa_state: true
                   is_alnum: true
                   is_alpha: true
                 aggregate_rules:

--- a/tests/Rules/Cell/IsUsaStateTest.php
+++ b/tests/Rules/Cell/IsUsaStateTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Csv-Blueprint.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Csv-Blueprint
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit\Rules\Cell;
+
+use JBZoo\CsvBlueprint\Rules\Cell\IsUsaState;
+use JBZoo\PHPUnit\Rules\TestAbstractCellRule;
+
+use function JBZoo\PHPUnit\isSame;
+
+final class IsUsaStateTest extends TestAbstractCellRule
+{
+    protected string $ruleClass = IsUsaState::class;
+
+    public function testPositive(): void
+    {
+        $rule = $this->create(true);
+        isSame('', $rule->test(''));
+        isSame('', $rule->test('NY'));
+        isSame('', $rule->test('New York'));
+
+        isSame('', $rule->test('ny'));
+        isSame('', $rule->test('new york'));
+    }
+
+    public function testNegative(): void
+    {
+        $rule = $this->create(true);
+        isSame(
+            'Value "qwe" is not a valid USA state name or code',
+            $rule->test('qwe'),
+        );
+    }
+}


### PR DESCRIPTION
This commit introduces a new validation rule to check if a value represents a valid USA state name or code.