### PR TITLE
chore(linters): Configure static analysis tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,12 +579,12 @@ columns:
       # Check if a string is in a specific charset. Available charsets:
       #  - 7bit, 8bit, ASCII, ArmSCII-8, BASE64, BIG-5, CP850, CP866, CP932, CP936
       #  - CP950, CP50220, CP50221, CP50222, CP51932, EUC-CN, EUC-JP, EUC-JP-2004, EUC-KR, EUC-TW
-      #  - GB18030, GB18030-2022, HTML-ENTITIES, HZ, ISO-2022-JP, ISO-2022-JP-2004, ISO-2022-JP-MOBILE#KDDI, ISO-2022-JP-MS, ISO-2022-KR, ISO-8859-1
-      #  - ISO-8859-2, ISO-8859-3, ISO-8859-4, ISO-8859-5, ISO-8859-6, ISO-8859-7, ISO-8859-8, ISO-8859-9, ISO-8859-10, ISO-8859-13
-      #  - ISO-8859-14, ISO-8859-15, ISO-8859-16, JIS, KOI8-R, KOI8-U, Quoted-Printable, SJIS, SJIS-2004, SJIS-Mobile#DOCOMO
-      #  - SJIS-Mobile#KDDI, SJIS-Mobile#SOFTBANK, SJIS-mac, SJIS-win, UCS-2, UCS-2BE, UCS-2LE, UCS-4, UCS-4BE, UCS-4LE
-      #  - UHC, UTF-7, UTF-8, UTF-8-Mobile#DOCOMO, UTF-8-Mobile#KDDI-A, UTF-8-Mobile#KDDI-B, UTF-8-Mobile#SOFTBANK, UTF-16, UTF-16BE, UTF-16LE
-      #  - UTF-32, UTF-32BE, UTF-32LE, UTF7-IMAP, UUENCODE, Windows-1251, Windows-1252, Windows-1254, eucJP-win
+      #  - GB18030, HTML-ENTITIES, HZ, ISO-2022-JP, ISO-2022-JP-2004, ISO-2022-JP-MOBILE#KDDI, ISO-2022-JP-MS, ISO-2022-KR, ISO-8859-1, ISO-8859-2
+      #  - ISO-8859-3, ISO-8859-4, ISO-8859-5, ISO-8859-6, ISO-8859-7, ISO-8859-8, ISO-8859-9, ISO-8859-10, ISO-8859-13, ISO-8859-14
+      #  - ISO-8859-15, ISO-8859-16, JIS, KOI8-R, KOI8-U, Quoted-Printable, SJIS, SJIS-2004, SJIS-Mobile#DOCOMO, SJIS-Mobile#KDDI
+      #  - SJIS-Mobile#SOFTBANK, SJIS-mac, SJIS-win, UCS-2, UCS-2BE, UCS-2LE, UCS-4, UCS-4BE, UCS-4LE, UHC
+      #  - UTF-7, UTF-8, UTF-8-Mobile#DOCOMO, UTF-8-Mobile#KDDI-A, UTF-8-Mobile#KDDI-B, UTF-8-Mobile#SOFTBANK, UTF-16, UTF-16BE, UTF-16LE, UTF-32
+      #  - UTF-32BE, UTF-32LE, UTF7-IMAP, UUENCODE, Windows-1251, Windows-1252, Windows-1254, eucJP-win
       charset: charset_code             # Validates if a string is in a specific charset. Example: "UTF-8".
 
       # Validates whether the input is a credit card number.

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 
         "league/csv"                          : "^9.25.0",
         "jbzoo/data"                          : "^7.2.0",
