### PR TITLE
build(phar): Update Box PHAR builder to 4.6.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ build-prod: ##@Project Build project in production mode
 	@make build-version
 
 build-phar-file: ##@Project Build Phar file
-	curl -L "https://github.com/box-project/box/releases/download/4.5.1/box.phar" -o ./build/box.phar
+	curl -L "https://github.com/box-project/box/releases/download/4.6.7/box.phar" -o ./build/box.phar
 	@make build-version
 	@php ./build/box.phar --version
 	@php ./build/box.phar compile -vv


### PR DESCRIPTION
Upgrades the Box PHAR builder tool to version 4.6.7. This ensures compatibility and leverages the latest features and fixes from the Box project.
