### PR TITLE
Prevent composer package tests on master branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,6 +179,7 @@ jobs:
           ! $BLUEPRINT $CMD_VALIDATE $INVALID_TEST
 
       - name: Test as composer package
+        if: github.ref != 'refs/heads/master'
         run: |
           mkdir -pv ./build/composer-test
           cd ./build/composer-test


### PR DESCRIPTION
Exclude running the "Test as composer package" step on the master branch to streamline CI/CD workflows and reduce redundant checks. This change ensures that these tests only run on feature branches, optimizing build times and resource usage.