-        "jbzoo/cli"                           : "^7.2.4",
+        "jbzoo/cli"                           : "^7.2.5",
         "jbzoo/utils"                         : "^7.3.0",
         "jbzoo/ci-report-converter"           : "^7.2.3",
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0438979e716f3f657de258cae44dae1e",
+    "content-hash": "9e35b0b648ce5b57f75c7dfede62b2d1",
     "packages": [
         {
             "name": "fidry/cpu-core-counter",
@@ -238,16 +238,16 @@
         },
         {
             "name": "jbzoo/cli",
-            "version": "7.2.4",
+            "version": "7.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/JBZoo/Cli.git",
-                "reference": "85c14649e91cac976a00967f4d8baedc9b297aa0"
+                "reference": "c4d0dfdd61005ff55f4551485179b7170cfb63c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JBZoo/Cli/zipball/85c14649e91cac976a00967f4d8baedc9b297aa0",
-                "reference": "85c14649e91cac976a00967f4d8baedc9b297aa0",
+                "url": "https://api.github.com/repos/JBZoo/Cli/zipball/c4d0dfdd61005ff55f4551485179b7170cfb63c6",
+                "reference": "c4d0dfdd61005ff55f4551485179b7170cfb63c6",
                 "shasum": ""
             },
             "require": {
@@ -260,7 +260,7 @@
                 "symfony/process": ">=7.3.4"
             },
             "require-dev": {
-                "jbzoo/toolbox-dev": "^7.2"
+                "jbzoo/toolbox-dev": "^7.3"
             },
             "type": "library",
             "extra": {
@@ -308,9 +308,9 @@
             ],
             "support": {
                 "issues": "https://github.com/JBZoo/Cli/issues",
-                "source": "https://github.com/JBZoo/Cli/tree/7.2.4"
+                "source": "https://github.com/JBZoo/Cli/tree/7.2.5"
             },
-            "time": "2025-09-28T11:02:40+00:00"
+            "time": "2025-09-28T18:53:47+00:00"
         },
         {
             "name": "jbzoo/data",
@@ -4409,16 +4409,16 @@
         },
         {
             "name": "kubawerlos/php-cs-fixer-custom-fixers",
-            "version": "v3.35.0",
+            "version": "v3.35.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers.git",
-                "reference": "7c3d422b9e86b536c8fd8947d3f69af56e920b51"
+                "reference": "2a35f80ae24ca77443a7af1599c3a3db1b6bd395"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kubawerlos/php-cs-fixer-custom-fixers/zipball/7c3d422b9e86b536c8fd8947d3f69af56e920b51",
-                "reference": "7c3d422b9e86b536c8fd8947d3f69af56e920b51",
+                "url": "https://api.github.com/repos/kubawerlos/php-cs-fixer-custom-fixers/zipball/2a35f80ae24ca77443a7af1599c3a3db1b6bd395",
+                "reference": "2a35f80ae24ca77443a7af1599c3a3db1b6bd395",
                 "shasum": ""
             },
             "require": {
@@ -4449,7 +4449,7 @@
             "description": "A set of custom fixers for PHP CS Fixer",
             "support": {
                 "issues": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/issues",
-                "source": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/tree/v3.35.0"
+                "source": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/tree/v3.35.1"
             },
             "funding": [
                 {
@@ -4457,7 +4457,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-27T11:34:54+00:00"
+            "time": "2025-09-28T18:43:35+00:00"
         },
         {
             "name": "league/uri",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,25 @@
+#
+# JBZoo Toolbox - Csv-Blueprint.
+#
+# This file is part of the JBZoo Toolbox project.
+# For the full copyright and license information, please view the LICENSE
+# file that was distributed with this source code.
+#
+# @license    MIT
+# @copyright  Copyright (C) JBZoo.com, All rights reserved.
+# @see        https://github.com/JBZoo/Csv-Blueprint
+#
+
+includes:
+    - ./vendor/phpstan/phpstan-strict-rules/rules.neon
+
+parameters:
+    level: 9
+    checkExplicitMixed: false
+    reportUnmatchedIgnoredErrors: false
+    ignoreErrors:
+        - identifier: missingType.iterableValue
+        - identifier: phpDoc.parseError
+        - identifier: arrayFilter.strict
+        - identifier: arrayFilter.same
+        - identifier: return.unusedType

--- a/psalm.xml
+++ b/psalm.xml
@@ -11,13 +11,13 @@
     @see        https://github.com/JBZoo/Csv-Blueprint
 -->
 <psalm
-        errorLevel="8"
-        reportMixedIssues="false"
-        useDocblockPropertyTypes="true"
-        resolveFromConfigFile="false"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="https://getpsalm.org/schema/config"
-        xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorLevel="8"
+    reportMixedIssues="false"
+    useDocblockPropertyTypes="true"
+    resolveFromConfigFile="false"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
 >
     <projectFiles>
         <directory name="src"/>
@@ -34,8 +34,17 @@
                 <file name="src/Rules/Cell/Phone.php"/>
             </errorLevel>
         </TooManyArguments>
+        <MissingOverrideAttribute errorLevel="suppress"/>
+
+        <!-- From common codestyle JBZoo ruleset -->
+        <PossiblyUnusedMethod errorLevel="suppress"/>
+        <InvalidOperand errorLevel="suppress"/>
+        <MissingOverrideAttribute errorLevel="suppress"/>
+        <UnusedClass errorLevel="suppress"/>
+        <PossiblyUnusedReturnValue errorLevel="suppress"/>
+        <UnusedReturnValue errorLevel="suppress"/>
     </issueHandlers>
     <stubs>
-        <file name="tests/stubs/parallel.stub_php" />
+        <file name="tests/stubs/parallel.stub_php"/>
     </stubs>
 </psalm>

--- a/schema-examples/full.yml
+++ b/schema-examples/full.yml
@@ -301,12 +301,12 @@ columns:
       # Check if a string is in a specific charset. Available charsets:
       #  - 7bit, 8bit, ASCII, ArmSCII-8, BASE64, BIG-5, CP850, CP866, CP932, CP936
       #  - CP950, CP50220, CP50221, CP50222, CP51932, EUC-CN, EUC-JP, EUC-JP-2004, EUC-KR, EUC-TW
-      #  - GB18030, GB18030-2022, HTML-ENTITIES, HZ, ISO-2022-JP, ISO-2022-JP-2004, ISO-2022-JP-MOBILE#KDDI, ISO-2022-JP-MS, ISO-2022-KR, ISO-8859-1
-      #  - ISO-8859-2, ISO-8859-3, ISO-8859-4, ISO-8859-5, ISO-8859-6, ISO-8859-7, ISO-8859-8, ISO-8859-9, ISO-8859-10, ISO-8859-13
-      #  - ISO-8859-14, ISO-8859-15, ISO-8859-16, JIS, KOI8-R, KOI8-U, Quoted-Printable, SJIS, SJIS-2004, SJIS-Mobile#DOCOMO
-      #  - SJIS-Mobile#KDDI, SJIS-Mobile#SOFTBANK, SJIS-mac, SJIS-win, UCS-2, UCS-2BE, UCS-2LE, UCS-4, UCS-4BE, UCS-4LE
-      #  - UHC, UTF-7, UTF-8, UTF-8-Mobile#DOCOMO, UTF-8-Mobile#KDDI-A, UTF-8-Mobile#KDDI-B, UTF-8-Mobile#SOFTBANK, UTF-16, UTF-16BE, UTF-16LE
-      #  - UTF-32, UTF-32BE, UTF-32LE, UTF7-IMAP, UUENCODE, Windows-1251, Windows-1252, Windows-1254, eucJP-win
+      #  - GB18030, HTML-ENTITIES, HZ, ISO-2022-JP, ISO-2022-JP-2004, ISO-2022-JP-MOBILE#KDDI, ISO-2022-JP-MS, ISO-2022-KR, ISO-8859-1, ISO-8859-2
+      #  - ISO-8859-3, ISO-8859-4, ISO-8859-5, ISO-8859-6, ISO-8859-7, ISO-8859-8, ISO-8859-9, ISO-8859-10, ISO-8859-13, ISO-8859-14
+      #  - ISO-8859-15, ISO-8859-16, JIS, KOI8-R, KOI8-U, Quoted-Printable, SJIS, SJIS-2004, SJIS-Mobile#DOCOMO, SJIS-Mobile#KDDI
+      #  - SJIS-Mobile#SOFTBANK, SJIS-mac, SJIS-win, UCS-2, UCS-2BE, UCS-2LE, UCS-4, UCS-4BE, UCS-4LE, UHC
+      #  - UTF-7, UTF-8, UTF-8-Mobile#DOCOMO, UTF-8-Mobile#KDDI-A, UTF-8-Mobile#KDDI-B, UTF-8-Mobile#SOFTBANK, UTF-16, UTF-16BE, UTF-16LE, UTF-32
+      #  - UTF-32BE, UTF-32LE, UTF7-IMAP, UUENCODE, Windows-1251, Windows-1252, Windows-1254, eucJP-win
       charset: charset_code             # Validates if a string is in a specific charset. Example: "UTF-8".
 
       # Validates whether the input is a credit card number.

--- a/src/Analyze/Analyzer.php
+++ b/src/Analyze/Analyzer.php
@@ -57,7 +57,6 @@ final class Analyzer
     {
         $validRules = [];
 
-        /** @var class-string<\JBZoo\CsvBlueprint\Rules\AbstractRule> $ruleClassname */
         foreach (self::getRuleClasses('Aggregate', 'aggregate_rules') as $ruleCode => $ruleClassname) {
             $ruleCode = \str_replace('combo_', '', $ruleCode);
 
@@ -87,7 +86,6 @@ final class Analyzer
     {
         $validRules = [];
 
-        /** @var class-string<\JBZoo\CsvBlueprint\Rules\AbstractRule> $ruleClassname */
         foreach (self::getRuleClasses('Cell', 'rules') as $ruleCode => $ruleClassname) {
             try {
                 $result = $ruleClassname::analyzeColumnValues($columnValues);

--- a/src/Analyze/Exception.php
+++ b/src/Analyze/Exception.php
@@ -16,6 +16,9 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint\Analyze;
 
+/**
+ * @psalm-suppress UnusedClass
+ */
 final class Exception extends \JBZoo\CsvBlueprint\Exception
 {
 }

--- a/src/CliApplication.php
+++ b/src/CliApplication.php
@@ -16,6 +16,9 @@ declare(strict_types=1);
 
 namespace JBZoo\CsvBlueprint;
 
+/**
+ * @psalm-suppress UnusedClass
+ */
 final class CliApplication extends \JBZoo\Cli\CliApplication
 {
     private array $appLogo = [

--- a/src/Csv/CsvFile.php
+++ b/src/Csv/CsvFile.php
@@ -88,7 +88,7 @@ final class CsvFile
     public function getRecords(?int $offset = null): \Iterator
     {
         if ($offset !== null) {
-            $records = $this->reader->fetchColumnByOffset($offset);
+            $records = $this->reader->fetchColumn($offset);
         } else {
             $records = $this->reader->getRecords();
         }

--- a/src/Rules/AbstractRule.php
+++ b/src/Rules/AbstractRule.php
@@ -67,7 +67,6 @@ abstract class AbstractRule
      * @param  array|string $cellValue the value of the cell to validate
      * @param  int          $line      the line number of the cell
      * @return ?Error       An Error object if validation fails, null otherwise
-     * @throws Exception    If the "validateRule" method is not found in the subclass
      */
     public function validate(array|string $cellValue, int $line = ValidatorColumn::FALLBACK_LINE): ?Error
     {
@@ -152,9 +151,8 @@ abstract class AbstractRule
 
     /**
      * Checks if the given cell value is valid.
-     * @param  string    $cellValue the value to test
-     * @return bool      true if the cell value is valid, false otherwise
-     * @throws Exception when the method is not implemented in the child class
+     * @param  string $cellValue the value to test
+     * @return bool   true if the cell value is valid, false otherwise
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @phan-suppress PhanUnusedPublicMethodParameter
@@ -169,8 +167,7 @@ abstract class AbstractRule
     /**
      * Checks if the rule is enabled based on the value of the options property.
      * Converts the options property to a boolean value and throws an exception if it is not a boolean.
-     * @return bool      true if the rule is enabled, false otherwise
-     * @throws Exception if the options property is not a boolean
+     * @return bool true if the rule is enabled, false otherwise
      */
     protected function isEnabledByOption(): bool
     {
@@ -251,8 +248,7 @@ abstract class AbstractRule
      * Checks if the options property is an array and throws an exception if it is not.
      * The exception includes the invalid option and the rule code.
      * The options property should be an array of strings.
-     * @return array     the options as an array
-     * @throws Exception if the options property is not an array
+     * @return array the options as an array
      */
     protected function getOptionAsArray(): array
     {

--- a/src/Rules/Cell/ComboDateInterval.php
+++ b/src/Rules/Cell/ComboDateInterval.php
@@ -90,6 +90,9 @@ final class ComboDateInterval extends AbstractCellRuleCombo
         return "parsed as \"{$seconds}\" seconds";
     }
 
+    /**
+     * @phan-suppress PhanRedundantCondition
+     */
     private static function dateIntervalToSeconds(string $dateIntervalOrAsString): int
     {
         try {

--- a/src/Rules/Cell/ComboPasswordStrength.php
+++ b/src/Rules/Cell/ComboPasswordStrength.php
@@ -85,9 +85,9 @@ final class ComboPasswordStrength extends AbstractCellRuleCombo
             $deductions++;
         }
 
-        $deductions += \preg_match_all('/01|12|23|34|45|56|67|78|89|90/', $password);
+        $deductions += (int)\preg_match_all('/01|12|23|34|45|56|67|78|89|90/', $password);
 
-        $deductions += \preg_match_all(
+        $deductions += (int)\preg_match_all(
             '/abc|bcd|cde|def|efg|fgh|ghi|hij|ijk|jkl|klm|lmn|mno|nop|opq|pqr|qrs|rst|stu|tuv|uvw|vwx|wxy|xyz/',
             \strtolower($password),
         );

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -222,8 +222,7 @@ final class Schema
 
     /**
      * Retrieves the CSV delimiter from the internal state.
-     * @return string    the CSV delimiter as a single character
-     * @throws Exception if the delimiter is not a single character
+     * @return string the CSV delimiter as a single character
      */
     public function getCsvDelimiter(): string
     {
@@ -237,8 +236,7 @@ final class Schema
 
     /**
      * Retrieves the CSV quote character from the internal state.
-     * @return string    the CSV quote character
-     * @throws Exception if the quote char is not a single character
+     * @return string the CSV quote character
      */
     public function getCsvQuoteChar(): string
     {
@@ -252,8 +250,7 @@ final class Schema
 
     /**
      * Retrieves the CSV enclosure character from the internal state.
-     * @return string    the CSV enclosure character
-     * @throws Exception if the enclosure is not a single character
+     * @return string the CSV enclosure character
      */
     public function getCsvEnclosure(): string
     {
@@ -269,11 +266,10 @@ final class Schema
     /**
      * Returns the CSV encoding specified in the internal state.
      *
-     * @return string    the CSV encoding. It can be one of the following values:
-     *                   - self::ENCODING_UTF8: UTF-8 encoding
-     *                   - self::ENCODING_UTF16: UTF-16 encoding
-     *                   - self::ENCODING_UTF32: UTF-32 encoding
-     * @throws Exception if the specified encoding is not valid
+     * @return string the CSV encoding. It can be one of the following values:
+     *                - self::ENCODING_UTF8: UTF-8 encoding
+     *                - self::ENCODING_UTF16: UTF-16 encoding
+     *                - self::ENCODING_UTF32: UTF-32 encoding
      */
     public function getCsvEncoding(): string
     {

--- a/src/SchemaDataPrep.php
+++ b/src/SchemaDataPrep.php
@@ -110,8 +110,7 @@ final class SchemaDataPrep
 
     /**
      * Validates a preset alias.
-     * @param  string    $alias the alias to validate
-     * @throws Exception if the alias is empty or invalid
+     * @param string $alias the alias to validate
      */
     public static function validateAlias(string $alias): void
     {

--- a/src/Tools/RandomCsvGenerator.php
+++ b/src/Tools/RandomCsvGenerator.php
@@ -34,7 +34,6 @@ final class RandomCsvGenerator
      * The number of rows is determined by the `rows` property of the class, and the columns
      * are determined by the `columns` property. The data for each cell in the CSV is a random integer
      * between `MIN` and `MAX` constants defined in the class.
-     * @throws Exception if the file cannot be opened for writing
      */
     public function generateCsv(): void
     {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -165,7 +165,6 @@ final class Utils
      * Find files based on the given paths.
      * @param  string[]      $paths an array of file or directory paths
      * @return SplFileInfo[] an array of SplFileInfo objects representing the found files
-     * @throws Exception     if a file is not readable
      */
     public static function findFiles(array $paths): array
     {
@@ -376,7 +375,6 @@ final class Utils
      * @param  null|string $regex   the regex pattern to match
      * @param  string      $subject the subject string
      * @return bool        returns true if the pattern does not match the subject, false otherwise
-     * @throws Exception   if an invalid regex pattern is provided
      */
     public static function testRegex(?string $regex, string $subject): bool
     {

--- a/src/Validators/ErrorSuite.php
+++ b/src/Validators/ErrorSuite.php
@@ -64,7 +64,6 @@ final class ErrorSuite
      * @param  string      $mode        the render mode
      * @param  bool        $cleanOutput Whether to clean the output. Default is false.
      * @return null|string the rendered batch of errors as a string, or null if there are no errors
-     * @throws Exception   if the specified render mode is unknown
      */
     public function render(string $mode = self::REPORT_TEXT, bool $cleanOutput = false): ?string
     {

--- a/src/Validators/ValidatorSchema.php
+++ b/src/Validators/ValidatorSchema.php
@@ -26,7 +26,7 @@ use function JBZoo\Data\phpArray;
 
 final class ValidatorSchema
 {
-    private ?string      $filename;
+    private string       $filename;
     private bool         $isHeader;
     private AbstractData $data;
 
@@ -66,8 +66,7 @@ final class ValidatorSchema
 
     /**
      * Retrieve the expected meta and column structure.
-     * @return array     the expected meta and column data
-     * @throws Exception if the reference schema file is not found
+     * @return array the expected meta and column data
      */
     public static function getExpected(): array
     {

--- a/src/Workers/WorkerPool.php
+++ b/src/Workers/WorkerPool.php
@@ -157,6 +157,9 @@ final class WorkerPool
         return $results;
     }
 
+    /**
+     * @phan-suppress PhanTypeMismatchProperty
+     */
     private function maintainTaskPool(): void
     {
         $bootstrap = self::$bootstrap;

--- a/tests/Rules/Cell/CharsetTest.php
+++ b/tests/Rules/Cell/CharsetTest.php
@@ -20,20 +20,10 @@ use JBZoo\CsvBlueprint\Rules\Cell\Charset;
 use JBZoo\PHPUnit\Rules\TestAbstractCellRule;
 
 use function JBZoo\PHPUnit\isSame;
-use function JBZoo\PHPUnit\skip;
 
 final class CharsetTest extends TestAbstractCellRule
 {
     protected string $ruleClass = Charset::class;
-
-    public function testHelpMessageInExample(): void
-    {
-        if (\version_compare(\PHP_VERSION, '8.4.0', '>=')) {
-            parent::testHelpMessageInExample();
-        } else {
-            skip('Help message depends on PHP version');
-        }
-    }
 
     public function testPositive(): void
     {

--- a/tests/Tools.php
+++ b/tests/Tools.php
@@ -28,31 +28,31 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 final class Tools
 {
-    public const CSV_SIMPLE_HEADER = './tests/fixtures/simple_header.csv';
-    public const CSV_SIMPLE_NO_HEADER = './tests/fixtures/simple_no_header.csv';
-    public const CSV_COMPLEX = './tests/fixtures/complex_header.csv';
+    public const string CSV_SIMPLE_HEADER = './tests/fixtures/simple_header.csv';
+    public const string CSV_SIMPLE_NO_HEADER = './tests/fixtures/simple_no_header.csv';
+    public const string CSV_COMPLEX = './tests/fixtures/complex_header.csv';
 
-    public const SCHEMA_SIMPLE_HEADER = './tests/schemas/simple_header.yml';
-    public const SCHEMA_SIMPLE_NO_HEADER = './tests/schemas/simple_no_header.yml';
-    public const SCHEMA_SIMPLE_HEADER_PHP = './tests/schemas/simple_header.php';
-    public const SCHEMA_SIMPLE_HEADER_JSON = './tests/schemas/simple_header.json';
-    public const SCHEMA_EXAMPLE_EMPTY = PROJECT_ROOT . '/tests/schemas/example_empty.yml';
+    public const string SCHEMA_SIMPLE_HEADER = './tests/schemas/simple_header.yml';
+    public const string SCHEMA_SIMPLE_NO_HEADER = './tests/schemas/simple_no_header.yml';
+    public const string SCHEMA_SIMPLE_HEADER_PHP = './tests/schemas/simple_header.php';
+    public const string SCHEMA_SIMPLE_HEADER_JSON = './tests/schemas/simple_header.json';
+    public const string SCHEMA_EXAMPLE_EMPTY = PROJECT_ROOT . '/tests/schemas/example_empty.yml';
 
-    public const SCHEMA_FULL_YML = PROJECT_ROOT . '/schema-examples/full.yml';
-    public const SCHEMA_FULL_YML_CLEAN = './schema-examples/full_clean.yml';
-    public const SCHEMA_FULL_JSON = './schema-examples/full.json';
-    public const SCHEMA_FULL_PHP = './schema-examples/full.php';
-    public const SCHEMA_INVALID = './tests/schemas/invalid_schema.yml';
+    public const string SCHEMA_FULL_YML = PROJECT_ROOT . '/schema-examples/full.yml';
+    public const string SCHEMA_FULL_YML_CLEAN = './schema-examples/full_clean.yml';
+    public const string SCHEMA_FULL_JSON = './schema-examples/full.json';
+    public const string SCHEMA_FULL_PHP = './schema-examples/full.php';
+    public const string SCHEMA_INVALID = './tests/schemas/invalid_schema.yml';
 
-    public const SCHEMA_TODO = './tests/schemas/todo.yml';
+    public const string SCHEMA_TODO = './tests/schemas/todo.yml';
 
-    public const DEMO_YML_VALID = './tests/schemas/demo_valid.yml';
-    public const DEMO_YML_INVALID = './tests/schemas/demo_invalid.yml';
-    public const DEMO_CSV = './tests/fixtures/demo.csv';
-    public const DEMO_INVALID_CSV = './tests/fixtures/demo_invalid.csv';
-    public const DEMO_CSV_FULL = PROJECT_ROOT . '/tests/fixtures/demo.csv';
+    public const string DEMO_YML_VALID = './tests/schemas/demo_valid.yml';
+    public const string DEMO_YML_INVALID = './tests/schemas/demo_invalid.yml';
+    public const string DEMO_CSV = './tests/fixtures/demo.csv';
+    public const string DEMO_INVALID_CSV = './tests/fixtures/demo_invalid.csv';
+    public const string DEMO_CSV_FULL = PROJECT_ROOT . '/tests/fixtures/demo.csv';
 
-    public const README = PROJECT_ROOT . '/README.md';
+    public const string README = PROJECT_ROOT . '/README.md';
 
     public static function virtualExecution(string $action, array|string $params = []): array
     {


### PR DESCRIPTION
- Introduce PHPStan for stricter static analysis with a new configuration file.
- Update Psalm configuration to suppress specific issues and improve formatting.
- Refine PHPDoc comments by removing redundant `@throws` tags.
- Introduce explicit type casts and constant type declarations for improved type safety.
- Update `jbzoo/cli` and `kubawerlos/php-cs-fixer-custom-fixers` dependencies.
- Reformat charset list in schema example and README for readability.
- Remove PHP version-specific test skip for Charset rule.
