### PR TITLE
style: Standardize PHP type hint order and formatting

### DIFF
--- a/src/Commands/AbstractValidate.php
+++ b/src/Commands/AbstractValidate.php
@@ -155,7 +155,7 @@ abstract class AbstractValidate extends CliCommand
         return $filenames;
     }
 
-    protected function out(null|array|string $messge, int $indent = 0): void
+    protected function out(array|string|null $messge, int $indent = 0): void
     {
         if ($messge === null) {
             return;

--- a/src/Csv/CsvFile.php
+++ b/src/Csv/CsvFile.php
@@ -36,7 +36,7 @@ final class CsvFile
     private bool         $isEmpty;
     private ?array       $header = null;
 
-    public function __construct(string $csvFilename, null|array|string $csvSchemaFilenameOrArray = null)
+    public function __construct(string $csvFilename, array|string|null $csvSchemaFilenameOrArray = null)
     {
         if (\realpath($csvFilename) !== false && \file_exists($csvFilename) === false) {
             throw new Exception('File not found: ' . $csvFilename);

--- a/src/Rules/AbstractRule.php
+++ b/src/Rules/AbstractRule.php
@@ -46,13 +46,13 @@ abstract class AbstractRule
     protected string $ruleCode;
     protected string $mode;
 
-    private null|array|bool|float|int|string $options;
+    private array|bool|float|int|string|null $options;
 
     abstract public function getHelpMeta(): array;
 
     public function __construct(
         string $columnNameId,
-        null|array|bool|float|int|string $options,
+        array|bool|float|int|string|null $options,
         string $mode = self::DEFAULT,
     ) {
         $this->mode = $mode;

--- a/src/Rules/Aggregate/AbstractAggregateRuleCombo.php
+++ b/src/Rules/Aggregate/AbstractAggregateRuleCombo.php
@@ -23,7 +23,7 @@ abstract class AbstractAggregateRuleCombo extends AbstractRuleCombo
 {
     public const INPUT_TYPE = AbstractRule::INPUT_TYPE_STRINGS;
 
-    abstract protected static function calcValue(array $columnValues, ?array $options = null): null|float|int;
+    abstract protected static function calcValue(array $columnValues, ?array $options = null): float|int|null;
 
     public function getRuleCode(?string $mode = null): string
     {

--- a/src/Rules/Aggregate/ComboAverage.php
+++ b/src/Rules/Aggregate/ComboAverage.php
@@ -31,7 +31,7 @@ final class ComboAverage extends AbstractAggregateRuleCombo
         return [['Regular the arithmetic mean. The sum of the numbers divided by the count.'], []];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboCoefOfVar.php
+++ b/src/Rules/Aggregate/ComboCoefOfVar.php
@@ -39,7 +39,7 @@ final class ComboCoefOfVar extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboContraharmonicMean.php
+++ b/src/Rules/Aggregate/ComboContraharmonicMean.php
@@ -38,7 +38,7 @@ final class ComboContraharmonicMean extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboCount.php
+++ b/src/Rules/Aggregate/ComboCount.php
@@ -37,7 +37,7 @@ final class ComboCount extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboCountDistinct.php
+++ b/src/Rules/Aggregate/ComboCountDistinct.php
@@ -30,7 +30,7 @@ final class ComboCountDistinct extends AbstractAggregateRuleCombo
         return [['Number of unique values.'], []];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboCountEmpty.php
+++ b/src/Rules/Aggregate/ComboCountEmpty.php
@@ -30,7 +30,7 @@ final class ComboCountEmpty extends AbstractAggregateRuleCombo
         return [['Counts only empty values (string length is 0).'], []];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboCountEven.php
+++ b/src/Rules/Aggregate/ComboCountEven.php
@@ -30,7 +30,7 @@ final class ComboCountEven extends AbstractAggregateRuleCombo
         return [['Number of even values.'], []];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboCountNegative.php
+++ b/src/Rules/Aggregate/ComboCountNegative.php
@@ -30,7 +30,7 @@ final class ComboCountNegative extends AbstractAggregateRuleCombo
         return [['Number of negative values.'], []];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboCountNotEmpty.php
+++ b/src/Rules/Aggregate/ComboCountNotEmpty.php
@@ -30,7 +30,7 @@ final class ComboCountNotEmpty extends AbstractAggregateRuleCombo
         return [['Counts only not empty values (string length is not 0).'], []];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboCountOdd.php
+++ b/src/Rules/Aggregate/ComboCountOdd.php
@@ -30,7 +30,7 @@ final class ComboCountOdd extends AbstractAggregateRuleCombo
         return [['Number of odd values.'], []];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboCountPositive.php
+++ b/src/Rules/Aggregate/ComboCountPositive.php
@@ -30,7 +30,7 @@ final class ComboCountPositive extends AbstractAggregateRuleCombo
         return [['Number of positive values.'], []];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboCountPrime.php
+++ b/src/Rules/Aggregate/ComboCountPrime.php
@@ -31,7 +31,7 @@ final class ComboCountPrime extends AbstractAggregateRuleCombo
         return [['Number of prime values.'], []];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboCountZero.php
+++ b/src/Rules/Aggregate/ComboCountZero.php
@@ -36,7 +36,7 @@ final class ComboCountZero extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboCubicMean.php
+++ b/src/Rules/Aggregate/ComboCubicMean.php
@@ -31,7 +31,7 @@ final class ComboCubicMean extends AbstractAggregateRuleCombo
         return [['Cubic mean. See: https://en.wikipedia.org/wiki/Cubic_mean'], []];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboFirstNum.php
+++ b/src/Rules/Aggregate/ComboFirstNum.php
@@ -38,7 +38,7 @@ final class ComboFirstNum extends AbstractAggregateRuleCombo
         return (float)$colValues[0];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         return null;
     }

--- a/src/Rules/Aggregate/ComboGeometricMean.php
+++ b/src/Rules/Aggregate/ComboGeometricMean.php
@@ -39,7 +39,7 @@ final class ComboGeometricMean extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboHarmonicMean.php
+++ b/src/Rules/Aggregate/ComboHarmonicMean.php
@@ -39,7 +39,7 @@ final class ComboHarmonicMean extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboInterquartileMean.php
+++ b/src/Rules/Aggregate/ComboInterquartileMean.php
@@ -41,7 +41,7 @@ final class ComboInterquartileMean extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboLastNum.php
+++ b/src/Rules/Aggregate/ComboLastNum.php
@@ -38,7 +38,7 @@ final class ComboLastNum extends AbstractAggregateRuleCombo
         return (float)\end($colValues);
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         return null;
     }

--- a/src/Rules/Aggregate/ComboMeanAbsDev.php
+++ b/src/Rules/Aggregate/ComboMeanAbsDev.php
@@ -38,7 +38,7 @@ final class ComboMeanAbsDev extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboMedian.php
+++ b/src/Rules/Aggregate/ComboMedian.php
@@ -37,7 +37,7 @@ final class ComboMedian extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboMedianAbsDev.php
+++ b/src/Rules/Aggregate/ComboMedianAbsDev.php
@@ -39,7 +39,7 @@ final class ComboMedianAbsDev extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboMidhinge.php
+++ b/src/Rules/Aggregate/ComboMidhinge.php
@@ -39,7 +39,7 @@ final class ComboMidhinge extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboNthNum.php
+++ b/src/Rules/Aggregate/ComboNthNum.php
@@ -75,7 +75,7 @@ final class ComboNthNum extends AbstractAggregateRuleCombo
         return float($actual);
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         return null;
     }

--- a/src/Rules/Aggregate/ComboPercentile.php
+++ b/src/Rules/Aggregate/ComboPercentile.php
@@ -82,7 +82,7 @@ final class ComboPercentile extends AbstractAggregateRuleCombo
         return self::calcValue($colValues, ['p' => $percentile]);
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboPopulationVariance.php
+++ b/src/Rules/Aggregate/ComboPopulationVariance.php
@@ -38,7 +38,7 @@ final class ComboPopulationVariance extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboQuartiles.php
+++ b/src/Rules/Aggregate/ComboQuartiles.php
@@ -79,7 +79,7 @@ final class ComboQuartiles extends AbstractAggregateRuleCombo
         return self::calcValue($colValues, ['method' => $method, 'type' => $type]);
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboRootMeanSquare.php
+++ b/src/Rules/Aggregate/ComboRootMeanSquare.php
@@ -38,7 +38,7 @@ final class ComboRootMeanSquare extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboSampleVariance.php
+++ b/src/Rules/Aggregate/ComboSampleVariance.php
@@ -38,7 +38,7 @@ final class ComboSampleVariance extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboStddev.php
+++ b/src/Rules/Aggregate/ComboStddev.php
@@ -43,7 +43,7 @@ final class ComboStddev extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboStddevPop.php
+++ b/src/Rules/Aggregate/ComboStddevPop.php
@@ -36,7 +36,7 @@ final class ComboStddevPop extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboSum.php
+++ b/src/Rules/Aggregate/ComboSum.php
@@ -30,7 +30,7 @@ final class ComboSum extends AbstractAggregateRuleCombo
         return [['Sum of the numbers in the column. Example: [1, 2, 3] => 6.'], []];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Aggregate/ComboTrimean.php
+++ b/src/Rules/Aggregate/ComboTrimean.php
@@ -39,7 +39,7 @@ final class ComboTrimean extends AbstractAggregateRuleCombo
         ];
     }
 
-    protected static function calcValue(array $columnValues, ?array $options = null): null|float|int
+    protected static function calcValue(array $columnValues, ?array $options = null): float|int|null
     {
         $columnValues = Utils::analyzeGuard($columnValues, self::INPUT_TYPE);
         if ($columnValues === null) {

--- a/src/Rules/Ruleset.php
+++ b/src/Rules/Ruleset.php
@@ -78,7 +78,7 @@ final class Ruleset
      */
     public function ruleDiscovery(
         string $origRuleName,
-        null|array|bool|float|int|string $options = null,
+        array|bool|float|int|string|null $options = null,
     ): ?AbstractRule {
         $mode = AbstractCellRuleCombo::parseMode($origRuleName);
         $noCombo = \preg_replace("/(_{$mode})\$/", '', $origRuleName);
@@ -123,7 +123,7 @@ final class Ruleset
      */
     private function createRuleClassAttempt(
         string $posibleClassName,
-        null|array|bool|float|int|string $options,
+        array|bool|float|int|string|null $options,
         string $mode,
     ): ?AbstractRule {
         if (\class_exists($posibleClassName)) {

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -38,7 +38,7 @@ final class Schema
     private ?string      $filename;
     private AbstractData $internalState;
 
-    public function __construct(null|array|string $csvSchemaFilenameOrArray = null)
+    public function __construct(array|string|null $csvSchemaFilenameOrArray = null)
     {
         if (\is_array($csvSchemaFilenameOrArray)) {
             $this->filename = '_custom_array_';

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -36,8 +36,8 @@ final class Utils
 
     /**
      * Checks if the elements in an array are in a specific order.
-     * @param array $array        the array to check the order of
-     * @param array $correctOrder the correct order that the elements should be in
+     * @param  array $array        the array to check the order of
+     * @param  array $correctOrder the correct order that the elements should be in
      * @return bool  returns true if the elements are in the correct order, false otherwise
      */
     public static function isArrayInOrder(array $array, array $correctOrder): bool
@@ -58,11 +58,11 @@ final class Utils
 
     /**
      * Prints a list of items for CLI output.
-     * @param null|array|bool|float|int|string $items the list of items to print
-     * @param string                           $color the color to apply to each item
+     * @param  null|array|bool|float|int|string $items the list of items to print
+     * @param  string                           $color the color to apply to each item
      * @return string                           the formatted string representation of the list
      */
-    public static function printList(null|array|bool|float|int|string $items, string $color = ''): string
+    public static function printList(array|bool|float|int|string|null $items, string $color = ''): string
     {
         if (!\is_array($items)) {
             $items = [$items];
@@ -118,7 +118,7 @@ final class Utils
 
     /**
      * Convert a kebab-case string to camelCase.
-     * @param string $input the kebab-case string to be converted
+     * @param  string $input the kebab-case string to be converted
      * @return string the converted camelCase string
      */
     public static function kebabToCamelCase(string $input): string
@@ -129,7 +129,7 @@ final class Utils
     /**
      * Converts a camelCase string to kebab-case.
      *
-     * @param string $input the camelCase string to be converted
+     * @param  string $input the camelCase string to be converted
      * @return string the converted kebab-case string
      */
     public static function camelToKebabCase(string $input): string
@@ -139,10 +139,10 @@ final class Utils
 
     /**
      * Prepares a regular expression pattern by adding a delimiter if necessary.
-     * @param null|string $pattern      The regular expression pattern to prepare. If null or empty, returns null.
-     * @param string      $addDelimiter the delimiter to be added if the pattern doesn't already have a delimiter
+     * @param  null|string $pattern      The regular expression pattern to prepare. If null or empty, returns null.
+     * @param  string      $addDelimiter the delimiter to be added if the pattern doesn't already have a delimiter
      * @return null|string the prepared regular expression pattern with a delimiter, or null if the input pattern
-     *                                  is null or empty
+     *                     is null or empty
      */
     public static function prepareRegex(?string $pattern, string $addDelimiter = '/'): ?string
     {
@@ -163,7 +163,7 @@ final class Utils
 
     /**
      * Find files based on the given paths.
-     * @param string[] $paths an array of file or directory paths
+     * @param  string[]      $paths an array of file or directory paths
      * @return SplFileInfo[] an array of SplFileInfo objects representing the found files
      * @throws Exception     if a file is not readable
      */
@@ -205,9 +205,9 @@ final class Utils
 
     /**
      * Cuts the path of a given file and replaces the current working directory with a dot (.).
-     * @param null|string $fullpath the full path of the file
+     * @param  null|string $fullpath the full path of the file
      * @return string      The modified path with the current working directory replaced by a dot (.) or an empty
-     *                              string if the $fullpath is null.
+     *                     string if the $fullpath is null.
      */
     public static function cutPath(?string $fullpath): string
     {
@@ -266,11 +266,11 @@ final class Utils
 
     /**
      * Compare two arrays and return the differences between them.
-     * @param array  $expectedSchema the expected schema array
-     * @param array  $actualSchema   the actual schema array
-     * @param string $columnId       the column ID
-     * @param string $keyPrefix      the key prefix
-     * @param string $path           the current path
+     * @param  array  $expectedSchema the expected schema array
+     * @param  array  $actualSchema   the actual schema array
+     * @param  string $columnId       the column ID
+     * @param  string $keyPrefix      the key prefix
+     * @param  string $path           the current path
      * @return array  an array containing the differences between the two arrays
      */
     public static function compareArray(
@@ -343,14 +343,14 @@ final class Utils
 
     /**
      * Checks whether the expected type matches the actual type and if there is a valid conversion between them.
-     * @param null|array|bool|float|int|string $expected The expected type
-     * @param null|array|bool|float|int|string $actual   The actual type
+     * @param  null|array|bool|float|int|string $expected The expected type
+     * @param  null|array|bool|float|int|string $actual   The actual type
      * @return bool                             returns true if the expected type matches the actual type or if there
-     *                                                   is a valid conversion between them, otherwise returns false
+     *                                          is a valid conversion between them, otherwise returns false
      */
     public static function matchTypes(
-        null|array|bool|float|int|string $expected,
-        null|array|bool|float|int|string $actual,
+        array|bool|float|int|string|null $expected,
+        array|bool|float|int|string|null $actual,
     ): bool {
         $expectedType = \gettype($expected);
         $actualType = \gettype($actual);
@@ -373,8 +373,8 @@ final class Utils
 
     /**
      * Test if a regex pattern matches a subject string.
-     * @param null|string $regex   the regex pattern to match
-     * @param string      $subject the subject string
+     * @param  null|string $regex   the regex pattern to match
+     * @param  string      $subject the subject string
      * @return bool        returns true if the pattern does not match the subject, false otherwise
      * @throws Exception   if an invalid regex pattern is provided
      */
@@ -399,11 +399,11 @@ final class Utils
 
     /**
      * Matches schema files with CSV files based on the filename pattern in the schema.
-     * @param SplFileInfo[] $csvFiles         an array of CSV files to match
-     * @param SplFileInfo[] $schemaFiles      an array of schema files to match
-     * @param bool          $useGlobalSchemas whether to include global schemas without a filename pattern
+     * @param  SplFileInfo[] $csvFiles         an array of CSV files to match
+     * @param  SplFileInfo[] $schemaFiles      an array of schema files to match
+     * @param  bool          $useGlobalSchemas whether to include global schemas without a filename pattern
      * @return array         an array containing the matched pairs of schema and CSV files, as well as additional
-     *                                        information
+     *                       information
      */
     public static function matchSchemaAndCsvFiles(
         array $csvFiles,
@@ -455,8 +455,8 @@ final class Utils
 
     /**
      * Prints the file path with an optional HTML tag around the filename.
-     * @param string $fullpath the full path of the file
-     * @param string $tag      the HTML tag to wrap the filename with
+     * @param  string $fullpath the full path of the file
+     * @param  string $tag      the HTML tag to wrap the filename with
      * @return string the file path with the filename wrapped in the specified HTML tag
      */
     public static function printFile(string $fullpath, string $tag = 'bright-blue'): string
@@ -469,9 +469,9 @@ final class Utils
 
     /**
      * Retrieves the version of the software.
-     * @param bool $showFull Whether to display the full version information or not. Default is false.
+     * @param  bool        $showFull Whether to display the full version information or not. Default is false.
      * @return null|string the version of the software as a string, or an error message if the version file is
-     *                       not found
+     *                     not found
      */
     public static function getVersion(bool $showFull): ?string
     {
@@ -489,8 +489,8 @@ final class Utils
 
     /**
      * Parses the version information from a content string.
-     * @param string $content  the content string containing the version information
-     * @param bool   $showFull Optional. Whether to show the full version information.
+     * @param  string $content  the content string containing the version information
+     * @param  bool   $showFull Optional. Whether to show the full version information.
      * @return string the parsed version string
      */
     public static function parseVersion(string $content, bool $showFull): string
@@ -525,9 +525,9 @@ final class Utils
 
     /**
      * Returns the size of a file.
-     * @param string $csv the path of the file
+     * @param  string $csv the path of the file
      * @return string The size of the file, formatted as a string.
-     *                    If the file is not found, returns 'file not found'.
+     *                If the file is not found, returns 'file not found'.
      */
     public static function getFileSize(string $csv): string
     {
@@ -553,7 +553,7 @@ final class Utils
 
     /**
      * Fix the command line arguments by extracting flags from the original arguments.
-     * @param array $originalArgs the original command line arguments
+     * @param  array $originalArgs the original command line arguments
      * @return array the fixed command line arguments with extracted flags
      */
     public static function fixArgv(array $originalArgs): array
@@ -571,7 +571,7 @@ final class Utils
                 $extraArgs = \str_replace(['extra:', 'options:'], '', $argValue);
                 $flags = \array_filter(
                     \array_map('trim', \explode(' ', $extraArgs)),
-                    static fn($flag): bool => $flag !== '',
+                    static fn ($flag): bool => $flag !== '',
                 );
 
                 foreach ($flags as $flag) {
@@ -588,7 +588,7 @@ final class Utils
     /**
      * Merge multiple arrays of configurations into a single configuration array.
      *
-     * @param array<string, null|array|bool|string>|int[]|string[] ...$configs the arrays of configs to be merged
+     * @param  array<string, null|array|bool|string>|int[]|string[] ...$configs the arrays of configs to be merged
      * @return array                                                the merged configuration array
      */
     public static function mergeConfigs(array ...$configs): array
@@ -673,8 +673,8 @@ final class Utils
 
     /**
      * Remove default settings from an array of original settings.
-     * @param array $original the original settings array
-     * @param array $defaults the default settings array to compare against
+     * @param  array $original the original settings array
+     * @param  array $defaults the default settings array to compare against
      * @return array the modified settings array with default settings removed
      */
     public static function removeDefaultSettings(array $original, array $defaults): array
@@ -703,7 +703,7 @@ final class Utils
 
     /**
      * Sort the rules in the given schema dump based on the original rule order.
-     * @param array $schemaDump the schema dump containing the rules to be sorted
+     * @param  array $schemaDump the schema dump containing the rules to be sorted
      * @return array the sorted schema dump with rules sorted based on the original order
      */
     public static function sortRules(array $schemaDump): array
@@ -733,25 +733,25 @@ final class Utils
 
     /**
      * Sorts an array based on a reference order.
-     * @param array $dataArray the array to be sorted
-     * @param array $refOrder  the reference order used for sorting
+     * @param  array $dataArray the array to be sorted
+     * @param  array $refOrder  the reference order used for sorting
      * @return array the sorted array
      */
     public static function sortByArray(array $dataArray, array $refOrder): array
     {
         \uksort(
             $dataArray,
-            static fn($arrA, $arrB) => \array_search($arrA, $refOrder, true) <=> \array_search($arrB, $refOrder, true),
+            static fn ($arrA, $arrB) => \array_search($arrA, $refOrder, true) <=> \array_search($arrB, $refOrder, true),
         );
         return $dataArray;
     }
 
     /**
      * Analyze the column values and extract numeric values in a numeric array.
-     * @param array $columnValues the column values to be analyzed
+     * @param  array      $columnValues the column values to be analyzed
      * @return null|array The array of numeric values extracted from the column values.
-     *                            Returns null if there are not enough numeric values or non-numeric values present in
-     *                            the column values.
+     *                    Returns null if there are not enough numeric values or non-numeric values present in
+     *                    the column values.
      */
     public static function analyzeGuard(array $columnValues, int $varType = AbstractRule::INPUT_TYPE_FLOATS): ?array
     {
@@ -763,8 +763,8 @@ final class Utils
             return \array_map('\strval', $columnValues);
         }
 
-        $notEmptyArray = \array_filter($columnValues, static fn(string $value): bool => \trim($value) !== '');
-        $nonNumeric = \array_filter($notEmptyArray, static fn(string $value) => !\is_numeric($value));
+        $notEmptyArray = \array_filter($columnValues, static fn (string $value): bool => \trim($value) !== '');
+        $nonNumeric = \array_filter($notEmptyArray, static fn (string $value) => !\is_numeric($value));
         if (\count($nonNumeric) > 0) {
             return null;
         }
@@ -798,7 +798,7 @@ final class Utils
 
     private static function filterNotUsedFiles(array $files): array
     {
-        return \array_keys(\array_filter($files, static fn($value) => $value === false));
+        return \array_keys(\array_filter($files, static fn ($value) => $value === false));
     }
 
     private static function convertTzToUTC(string $dateWithSourceTZ): \DateTime

--- a/tests/PackageTest.php
+++ b/tests/PackageTest.php
@@ -83,11 +83,6 @@ final class PackageTest extends \JBZoo\Codestyle\PHPUnit\AbstractPackageTest
         parent::setUp();
     }
 
-    public static function testGithubActionsWorkflow(): void
-    {
-        success('It uses different workflows for CI');
-    }
-
     public function testComposerType(): void
     {
         $composer = json(PROJECT_ROOT . '/composer.json');
@@ -118,6 +113,11 @@ final class PackageTest extends \JBZoo\Codestyle\PHPUnit\AbstractPackageTest
         $expectedBadgeLine = \implode("\n", $expectedBadges);
 
         Tools::insertInReadme('top-badges', $expectedBadgeLine);
+    }
+
+    public static function testGithubActionsWorkflow(): void
+    {
+        success('It uses different workflows for CI');
     }
 
     protected function checkBadgeGithubActionsDemo(): ?string


### PR DESCRIPTION
- Reordered union types in parameter and return type declarations to follow a consistent style.
- Aligned docblock `@param` and `@return` tags for improved readability.
- Added spaces after `fn` in arrow function syntax.
- Reordered a test method in `PackageTest.php` for better organization.
