### PR TITLE
Update schema tests and README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![Static Badge](https://img.shields.io/badge/Rules-127-green?label=Cell%20rules&labelColor=blue&color=gray)](src/Rules/Cell)
 [![Static Badge](https://img.shields.io/badge/Rules-206-green?label=Aggregate%20rules&labelColor=blue&color=gray)](src/Rules/Aggregate)
 [![Static Badge](https://img.shields.io/badge/Rules-8-green?label=Extra%20checks&labelColor=blue&color=gray)](#extra-checks)
-[![Static Badge](https://img.shields.io/badge/Rules-22/11/20-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
+[![Static Badge](https://img.shields.io/badge/Rules-31/11/20-green?label=Plan%20to%20add&labelColor=gray&color=gray)](tests/schemas/todo.yml)
 <!-- auto-update:/rules-counter -->
 
 Strict and automated line-by-line CSV validation tool based on customizable Yaml schemas.
@@ -1976,6 +1976,7 @@ It's random ideas and plans. No promises and deadlines. Feel free to [help me!](
     see all errors in one place. Especially for GitLab and JUnit reports.
 
 - **Misc**
+  - Rewrite in Go/Rust. It's a good idea to have a standalone binary with the same functionality.
   - Install via brew on MacOS.
   - Install via apt on Ubuntu.
   - Use it as PHP SDK. Examples in Readme.

--- a/tests/Commands/CreateSchemaTest.php
+++ b/tests/Commands/CreateSchemaTest.php
@@ -482,7 +482,7 @@ final class CreateSchemaTest extends TestCase
                   date_max: '2124-05-22'
                   date_format: Y/m/d
                   date_age_min: 0
-                  date_age_max: 100
+                  date_age_max: 99
                 aggregate_rules:
                   is_unique: true
                   count_empty: 0

--- a/tests/schemas/todo.yml
+++ b/tests/schemas/todo.yml
@@ -50,6 +50,17 @@ columns:
       is_realtive_path: true
       is_scientific_notation: true
 
+      is_positive: true
+      is_positive_zero: true
+      is_negative: true
+      is_negative_zero: true
+      soft_precision: "1.1 == 1.10"
+      # https://stackoverflow.com/questions/69107743/regular-expression-for-wkt-polygon: true
+      is_unicode: true
+      is_ascii: true
+      is_latin: true
+      coordinates: "1.0, -2.0"
+
       # identifier
       is_bsn: true                    # Validates a Dutch citizen service number (BSN).
       is_cnh: true                    # Validates a Brazilian national health card number (CNH).


### PR DESCRIPTION
Modified the maximum age limit in CreateSchemaTest from 100 to 99. Additional rules were added to the todo schema tests. The "Plan to add" badge count in README was updated to reflect the additional rules, and a suggestion to rewrite the tool in Go/Rust was added to the Miscellaneous section.