### PR TITLE
Adjust `Utils::getVersion` to return null if version is not found

### DIFF
--- a/csv-blueprint.php
+++ b/csv-blueprint.php
@@ -43,6 +43,6 @@ if ('cli' !== \PHP_SAPI) {
 
 Utils::init();
 
-(new CliApplication('CSV Blueprint', Utils::getVersion(true)))
+(new CliApplication('CSV Blueprint', (string)Utils::getVersion(true)))
     ->registerCommandsByPath(PATH_ROOT . '/src/Commands', __NAMESPACE__)
     ->run();

--- a/src/CliApplication.php
+++ b/src/CliApplication.php
@@ -33,7 +33,8 @@ final class CliApplication extends \JBZoo\Cli\CliApplication
     public function getLongVersion(): string
     {
         $logo = '<info>' . \implode("</info>\n<info>", $this->appLogo) . '</info>';
+        $version = Utils::getVersion(true);
 
-        return "{$logo}\n" . Utils::getVersion(true);
+        return $version === null ? $logo : "{$logo}\n{$version}";
     }
 }

--- a/src/Commands/AbstractValidate.php
+++ b/src/Commands/AbstractValidate.php
@@ -86,7 +86,10 @@ abstract class AbstractValidate extends CliCommand
     {
         if ($showIntro) {
             if ($this->isHumanReadableMode()) {
-                $this->_('CSV Blueprint: ' . Utils::getVersion(true));
+                $version = Utils::getVersion(true);
+                if ($version !== null) {
+                    $this->_("CSV Blueprint: {$version}");
+                }
             }
 
             $threads = $this->getNumberOfThreads();

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -463,11 +463,11 @@ final class Utils
 
     /**
      * Retrieves the version of the software.
-     * @param  bool   $showFull Whether to display the full version information or not. Default is false.
-     * @return string the version of the software as a string, or an error message if the version file is
-     *                not found
+     * @param  bool        $showFull Whether to display the full version information or not. Default is false.
+     * @return null|string the version of the software as a string, or an error message if the version file is
+     *                     not found
      */
-    public static function getVersion(bool $showFull): string
+    public static function getVersion(bool $showFull): ?string
     {
         if (self::isPhpUnit()) {
             return 'Unknown version (PhpUnit)';
@@ -475,7 +475,7 @@ final class Utils
 
         $versionFile = __DIR__ . '/../.version';
         if (!\file_exists($versionFile)) {
-            return 'Version file not found';
+            return null;
         }
 
         return self::parseVersion((string)\file_get_contents($versionFile), $showFull);


### PR DESCRIPTION
This commit updates the Utils::getVersion method to return null when the version file is not found, instead of a string error message.